### PR TITLE
[codex] prepare 0.1.1 release and registry publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,9 +217,40 @@ jobs:
           # Tier 4: depends on email-mcp
           publish_pkg "email-agent-mcp" "packages/email-agent-mcp"
 
+  publish-mcp-registry:
+    name: Publish MCP Registry metadata
+    needs: [preflight, publish-suite]
+    if: needs.publish-suite.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+    concurrency:
+      group: npm-release-${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref_name }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          chmod +x ./mcp-publisher
+
+      - name: Authenticate with MCP Registry via GitHub OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json to MCP Registry
+        working-directory: packages/email-agent-mcp
+        run: ../../mcp-publisher publish
+
   publish-github-release:
     name: Publish GitHub release notes
-    needs: [preflight, publish-suite]
+    needs: [preflight, publish-suite, publish-mcp-registry]
     if: always() && needs.preflight.result == 'success'
     runs-on: ubuntu-latest
     permissions:
@@ -234,7 +265,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.ref }}
 
       - name: Create GitHub release (only if publish succeeded)
-        if: needs.publish-suite.result == 'success'
+        if: needs.publish-suite.result == 'success' && needs.publish-mcp-registry.result == 'success'
         id: release
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
@@ -251,16 +282,20 @@ jobs:
         if: always()
         run: |
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
-          PUBLISH_RESULT="${{ needs.publish-suite.result }}"
+          NPM_PUBLISH_RESULT="${{ needs.publish-suite.result }}"
+          REGISTRY_PUBLISH_RESULT="${{ needs.publish-mcp-registry.result }}"
           {
             echo "### GitHub Release: ${TAG_REF}"
-            if [ "$PUBLISH_RESULT" = "success" ]; then
+            if [ "$NPM_PUBLISH_RESULT" = "success" ] && [ "$REGISTRY_PUBLISH_RESULT" = "success" ]; then
               RELEASE_URL="$(gh release view "$TAG_REF" --json url --jq '.url' 2>/dev/null || echo 'n/a')"
               echo "- npm publish: SUCCESS"
+              echo "- MCP Registry publish: SUCCESS"
               echo "- Release created: ${{ steps.release.outputs.created || 'already existed' }}"
               echo "- Release URL: ${RELEASE_URL}"
             else
-              echo "- npm publish: FAILED — GitHub Release was NOT created"
+              echo "- npm publish: ${NPM_PUBLISH_RESULT}"
+              echo "- MCP Registry publish: ${REGISTRY_PUBLISH_RESULT}"
+              echo "- GitHub Release was NOT created"
               echo "- To recover once the issue is fixed, run:"
               echo '  ```'
               echo "  gh workflow run release.yml -f release_tag=${TAG_REF}"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,27 @@
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
-**email-agent-mcp** by [UseJunior](https://usejunior.com) -- email connectivity for AI agents.
+**email-agent-mcp** by [UseJunior](https://usejunior.com) -- local email connectivity for AI agents.
 
-Agent Email is an open-source TypeScript MCP server that gives AI agents secure access to email. It exposes email operations via [Model Context Protocol](https://modelcontextprotocol.io/) for any MCP-compatible agent runtime -- Claude Code, Gemini CLI, Cursor, Goose, and more. Security-first defaults mean agents cannot send email until you explicitly configure an allowlist.
+Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook is supported today; Gmail wiring is in progress. Security-first defaults mean agents cannot send email until you explicitly configure an allowlist.
+
+## Quick Start
+
+```bash
+npx -y email-agent-mcp
+```
+
+The interactive setup wizard walks you through OAuth configuration and mailbox selection.
+
+## What Works Today
+
+- Microsoft 365 / Outlook mailbox access through MCP stdio
+- `list_emails`, `read_email`, `search_emails`, and `get_thread`
+- `create_draft`, `update_draft`, `send_draft`, `send_email`, and `reply_to_email`
+- `label_email`, `mark_read`, and `move_to_folder`
+- send allowlists, delete disabled by default, and sanitized errors
+
+The current launch-prep pass was validated against a real Outlook mailbox for read, draft, send, categorize, move, and read-state flows.
 
 ## Why This Exists
 
@@ -44,12 +62,6 @@ Add to `~/.claude/settings.json` or your project `.claude/settings.json`:
 }
 ```
 
-## Use with Gemini CLI
-
-```bash
-gemini extensions install https://github.com/UseJunior/email-agent-mcp
-```
-
 ## Use with Cursor
 
 ```json
@@ -64,13 +76,34 @@ gemini extensions install https://github.com/UseJunior/email-agent-mcp
 }
 ```
 
-## Use with CLI
+## Use with Gemini CLI
 
 ```bash
-npx -y email-agent-mcp
+gemini extensions install https://github.com/UseJunior/email-agent-mcp
 ```
 
-The interactive setup wizard walks you through OAuth configuration and mailbox selection.
+## Launch Prep Smoke Test
+
+Before recording a demo, run the live smoke script against a real mailbox and a safe send allowlist. The script exercises:
+
+- `get_mailbox_status`
+- `list_emails` + `read_email`
+- `mark_read` unread -> read -> unread
+- `label_email` on a safe inbox candidate
+- `create_draft`
+- draft-only `reply_to_email`
+- optional `send_email`
+
+Example:
+
+```bash
+EMAIL_AGENT_MCP_HOME=/tmp/email-agent-mcp-live \
+AGENT_EMAIL_SEND_ALLOWLIST=/tmp/email-agent-mcp-live/send-allowlist.json \
+npm run launch:prep:smoke -- --live-write --send-to beta@usejunior.com
+```
+
+Default safe-candidate selection looks for `notifications@github.com` in the inbox so you can rehearse the recording flow on a public-safe message instead of customer mail.
+If your mailbox status name is not an email address, pass `--reply-sender <email>` or set `EMAIL_AGENT_MCP_REPLY_SENDER` so the script can find a self-sent message for the draft-reply check.
 
 ## Tool Reference
 
@@ -129,7 +162,7 @@ Agent Email ships with restrictive defaults that you loosen as needed:
 - CodeQL and Semgrep security scanning
 - Coverage published to Codecov
 - OpenSpec traceability enforcement via `npm run check:spec-coverage`
-- 310 tests across 34 test files
+- 300+ tests across the suite
 - Maintainer: [Steven Obiajulu](https://www.linkedin.com/in/steven-obiajulu/)
 
 ## Architecture
@@ -148,7 +181,7 @@ email-agent-mcp/
 
 ## Releasing
 
-Tag-driven release via GitHub Actions with npm OIDC trusted publishing. All 5 packages publish in dependency order with `--provenance`.
+Tag-driven release via GitHub Actions with npm OIDC trusted publishing. All 5 packages publish in dependency order with `--provenance`, then `server.json` is published to the official MCP Registry with `mcp-publisher`.
 
 ## FAQ
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.0",
-  "description": "Email connectivity for AI agents — read, reply, send, categorize emails from Microsoft 365 and Gmail via MCP.",
+  "version": "0.1.1",
+  "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",
   "mcpServers": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
-  "description": "Open-source email connectivity for AI agents — MCP server for OpenClaw, Claude Code, Gemini CLI, and more",
+  "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 today, Gmail wiring in progress",
   "type": "module",
   "workspaces": [
     "packages/*"
@@ -20,6 +20,7 @@
     "check:server-json": "node scripts/check-server-json.mjs",
     "check:gemini-extension-manifest": "node scripts/check-gemini-extension-manifest.mjs",
     "check:isolated-runtime": "node scripts/check-isolated-runtime.mjs",
+    "launch:prep:smoke": "node scripts/launch-prep-smoke.mjs",
     "dev:serve": "npx tsx packages/email-mcp/src/serve-entry.ts",
     "dev:watch": "npx tsx packages/email-mcp/src/cli.ts watch",
     "dev:configure": "npx tsx packages/email-mcp/src/cli.ts configure"
@@ -37,8 +38,11 @@
     "mcp",
     "ai-agent",
     "microsoft-graph",
+    "microsoft-365",
     "gmail",
+    "outlook",
     "model-context-protocol",
+    "openclaw",
     "claude",
     "gemini",
     "typescript"

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -1,0 +1,113 @@
+# Agent Email
+
+[![npm version](https://img.shields.io/npm/v/email-agent-mcp)](https://www.npmjs.com/package/email-agent-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/email-agent-mcp.svg)](https://npmjs.org/package/email-agent-mcp)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![CI](https://github.com/UseJunior/email-agent-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/UseJunior/email-agent-mcp/actions/workflows/ci.yml)
+[![codecov](https://img.shields.io/codecov/c/github/UseJunior/email-agent-mcp/main)](https://app.codecov.io/gh/UseJunior/email-agent-mcp)
+[![GitHub stargazers](https://img.shields.io/github/stars/UseJunior/email-agent-mcp?style=social)](https://github.com/UseJunior/email-agent-mcp/stargazers)
+[![Socket Badge](https://socket.dev/api/badge/npm/package/email-agent-mcp)](https://socket.dev/npm/package/email-agent-mcp)
+[![install size](https://packagephobia.com/badge?p=email-agent-mcp)](https://packagephobia.com/result?p=email-agent-mcp)
+
+[Repo README](https://github.com/UseJunior/email-agent-mcp/blob/main/README.md) | [Español](https://github.com/UseJunior/email-agent-mcp/blob/main/README.es.md) | [简体中文](https://github.com/UseJunior/email-agent-mcp/blob/main/README.zh.md) | [Português (Brasil)](https://github.com/UseJunior/email-agent-mcp/blob/main/README.pt-br.md) | [Deutsch](https://github.com/UseJunior/email-agent-mcp/blob/main/README.de.md)
+
+**email-agent-mcp** by [UseJunior](https://usejunior.com) -- local email connectivity for AI agents.
+
+Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook is supported today; Gmail wiring is in progress.
+
+## Quick Start
+
+```bash
+npx -y email-agent-mcp
+```
+
+The interactive setup wizard walks you through OAuth configuration and mailbox selection.
+
+## What Works Today
+
+- Microsoft 365 / Outlook mailbox access through MCP stdio
+- `list_emails`, `read_email`, `search_emails`, and `get_thread`
+- `create_draft`, `update_draft`, `send_draft`, `send_email`, and `reply_to_email`
+- `label_email`, `mark_read`, and `move_to_folder`
+- send allowlists, delete disabled by default, and sanitized errors
+
+The current launch-prep pass was validated against a real Outlook mailbox for read, draft, send, categorize, move, and read-state flows.
+
+## Use with Claude Code
+
+Add to `~/.claude/settings.json` or your project `.claude/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "email-agent-mcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "email-agent-mcp"]
+    }
+  }
+}
+```
+
+## Use with Cursor
+
+```json
+// .cursor/mcp.json
+{
+  "mcpServers": {
+    "email-agent-mcp": {
+      "command": "npx",
+      "args": ["-y", "email-agent-mcp"]
+    }
+  }
+}
+```
+
+## Use with Gemini CLI
+
+```bash
+gemini extensions install https://github.com/UseJunior/email-agent-mcp
+```
+
+## Tool Reference
+
+Agent Email exposes 15 MCP tools:
+
+| Tool | Description | Type |
+|------|-------------|------|
+| `list_emails` | List recent emails with filtering | read |
+| `read_email` | Read full email content as markdown | read |
+| `search_emails` | Full-text search across mailboxes | read |
+| `get_mailbox_status` | Connection status and warnings | read |
+| `get_thread` | Full conversation context | read |
+| `send_email` | Send new email (allowlist-gated) | write |
+| `reply_to_email` | Reply with RFC threading | write |
+| `create_draft` | Create email draft | write |
+| `update_draft` | Update draft content | write |
+| `send_draft` | Send a saved draft | write |
+| `label_email` | Apply labels/categories | write |
+| `flag_email` | Flag/unflag emails | write |
+| `mark_read` | Mark as read/unread | write |
+| `move_to_folder` | Move between folders | write |
+| `delete_email` | Delete (requires opt-in) | destructive |
+
+## Provider Support
+
+| Provider | Status | Package |
+|----------|--------|---------|
+| Microsoft 365 (Graph API) | Fully supported | `@usejunior/provider-microsoft` |
+| Gmail | Coming soon | `@usejunior/provider-gmail` |
+
+## Security Defaults
+
+- **Send allowlist**: empty by default -- agents cannot send email until you add recipients
+- **Receive allowlist**: accepts all by default -- controls which senders trigger the watcher
+- **Delete disabled**: agents cannot delete email unless you set `user_explicitly_requested_deletion: true`
+- **Error sanitization**: API keys, file paths, and stack traces are redacted from error responses
+- **Body file sandboxing**: no `../` traversal, no symlinks, binary detection
+
+## More
+
+- [Repository README](https://github.com/UseJunior/email-agent-mcp/blob/main/README.md)
+- [Contributing Guide](https://github.com/UseJunior/email-agent-mcp/blob/main/CONTRIBUTING.md)
+- [Security Policy](https://github.com/UseJunior/email-agent-mcp/blob/main/SECURITY.md)

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.0",
-  "description": "Email connectivity for AI agents — MCP server for OpenClaw, Claude Code, Gemini CLI, and more",
+  "version": "0.1.1",
+  "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook with Gmail wiring in progress",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",
@@ -15,8 +15,9 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.1.0"
+    "@usejunior/email-mcp": "^0.1.1"
   },
+  "mcpName": "io.github.usejunior/email-agent-mcp",
   "engines": { "node": ">=20" },
   "files": ["bin", "index.js", "index.d.ts", "server.json"],
   "publishConfig": {"access": "public"},
@@ -29,6 +30,6 @@
   "bugs": {
     "url": "https://github.com/UseJunior/email-agent-mcp/issues"
   },
-  "keywords": ["email", "mcp", "ai-agent", "microsoft-graph", "gmail", "model-context-protocol", "claude", "gemini"],
+  "keywords": ["email", "mcp", "ai-agent", "microsoft-graph", "microsoft-365", "outlook", "gmail", "model-context-protocol", "openclaw", "claude", "gemini"],
   "license": "Apache-2.0"
 }

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.UseJunior/email-agent-mcp",
+  "name": "io.github.usejunior/email-agent-mcp",
   "title": "Agent Email",
-  "description": "Email connectivity for AI agents — read, reply, send, categorize emails from Microsoft 365 and Gmail",
-  "version": "0.1.0",
+  "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP",
+  "version": "0.1.1",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -11,12 +11,12 @@
     "id": "UseJunior/email-agent-mcp"
   },
   "license": "Apache-2.0",
-  "tags": ["email", "mcp", "ai-agent", "microsoft-graph", "gmail", "outlook", "model-context-protocol"],
+  "tags": ["email", "mcp", "ai-agent", "microsoft-graph", "microsoft-365", "gmail", "outlook", "model-context-protocol", "openclaw"],
   "packages": [
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": { "type": "stdio" },
       "runtimeHint": "npx",
       "environmentVariables": []

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-core/src/security/receive-allowlist.test.ts
+++ b/packages/email-core/src/security/receive-allowlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isAllowedSender, checkDeletePolicy, checkAntiSpoofing } from './receive-allowlist.js';
+import { isAllowedSender, checkDeletePolicy, checkAntiSpoofing, getReceiveAllowlistPath } from './receive-allowlist.js';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 
 describe('email-security/Receive Allowlist', () => {
@@ -11,6 +11,27 @@ describe('email-security/Receive Allowlist', () => {
 
     // Empty entries also accepts all
     expect(isAllowedSender('anyone@anywhere.com', { entries: [] })).toBe(true);
+  });
+
+  it('Scenario: EMAIL_AGENT_MCP_HOME controls default receive allowlist path', () => {
+    const originalEnv = process.env['AGENT_EMAIL_RECEIVE_ALLOWLIST'];
+    const originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    try {
+      delete process.env['AGENT_EMAIL_RECEIVE_ALLOWLIST'];
+      process.env['EMAIL_AGENT_MCP_HOME'] = '/tmp/email-agent-mcp-live';
+      expect(getReceiveAllowlistPath()).toBe('/tmp/email-agent-mcp-live/receive-allowlist.json');
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env['AGENT_EMAIL_RECEIVE_ALLOWLIST'];
+      } else {
+        process.env['AGENT_EMAIL_RECEIVE_ALLOWLIST'] = originalEnv;
+      }
+      if (originalHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
+      }
+    }
   });
 });
 

--- a/packages/email-core/src/security/receive-allowlist.ts
+++ b/packages/email-core/src/security/receive-allowlist.ts
@@ -6,6 +6,11 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { AllowlistConfig } from '../actions/registry.js';
 
+function getAgentEmailHome(): string {
+  return process.env['EMAIL_AGENT_MCP_HOME']
+    ?? join(homedir(), '.email-agent-mcp');
+}
+
 /**
  * Check if an inbound sender is allowed by the receive allowlist.
  * Default (no config): accept all.
@@ -58,7 +63,7 @@ export async function loadReceiveAllowlist(filePath?: string): Promise<Allowlist
  */
 export function getReceiveAllowlistPath(): string {
   return process.env['AGENT_EMAIL_RECEIVE_ALLOWLIST']
-    ?? join(homedir(), '.email-agent-mcp', 'receive-allowlist.json');
+    ?? join(getAgentEmailHome(), 'receive-allowlist.json');
 }
 
 // Delete policy enforcement

--- a/packages/email-core/src/security/send-allowlist.test.ts
+++ b/packages/email-core/src/security/send-allowlist.test.ts
@@ -73,8 +73,10 @@ describe('email-security/Allowlist Protection', () => {
     // WHEN no env var is set
     // THEN defaults to ~/.email-agent-mcp/send-allowlist.json
     const originalEnv = process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+    const originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
     try {
       delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+      delete process.env['EMAIL_AGENT_MCP_HOME'];
       const path = getSendAllowlistPath();
       expect(path).toContain('.email-agent-mcp');
       expect(path).toContain('send-allowlist.json');
@@ -85,6 +87,32 @@ describe('email-security/Allowlist Protection', () => {
         delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
       } else {
         process.env['AGENT_EMAIL_SEND_ALLOWLIST'] = originalEnv;
+      }
+      if (originalHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
+      }
+    }
+  });
+
+  it('Scenario: EMAIL_AGENT_MCP_HOME controls default allowlist path', () => {
+    const originalEnv = process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+    const originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    try {
+      delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+      process.env['EMAIL_AGENT_MCP_HOME'] = '/tmp/email-agent-mcp-live';
+      expect(getSendAllowlistPath()).toBe('/tmp/email-agent-mcp-live/send-allowlist.json');
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+      } else {
+        process.env['AGENT_EMAIL_SEND_ALLOWLIST'] = originalEnv;
+      }
+      if (originalHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
       }
     }
   });

--- a/packages/email-core/src/security/send-allowlist.ts
+++ b/packages/email-core/src/security/send-allowlist.ts
@@ -6,6 +6,11 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { AllowlistConfig } from '../actions/registry.js';
 
+function getAgentEmailHome(): string {
+  return process.env['EMAIL_AGENT_MCP_HOME']
+    ?? join(homedir(), '.email-agent-mcp');
+}
+
 /**
  * Check if a recipient email address is allowed by the send allowlist.
  */
@@ -59,7 +64,7 @@ export async function loadSendAllowlist(filePath?: string): Promise<AllowlistCon
  */
 export function getSendAllowlistPath(): string {
   return process.env['AGENT_EMAIL_SEND_ALLOWLIST']
-    ?? join(homedir(), '.email-agent-mcp', 'send-allowlist.json');
+    ?? join(getAgentEmailHome(), 'send-allowlist.json');
 }
 
 /**

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.1.0",
-    "@usejunior/provider-microsoft": "^0.1.0"
+    "@usejunior/email-core": "^0.1.1",
+    "@usejunior/provider-microsoft": "^0.1.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -86,7 +86,7 @@ describe('cli/Version and Help', () => {
     const exitCode = await runCli(['--version']);
     expect(exitCode).toBe(0);
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('0.1.0'),
+      expect.stringMatching(/^email-agent-mcp \d+\.\d+\.\d+(?:[-+][\w.-]+)?$/),
     );
   });
 });
@@ -355,4 +355,3 @@ describe('cli/Poll Interval Validation', () => {
     // Clamping happens at runtime in runWatch, not in parseCliArgs
   });
 });
-

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.1.0"
+    "@usejunior/email-core": "^0.1.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.1.0"
+    "@usejunior/email-core": "^0.1.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -194,7 +194,9 @@ describe('provider-microsoft/Thread Lookup', () => {
     const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[1]![0] as string;
     const decodedUrl = decodeURIComponent(url).replaceAll('+', ' ');
     expect(decodedUrl).toContain("conversationId eq 'conv-123'");
-    expect(url).toContain('%24orderby=receivedDateTime+asc');
+    expect(decodedUrl).not.toContain('$orderby=');
+    expect(thread.messages[0]!.id).toBe('msg-1');
+    expect(thread.messages[1]!.id).toBe('msg-2');
   });
 });
 
@@ -509,6 +511,26 @@ describe('provider-microsoft/Inbox-Scoped Message Access', () => {
     const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
     expect(url).toContain('mailFolders/inbox/messages');
     expect(url).not.toMatch(/\/me\/messages\?/);
+  });
+
+  it('Scenario: Sent alias listing normalizes to sentitems', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.listMessages({ folder: 'sent', limit: 10 });
+
+    const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(url).toContain('mailFolders/sentitems/messages');
+  });
+
+  it('Scenario: Folder-scoped search normalizes well-known aliases', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.searchMessages('launch prep', 'trash');
+
+    const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(url).toContain('mailFolders/deleteditems/messages');
   });
 
   it('Scenario: Inbox-scoped delta query', async () => {

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -148,7 +148,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (opts.from) filters.push(`from/emailAddress/address eq '${opts.from}'`);
     if (filters.length > 0) params.set('$filter', filters.join(' and '));
 
-    const folder = opts.folder ?? 'inbox';
+    const folder = normalizeFolderId(opts.folder ?? 'inbox');
     const url = `${this.basePath}/mailFolders/${folder}/messages?${params}`;
     const response = await this.client.get(url);
     return ((response.value ?? []) as GraphMessage[]).map(mapGraphMessage);
@@ -165,8 +165,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     const params = new URLSearchParams();
     params.set('$search', `"${query}"`);
     params.set('$top', '50');
-    const base = folder
-      ? `${this.basePath}/mailFolders/${folder}/messages`
+    const normalizedFolder = folder ? normalizeFolderId(folder) : undefined;
+    const base = normalizedFolder
+      ? `${this.basePath}/mailFolders/${normalizedFolder}/messages`
       : `${this.basePath}/messages`;
 
     try {
@@ -195,9 +196,10 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (conversationId) {
       const params = new URLSearchParams();
       params.set('$filter', `conversationId eq '${conversationId}'`);
-      params.set('$orderby', 'receivedDateTime asc');
       const response = await this.client.get(`${this.basePath}/messages?${params}`);
-      const messages = ((response.value ?? []) as GraphMessage[]).map(mapGraphMessage);
+      const messages = ((response.value ?? []) as GraphMessage[])
+        .map(mapGraphMessage)
+        .sort((a, b) => a.receivedAt.localeCompare(b.receivedAt));
 
       return {
         id: conversationId,

--- a/scripts/check-server-json.mjs
+++ b/scripts/check-server-json.mjs
@@ -28,6 +28,13 @@ if (serverJson.version !== packageJson.version) {
   ok = false;
 }
 
+if (serverJson.name !== packageJson.mcpName) {
+  console.error(
+    `FAIL: server.json name "${serverJson.name}" !== package.json mcpName "${packageJson.mcpName}"`,
+  );
+  ok = false;
+}
+
 const pkgEntry = serverJson.packages?.[0];
 if (pkgEntry && pkgEntry.version !== packageJson.version) {
   console.error(
@@ -36,9 +43,16 @@ if (pkgEntry && pkgEntry.version !== packageJson.version) {
   ok = false;
 }
 
+if (pkgEntry && pkgEntry.identifier !== packageJson.name) {
+  console.error(
+    `FAIL: server.json packages[0].identifier "${pkgEntry.identifier}" !== package.json name "${packageJson.name}"`,
+  );
+  ok = false;
+}
+
 if (ok) {
   console.log(
-    `PASS: server.json version matches package.json (${packageJson.version})`,
+    `PASS: server.json matches package.json (${packageJson.version})`,
   );
 } else {
   process.exit(1);

--- a/scripts/e2e-mcp-test.mjs
+++ b/scripts/e2e-mcp-test.mjs
@@ -10,8 +10,11 @@ async function main() {
 
   // Launch agent-email MCP server as a child process
   const transport = new StdioClientTransport({
-    command: 'npx',
-    args: ['tsx', 'packages/email-mcp/src/serve-entry.ts'],
+    command: 'node',
+    args: ['packages/email-agent-mcp/bin/email-agent-mcp.js', 'serve'],
+    cwd: process.cwd(),
+    env: { ...process.env },
+    stderr: 'inherit',
   });
 
   const client = new Client(

--- a/scripts/extended-live-test.mjs
+++ b/scripts/extended-live-test.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+function getRepoRoot() {
+  return new URL('..', import.meta.url).pathname;
+}
+
+async function connectClient() {
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: ['packages/email-agent-mcp/bin/email-agent-mcp.js', 'serve'],
+    cwd: getRepoRoot(),
+    env: { ...process.env },
+    stderr: 'pipe',
+  });
+
+  if (transport.stderr) {
+    transport.stderr.on('data', chunk => process.stderr.write(chunk));
+  }
+
+  const client = new Client(
+    { name: 'extended-live-test', version: '1.0.0' },
+    { capabilities: {} },
+  );
+
+  await client.connect(transport);
+  return client;
+}
+
+async function callJson(client, name, args) {
+  const result = await client.callTool({ name, arguments: args });
+  const text = result.content.find(item => item.type === 'text')?.text;
+  if (!text) {
+    throw new Error(`${name} returned no text content`);
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`${name} returned non-JSON content: ${text}`);
+  }
+}
+
+function requireSuccess(name, result) {
+  if (result?.success === false) {
+    throw new Error(`${name} failed: ${result.error?.code ?? 'UNKNOWN'} ${result.error?.message ?? ''}`.trim());
+  }
+  return result;
+}
+
+function requireBlocked(name, result, code) {
+  if (result?.success !== false || result?.error?.code !== code) {
+    throw new Error(`${name} expected ${code}, got ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForSentMessage(client, subject) {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const sent = await callJson(client, 'list_emails', { folder: 'sent', limit: 25 });
+    const match = (sent.emails ?? []).find(message => message.subject === subject);
+    if (match) {
+      return match;
+    }
+    await sleep(1500);
+  }
+
+  throw new Error(`Sent message not found in Sent folder: ${subject}`);
+}
+
+async function main() {
+  const client = await connectClient();
+
+  try {
+    const now = new Date().toISOString();
+    const draftSubject = `email-agent-mcp draft lifecycle ${now}`;
+    const updatedSubject = `${draftSubject} updated`;
+    const blockedSubject = `email-agent-mcp blocked send ${now}`;
+    const summary = {
+      status: null,
+      search: null,
+      thread: null,
+      draftLifecycle: {},
+      moveCycle: {},
+      blocked: {},
+    };
+
+    summary.status = await callJson(client, 'get_mailbox_status', {});
+
+    const search = await callJson(client, 'search_emails', { query: 'email-agent-mcp live smoke' });
+    summary.search = {
+      count: search.emails?.length ?? 0,
+      topSubjects: (search.emails ?? []).slice(0, 5).map(message => message.subject),
+    };
+
+    const sentList = await callJson(client, 'list_emails', { folder: 'sent', limit: 25 });
+    const existingSent = (sentList.emails ?? []).find(message =>
+      String(message.subject).includes('email-agent-mcp live smoke'),
+    );
+    if (!existingSent) {
+      throw new Error('Could not find an existing live smoke message in Sent Items');
+    }
+
+    const thread = await callJson(client, 'get_thread', { message_id: existingSent.id });
+    summary.thread = {
+      id: thread.id,
+      subject: thread.subject,
+      messageCount: thread.messageCount,
+    };
+
+    const createdDraft = requireSuccess('create_draft', await callJson(client, 'create_draft', {
+      to: 'beta@usejunior.com',
+      subject: draftSubject,
+      body: 'Initial body from extended live MCP test.',
+    }));
+    summary.draftLifecycle.create = createdDraft;
+
+    const updatedDraft = requireSuccess('update_draft', await callJson(client, 'update_draft', {
+      draft_id: createdDraft.draftId,
+      subject: updatedSubject,
+      body: 'Updated body from extended live MCP test.',
+    }));
+    summary.draftLifecycle.update = updatedDraft;
+
+    const updatedDraftRead = await callJson(client, 'read_email', { id: createdDraft.draftId });
+    summary.draftLifecycle.readBack = {
+      id: updatedDraftRead.id,
+      subject: updatedDraftRead.subject,
+      bodyPreview: String(updatedDraftRead.body ?? '').slice(0, 120),
+    };
+
+    const sentDraft = requireSuccess('send_draft', await callJson(client, 'send_draft', {
+      draft_id: createdDraft.draftId,
+    }));
+    summary.draftLifecycle.send = sentDraft;
+
+    const sentFromDraft = await waitForSentMessage(client, updatedSubject);
+    summary.draftLifecycle.sentFolderMatch = sentFromDraft;
+
+    const movedToArchive = requireSuccess('move_to_folder archive', await callJson(client, 'move_to_folder', {
+      id: sentFromDraft.id,
+      folder: 'archive',
+    }));
+    summary.moveCycle.archive = movedToArchive;
+
+    const movedBackToSent = requireSuccess('move_to_folder sent', await callJson(client, 'move_to_folder', {
+      id: movedToArchive.newId,
+      folder: 'sent',
+    }));
+    summary.moveCycle.restore = movedBackToSent;
+
+    const blockedSend = await callJson(client, 'send_email', {
+      to: 'not-allowlisted@example.com',
+      subject: blockedSubject,
+      body: 'This should be blocked by the send allowlist.',
+    });
+    summary.blocked.send = requireBlocked('send_email', blockedSend, 'ALLOWLIST_BLOCKED');
+
+    const inbox = await callJson(client, 'list_emails', { folder: 'inbox', limit: 25 });
+    const githubMessage = (inbox.emails ?? []).find(message =>
+      String(message.from).toLowerCase().includes('notifications@github.com'),
+    );
+    if (!githubMessage) {
+      throw new Error('Could not find a GitHub notification in Inbox for blocked reply/delete checks');
+    }
+
+    const blockedReply = await callJson(client, 'reply_to_email', {
+      message_id: githubMessage.id,
+      body: 'This should be blocked by the send allowlist.',
+      draft: true,
+    });
+    summary.blocked.reply = requireBlocked('reply_to_email', blockedReply, 'ALLOWLIST_BLOCKED');
+
+    const blockedDelete = await callJson(client, 'delete_email', {
+      id: githubMessage.id,
+      user_explicitly_requested_deletion: true,
+    });
+    summary.blocked.delete = requireBlocked('delete_email', blockedDelete, 'DELETE_DISABLED');
+
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/launch-prep-smoke.mjs
+++ b/scripts/launch-prep-smoke.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+function parseArgs(argv) {
+  const opts = {
+    liveWrite: false,
+    safeSender: 'notifications@github.com',
+    replySender: '',
+    label: 'email-agent-mcp-demo',
+    secondLabel: 'launch-prep',
+    sendTo: '',
+    mailbox: '',
+    limit: 25,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case '--live-write':
+        opts.liveWrite = true;
+        break;
+      case '--safe-sender':
+        opts.safeSender = argv[++i] ?? opts.safeSender;
+        break;
+      case '--reply-sender':
+        opts.replySender = argv[++i] ?? '';
+        break;
+      case '--label':
+        opts.label = argv[++i] ?? opts.label;
+        break;
+      case '--second-label':
+        opts.secondLabel = argv[++i] ?? opts.secondLabel;
+        break;
+      case '--send-to':
+        opts.sendTo = argv[++i] ?? '';
+        break;
+      case '--mailbox':
+        opts.mailbox = argv[++i] ?? '';
+        break;
+      case '--limit':
+        opts.limit = Number(argv[++i] ?? opts.limit);
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return opts;
+}
+
+function printHelp() {
+  console.log(`launch-prep-smoke — live MCP smoke test for launch prep
+
+Usage:
+  node scripts/launch-prep-smoke.mjs [options]
+
+Options:
+  --live-write            Run mutating actions (mark, label, draft, send)
+  --safe-sender <email>   Sender filter for safe demo candidate (default: notifications@github.com)
+  --reply-sender <email>  Sender filter for reply-draft candidate
+  --label <name>          Label/category for safe candidate (default: email-agent-mcp-demo)
+  --second-label <name>   Second label/category for sent candidate (default: launch-prep)
+  --send-to <email>       Recipient for draft/send smoke test
+  --mailbox <name>        Mailbox override
+  --limit <n>             Inbox/sent scan limit (default: 25)
+`);
+}
+
+function buildServerEnv() {
+  return {
+    ...process.env,
+  };
+}
+
+function getRepoRoot() {
+  return new URL('..', import.meta.url).pathname;
+}
+
+function getMailboxArg(mailbox) {
+  return mailbox ? { mailbox } : {};
+}
+
+function extractEmailAddress(value) {
+  if (typeof value !== 'string') return null;
+  const match = value.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return match?.[0]?.toLowerCase() ?? null;
+}
+
+async function readAllowlistEntries() {
+  const allowlistPath = process.env.AGENT_EMAIL_SEND_ALLOWLIST;
+  if (!allowlistPath) return [];
+
+  try {
+    const raw = await readFile(allowlistPath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed?.entries)) return [];
+    return parsed.entries
+      .map(entry => extractEmailAddress(entry))
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function connectClient() {
+  const transport = new StdioClientTransport({
+    command: 'node',
+    args: ['packages/email-agent-mcp/bin/email-agent-mcp.js', 'serve'],
+    cwd: getRepoRoot(),
+    env: buildServerEnv(),
+    stderr: 'pipe',
+  });
+
+  if (transport.stderr) {
+    transport.stderr.on('data', chunk => process.stderr.write(chunk));
+  }
+
+  const client = new Client(
+    { name: 'launch-prep-smoke', version: '1.0.0' },
+    { capabilities: {} },
+  );
+
+  await client.connect(transport);
+  return client;
+}
+
+async function callJson(client, name, args) {
+  const result = await client.callTool({ name, arguments: args });
+  const text = result.content.find(item => item.type === 'text')?.text;
+  if (!text) {
+    throw new Error(`${name} returned no text content`);
+  }
+  return JSON.parse(text);
+}
+
+function requireSuccess(name, result) {
+  if (result?.success === false) {
+    throw new Error(`${name} failed: ${result.error?.message ?? 'unknown error'}`);
+  }
+  return result;
+}
+
+function requireLiveMailbox(status) {
+  if (!status || typeof status !== 'object') {
+    throw new Error('get_mailbox_status returned an invalid payload');
+  }
+
+  if (
+    status.provider === 'none' ||
+    status.status === 'not configured' ||
+    String(status.provider).toLowerCase() === 'demo'
+  ) {
+    throw new Error(
+      'Live mailbox not configured. Set EMAIL_AGENT_MCP_HOME and allowlist env vars for a real mailbox before running launch-prep-smoke.',
+    );
+  }
+
+  if (String(status.status).toLowerCase() !== 'connected') {
+    throw new Error(`Mailbox is not connected: ${status.status ?? 'unknown status'}`);
+  }
+}
+
+async function resolveReplySender(opts, status) {
+  if (opts.replySender) return opts.replySender.toLowerCase();
+
+  const envReplySender = extractEmailAddress(process.env.EMAIL_AGENT_MCP_REPLY_SENDER);
+  if (envReplySender) return envReplySender;
+
+  const mailboxAddress = extractEmailAddress(status.name);
+  if (mailboxAddress) {
+    return mailboxAddress;
+  }
+
+  const allowlistEntries = await readAllowlistEntries();
+  if (allowlistEntries.length > 0) {
+    return allowlistEntries[0];
+  }
+
+  throw new Error(
+    'Unable to infer reply sender. Re-run with --reply-sender <email> or set EMAIL_AGENT_MCP_REPLY_SENDER.',
+  );
+}
+
+function findSafeCandidate(messages, safeSender) {
+  const safe = messages.find(message =>
+    typeof message.from === 'string' &&
+    message.from.toLowerCase().includes(safeSender.toLowerCase()),
+  );
+  if (!safe) {
+    throw new Error(`No inbox message matched safe sender filter: ${safeSender}. Re-run with --safe-sender <email> or raise --limit.`);
+  }
+  return safe;
+}
+
+function findReplyCandidate(messages, replySender) {
+  const selfSent = messages.find(message =>
+    typeof message.from === 'string' &&
+    message.from.toLowerCase().includes(replySender.toLowerCase()),
+  );
+  if (!selfSent) {
+    throw new Error(`No self-sent message found in Sent folder for reply-draft smoke test: ${replySender}. Re-run with --reply-sender <email> or raise --limit.`);
+  }
+  return selfSent;
+}
+
+function buildSendSubject(prefix) {
+  return `${prefix} ${new Date().toISOString()}`;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function readBackMessage(client, mailbox, id) {
+  return callJson(client, 'read_email', {
+    ...getMailboxArg(mailbox),
+    id,
+  });
+}
+
+async function waitForSentSubject(client, mailbox, subject, limit) {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const sent = await callJson(client, 'list_emails', {
+      ...getMailboxArg(mailbox),
+      folder: 'sent',
+      limit,
+    });
+    const match = (sent.emails ?? []).find(message => message.subject === subject);
+    if (match) {
+      return match;
+    }
+
+    if (attempt < 2) {
+      await sleep(1500);
+    }
+  }
+
+  return null;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const client = await connectClient();
+
+  try {
+    const summary = {
+      status: null,
+      safeCandidate: null,
+      replyCandidate: null,
+      readPreview: null,
+      liveWrite: opts.liveWrite,
+      mutations: [],
+    };
+
+    const status = await callJson(client, 'get_mailbox_status', getMailboxArg(opts.mailbox));
+    requireLiveMailbox(status);
+    summary.status = status;
+    summary.replySender = await resolveReplySender(opts, status);
+
+    const inbox = await callJson(client, 'list_emails', {
+      ...getMailboxArg(opts.mailbox),
+      folder: 'inbox',
+      limit: opts.limit,
+    });
+    const safeCandidate = findSafeCandidate(inbox.emails ?? [], opts.safeSender);
+    summary.safeCandidate = safeCandidate;
+
+    const safeRead = await callJson(client, 'read_email', {
+      ...getMailboxArg(opts.mailbox),
+      id: safeCandidate.id,
+    });
+    summary.readPreview = {
+      id: safeRead.id,
+      subject: safeRead.subject,
+      from: safeRead.from,
+      bodyPreview: String(safeRead.body ?? '').split('\n').slice(0, 3).join('\n'),
+    };
+
+    const sent = await callJson(client, 'list_emails', {
+      ...getMailboxArg(opts.mailbox),
+      folder: 'sent',
+      limit: opts.limit,
+    });
+    const replyCandidate = findReplyCandidate(sent.emails ?? [], summary.replySender);
+    summary.replyCandidate = replyCandidate;
+
+    if (opts.liveWrite) {
+      const markedRead = requireSuccess('mark_read(true)', await callJson(client, 'mark_read', {
+        ...getMailboxArg(opts.mailbox),
+        id: safeCandidate.id,
+        is_read: true,
+      }));
+      summary.mutations.push({ action: 'mark_read_true', result: markedRead });
+
+      const markedUnread = requireSuccess('mark_read(false)', await callJson(client, 'mark_read', {
+        ...getMailboxArg(opts.mailbox),
+        id: safeCandidate.id,
+        is_read: false,
+      }));
+      summary.mutations.push({ action: 'mark_read_false', result: markedUnread });
+
+      const labeledSafe = requireSuccess('label_email(safe)', await callJson(client, 'label_email', {
+        ...getMailboxArg(opts.mailbox),
+        id: safeCandidate.id,
+        labels: [opts.label],
+      }));
+      summary.mutations.push({ action: 'label_safe_candidate', labels: [opts.label], result: labeledSafe });
+
+      const labeledReply = requireSuccess('label_email(reply)', await callJson(client, 'label_email', {
+        ...getMailboxArg(opts.mailbox),
+        id: replyCandidate.id,
+        labels: [opts.label, opts.secondLabel],
+      }));
+      summary.mutations.push({
+        action: 'label_reply_candidate',
+        labels: [opts.label, opts.secondLabel],
+        result: labeledReply,
+      });
+
+      if (opts.sendTo) {
+        const draftSubject = buildSendSubject('email-agent-mcp launch prep draft');
+        const draft = requireSuccess('create_draft', await callJson(client, 'create_draft', {
+          ...getMailboxArg(opts.mailbox),
+          to: opts.sendTo,
+          subject: draftSubject,
+          body: 'Draft created by scripts/launch-prep-smoke.mjs during launch prep.',
+        }));
+        summary.mutations.push({ action: 'create_draft', to: opts.sendTo, draftId: draft.draftId, result: draft });
+
+        if (draft.draftId) {
+          const draftReadBack = await readBackMessage(client, opts.mailbox, draft.draftId);
+          summary.mutations.push({
+            action: 'verify_create_draft',
+            draftId: draft.draftId,
+            subject: draftReadBack.subject,
+          });
+        }
+      }
+
+      const replyDraft = requireSuccess('reply_to_email(draft)', await callJson(client, 'reply_to_email', {
+        ...getMailboxArg(opts.mailbox),
+        message_id: replyCandidate.id,
+        body: 'Draft-only reply created by scripts/launch-prep-smoke.mjs during launch prep.',
+        draft: true,
+      }));
+      summary.mutations.push({
+        action: 'reply_draft',
+        messageId: replyCandidate.id,
+        draftId: replyDraft.draftId,
+        result: replyDraft,
+      });
+
+      if (replyDraft.draftId) {
+        const replyDraftReadBack = await readBackMessage(client, opts.mailbox, replyDraft.draftId);
+        summary.mutations.push({
+          action: 'verify_reply_draft',
+          draftId: replyDraft.draftId,
+          subject: replyDraftReadBack.subject,
+        });
+      }
+
+      if (opts.sendTo) {
+        const sendSubject = buildSendSubject('email-agent-mcp live smoke');
+        const sentMessage = requireSuccess('send_email', await callJson(client, 'send_email', {
+          ...getMailboxArg(opts.mailbox),
+          to: opts.sendTo,
+          subject: sendSubject,
+          body: 'Live send smoke test from scripts/launch-prep-smoke.mjs.',
+        }));
+        const sentFolderMatch = await waitForSentSubject(client, opts.mailbox, sendSubject, Math.max(opts.limit, 50));
+        summary.mutations.push({
+          action: 'send_email',
+          to: opts.sendTo,
+          subject: sendSubject,
+          messageId: sentMessage.messageId,
+          sentFolderMatch,
+          result: sentMessage,
+        });
+      }
+    }
+
+    console.log(JSON.stringify(summary, null, 2));
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/scripts/read-email-test.mjs
+++ b/scripts/read-email-test.mjs
@@ -2,8 +2,11 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
 const transport = new StdioClientTransport({
-  command: 'npx',
-  args: ['tsx', 'packages/email-mcp/src/serve-entry.ts'],
+  command: 'node',
+  args: ['packages/email-agent-mcp/bin/email-agent-mcp.js', 'serve'],
+  cwd: process.cwd(),
+  env: { ...process.env },
+  stderr: 'inherit',
 });
 
 const client = new Client({ name: 'test', version: '1.0' }, { capabilities: {} });


### PR DESCRIPTION
## Summary
- add live Outlook launch-prep smoke coverage and the supporting Microsoft/allowlist fixes
- tighten launch-facing docs and npm metadata, including a package-level README and `0.1.1` release alignment
- automate official MCP Registry publication from the tag-driven release workflow after npm publish succeeds

## Why
The real mailbox validation exposed two release blockers:
- Microsoft folder alias and thread lookup issues that could break live Outlook usage
- registry publication gaps in the published npm metadata and release workflow

This PR moves the repo to a releaseable `0.1.1` state so `main` can be tagged and published to npm and the MCP Registry from one merged commit.

## Validation
- `npm run check:server-json`
- `npm run check:gemini-extension-manifest`
- `npm run build`
- `npm run lint`
- `npm run test:run`
- `npm run check:spec-coverage`
- live Outlook mailbox validation for read, draft, send, categorize, read/unread, move, search, and thread flows
