### PR TITLE
fix: shorten server.json description + bump to 0.1.3

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -4070,10 +4070,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.1.2"
+        "@usejunior/email-mcp": "^0.1.3"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -4084,7 +4084,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "node-html-markdown": "^2.0.0",
@@ -4102,13 +4102,13 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.1.2",
-        "@usejunior/provider-microsoft": "^0.1.2"
+        "@usejunior/email-core": "^0.1.3",
+        "@usejunior/provider-microsoft": "^0.1.3"
       },
       "bin": {
         "email-agent-mcp": "dist/cli.js"
@@ -4125,11 +4125,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.1.2"
+        "@usejunior/email-core": "^0.1.3"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -4143,13 +4143,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.1.2"
+        "@usejunior/email-core": "^0.1.3"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 today, Gmail wiring in progress",
   "type": "module",

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook with Gmail wiring in progress",
   "type": "module",
   "main": "./index.js",
@@ -15,9 +15,9 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.1.2"
+    "@usejunior/email-mcp": "^0.1.3"
   },
-  "mcpName": "io.github.usejunior/email-agent-mcp",
+  "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {
     "node": ">=20"
   },

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.usejunior/email-agent-mcp",
+  "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
-  "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP",
-  "version": "0.1.2",
+  "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
+  "version": "0.1.3",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.1.2",
-    "@usejunior/provider-microsoft": "^0.1.2"
+    "@usejunior/email-core": "^0.1.3",
+    "@usejunior/provider-microsoft": "^0.1.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.1.2"
+    "@usejunior/email-core": "^0.1.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.1.2"
+    "@usejunior/email-core": "^0.1.3"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

- Shorten server.json description from 111 to 95 chars (MCP Registry rejects >100)
- Align mcpName to `io.github.UseJunior` (canonical GitHub org casing)
- Bump all packages to 0.1.3

v0.1.2 npm publish succeeded but MCP Registry publish failed due to description length. This fixes it.