### PR TITLE
chore: add bump script + normalize version sync to 0.1.2

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,7 +7,10 @@
   "mcpServers": {
     "email-agent-mcp": {
       "command": "npx",
-      "args": ["-y", "email-agent-mcp"]
+      "args": [
+        "-y",
+        "email-agent-mcp"
+      ]
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -4070,10 +4070,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.1.0"
+        "@usejunior/email-mcp": "^0.1.2"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -4084,7 +4084,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "node-html-markdown": "^2.0.0",
@@ -4102,13 +4102,13 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.1.0",
-        "@usejunior/provider-microsoft": "^0.1.0"
+        "@usejunior/email-core": "^0.1.2",
+        "@usejunior/provider-microsoft": "^0.1.2"
       },
       "bin": {
         "email-agent-mcp": "dist/cli.js"
@@ -4125,11 +4125,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.1.0"
+        "@usejunior/email-core": "^0.1.2"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -4143,13 +4143,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.1.0"
+        "@usejunior/email-core": "^0.1.2"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -18,9 +18,18 @@
     "@usejunior/email-mcp": "^0.1.2"
   },
   "mcpName": "io.github.usejunior/email-agent-mcp",
-  "engines": { "node": ">=20" },
-  "files": ["bin", "index.js", "index.d.ts", "server.json"],
-  "publishConfig": {"access": "public"},
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "bin",
+    "index.js",
+    "index.d.ts",
+    "server.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/UseJunior/email-agent-mcp.git",
@@ -30,6 +39,18 @@
   "bugs": {
     "url": "https://github.com/UseJunior/email-agent-mcp/issues"
   },
-  "keywords": ["email", "mcp", "ai-agent", "microsoft-graph", "microsoft-365", "outlook", "gmail", "model-context-protocol", "openclaw", "claude", "gemini"],
+  "keywords": [
+    "email",
+    "mcp",
+    "ai-agent",
+    "microsoft-graph",
+    "microsoft-365",
+    "outlook",
+    "gmail",
+    "model-context-protocol",
+    "openclaw",
+    "claude",
+    "gemini"
+  ],
   "license": "Apache-2.0"
 }

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -11,13 +11,25 @@
     "id": "UseJunior/email-agent-mcp"
   },
   "license": "Apache-2.0",
-  "tags": ["email", "mcp", "ai-agent", "microsoft-graph", "microsoft-365", "gmail", "outlook", "model-context-protocol", "openclaw"],
+  "tags": [
+    "email",
+    "mcp",
+    "ai-agent",
+    "microsoft-graph",
+    "microsoft-365",
+    "gmail",
+    "outlook",
+    "model-context-protocol",
+    "openclaw"
+  ],
   "packages": [
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
       "version": "0.1.2",
-      "transport": { "type": "stdio" },
+      "transport": {
+        "type": "stdio"
+      },
       "runtimeHint": "npx",
       "environmentVariables": []
     }

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -47,6 +47,13 @@
   "bugs": {
     "url": "https://github.com/UseJunior/email-agent-mcp/issues"
   },
-  "keywords": ["email", "mcp", "ai-agent", "email-actions", "content-engine", "typescript"],
+  "keywords": [
+    "email",
+    "mcp",
+    "ai-agent",
+    "email-actions",
+    "content-engine",
+    "typescript"
+  ],
   "license": "Apache-2.0"
 }

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -52,6 +52,13 @@
   "bugs": {
     "url": "https://github.com/UseJunior/email-agent-mcp/issues"
   },
-  "keywords": ["email", "mcp", "model-context-protocol", "mcp-server", "ai-agent", "typescript"],
+  "keywords": [
+    "email",
+    "mcp",
+    "model-context-protocol",
+    "mcp-server",
+    "ai-agent",
+    "typescript"
+  ],
   "license": "Apache-2.0"
 }

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -47,6 +47,12 @@
   "bugs": {
     "url": "https://github.com/UseJunior/email-agent-mcp/issues"
   },
-  "keywords": ["email", "gmail", "google", "oauth", "ai-agent"],
+  "keywords": [
+    "email",
+    "gmail",
+    "google",
+    "oauth",
+    "ai-agent"
+  ],
   "license": "Apache-2.0"
 }

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -49,6 +49,13 @@
   "bugs": {
     "url": "https://github.com/UseJunior/email-agent-mcp/issues"
   },
-  "keywords": ["email", "microsoft-graph", "outlook", "office365", "oauth", "ai-agent"],
+  "keywords": [
+    "email",
+    "microsoft-graph",
+    "outlook",
+    "office365",
+    "oauth",
+    "ai-agent"
+  ],
   "license": "Apache-2.0"
 }

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -1,0 +1,194 @@
+#!/usr/bin/env node
+// bump_version.mjs — Bump all workspace versions in lockstep.
+//
+// Usage:
+//   node scripts/bump_version.mjs <new-version>
+//   node scripts/bump_version.mjs 0.2.0
+//   node scripts/bump_version.mjs --check   # Verify all versions are in sync
+//
+// Updates: root + all workspace package.json files, server.json,
+// gemini-extension.json, cross-workspace dep ranges, and package-lock.json.
+// After running, commit the changes and merge before tagging.
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const ROOT = resolve(import.meta.dirname, '..');
+
+// ── Files to update ─────────────────────────────────────────────────────
+
+const PACKAGE_JSONS = [
+  'package.json',
+  'packages/email-core/package.json',
+  'packages/email-mcp/package.json',
+  'packages/provider-microsoft/package.json',
+  'packages/provider-gmail/package.json',
+  'packages/email-agent-mcp/package.json',
+];
+
+const SERVER_JSON = 'packages/email-agent-mcp/server.json';
+const GEMINI_EXTENSION = 'gemini-extension.json';
+
+// Cross-workspace dependencies (package name → dep specifier pattern)
+const WORKSPACE_DEPS = [
+  '@usejunior/email-core',
+  '@usejunior/email-mcp',
+  '@usejunior/provider-microsoft',
+  '@usejunior/provider-gmail',
+];
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function readJson(relPath) {
+  const abs = join(ROOT, relPath);
+  return JSON.parse(readFileSync(abs, 'utf8'));
+}
+
+function writeJson(relPath, data) {
+  const abs = join(ROOT, relPath);
+  writeFileSync(abs, JSON.stringify(data, null, 2) + '\n');
+}
+
+function isValidSemver(v) {
+  return /^\d+\.\d+\.\d+(-[\w.]+)?$/.test(v);
+}
+
+// ── Check mode ──────────────────────────────────────────────────────────
+
+function checkVersionSync() {
+  const versions = new Map();
+  let ok = true;
+
+  for (const rel of PACKAGE_JSONS) {
+    const pkg = readJson(rel);
+    versions.set(rel, pkg.version);
+  }
+
+  const serverJson = readJson(SERVER_JSON);
+  versions.set(SERVER_JSON, serverJson.version);
+  if (serverJson.packages?.[0]?.version !== serverJson.version) {
+    console.error(`  ${SERVER_JSON}: packages[0].version (${serverJson.packages?.[0]?.version}) ≠ root version (${serverJson.version})`);
+    ok = false;
+  }
+
+  const gemini = readJson(GEMINI_EXTENSION);
+  versions.set(GEMINI_EXTENSION, gemini.version);
+
+  const uniqueVersions = new Set(versions.values());
+  if (uniqueVersions.size === 1) {
+    const v = [...uniqueVersions][0];
+    console.log(`All ${versions.size} files are at version ${v}`);
+  } else {
+    console.error('Version mismatch detected:');
+    for (const [file, v] of versions) {
+      console.error(`  ${v}  ${file}`);
+    }
+    ok = false;
+  }
+
+  // Check cross-workspace deps
+  for (const rel of PACKAGE_JSONS) {
+    const pkg = readJson(rel);
+    for (const depSection of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      const deps = pkg[depSection];
+      if (!deps) continue;
+      for (const name of WORKSPACE_DEPS) {
+        if (deps[name]) {
+          const expected = `^${[...uniqueVersions][0]}`;
+          if (deps[name] !== expected && uniqueVersions.size === 1) {
+            console.error(`  ${rel}: ${name} is "${deps[name]}", expected "${expected}"`);
+            ok = false;
+          }
+        }
+      }
+    }
+  }
+
+  return ok;
+}
+
+// ── Bump mode ───────────────────────────────────────────────────────────
+
+function bumpVersion(newVersion) {
+  if (!isValidSemver(newVersion)) {
+    console.error(`Invalid semver: ${newVersion}`);
+    process.exit(1);
+  }
+
+  const currentVersion = readJson('package.json').version;
+  console.log(`Bumping ${currentVersion} → ${newVersion}\n`);
+
+  // 1. Update all package.json version fields + cross-workspace deps
+  for (const rel of PACKAGE_JSONS) {
+    const pkg = readJson(rel);
+    pkg.version = newVersion;
+
+    for (const depSection of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      const deps = pkg[depSection];
+      if (!deps) continue;
+      for (const name of WORKSPACE_DEPS) {
+        if (deps[name]) {
+          deps[name] = `^${newVersion}`;
+        }
+      }
+    }
+
+    writeJson(rel, pkg);
+    console.log(`  ✓ ${rel}`);
+  }
+
+  // 2. Update server.json (both version fields)
+  const serverJson = readJson(SERVER_JSON);
+  serverJson.version = newVersion;
+  if (serverJson.packages?.[0]) {
+    serverJson.packages[0].version = newVersion;
+  }
+  writeJson(SERVER_JSON, serverJson);
+  console.log(`  ✓ ${SERVER_JSON}`);
+
+  // 3. Update gemini-extension.json
+  const gemini = readJson(GEMINI_EXTENSION);
+  gemini.version = newVersion;
+  writeJson(GEMINI_EXTENSION, gemini);
+  console.log(`  ✓ ${GEMINI_EXTENSION}`);
+
+  // 4. Regenerate package-lock.json
+  console.log('\nRegenerating package-lock.json...');
+  try {
+    execSync('npm install', { cwd: ROOT, stdio: 'inherit' });
+    console.log('  ✓ package-lock.json');
+  } catch {
+    console.error('  ✗ npm install failed — fix manually and re-run');
+    process.exit(1);
+  }
+
+  // 5. Verify
+  console.log('\nVerifying...');
+  if (checkVersionSync()) {
+    console.log(`\nDone! All files bumped to ${newVersion}.`);
+    console.log('\nNext steps:');
+    console.log(`  1. git add -A && git commit -m "chore(release): bump workspace versions to ${newVersion}"`);
+    console.log('  2. Open PR, merge to main');
+    console.log(`  3. git tag v${newVersion} && git push origin v${newVersion}`);
+  } else {
+    console.error('\nVersion sync check failed after bump — investigate manually.');
+    process.exit(1);
+  }
+}
+
+// ── Main ────────────────────────────────────────────────────────────────
+
+const arg = process.argv[2];
+
+if (!arg) {
+  console.error('Usage: node scripts/bump_version.mjs <new-version>');
+  console.error('       node scripts/bump_version.mjs --check');
+  process.exit(1);
+}
+
+if (arg === '--check') {
+  process.exit(checkVersionSync() ? 0 : 1);
+} else {
+  bumpVersion(arg);
+}


### PR DESCRIPTION
## Summary

- **New: `scripts/bump_version.mjs`** — manages all 8 version files + cross-workspace dep ranges + package-lock.json in one shot. Supports `--check` for CI validation.
- **Fixes broken npm state**: v0.1.1 published only the wrapper while internal packages stayed at 0.1.0. This normalizes everything to 0.1.2.
- **Regenerates package-lock.json** (was drifted at 0.1.0)

## Context

Peer review (Gemini + Codex) of the MCP directory registration plan found that `email-agent-mcp@0.1.1` is likely broken on npm — the wrapper depends on `@usejunior/email-mcp@^0.1.1` but that version was never published (still at 0.1.0). v0.1.2 is a recovery release.

## Test plan

- [ ] `node scripts/bump_version.mjs --check` passes
- [ ] All CI checks pass
- [ ] After merge + tag: verify all 5 npm packages at 0.1.2
- [ ] `npx -y email-agent-mcp --help` works