### PR TITLE
fix(ci): install libsecret in release workflow for keytar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Lint workspaces
         run: npm run lint
 
+      - name: Install libsecret (keytar dependency)
+        run: sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+
       - name: Run tests
         run: npm run test:run
 


### PR DESCRIPTION
## Summary
- The release workflow (`release.yml`) runs tests that import `keytar` (via `@usejunior/provider-microsoft`), which requires `libsecret-1-dev` on Linux
- The CI workflow (`ci.yml`) already installs this dependency, but the release workflow was missing it, causing test failures during release preflight
- Adds the same `sudo apt-get install -y libsecret-1-dev` step before the test step in the release workflow

## Test plan
- [ ] Trigger a release workflow run (via `workflow_dispatch`) and confirm the preflight tests pass
- [ ] Verify CI still passes on this branch