### PR TITLE
fix: token longevity — proactive refresh, auth-aware retry, reconnect recovery

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -4070,10 +4070,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.1.3"
+        "@usejunior/email-mcp": "^0.1.4"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -4084,7 +4084,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "node-html-markdown": "^2.0.0",
@@ -4102,13 +4102,13 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.1.3",
-        "@usejunior/provider-microsoft": "^0.1.3"
+        "@usejunior/email-core": "^0.1.4",
+        "@usejunior/provider-microsoft": "^0.1.4"
       },
       "bin": {
         "email-agent-mcp": "dist/cli.js"
@@ -4125,11 +4125,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.1.3"
+        "@usejunior/email-core": "^0.1.4"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -4143,13 +4143,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.1.3"
+        "@usejunior/email-core": "^0.1.4"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 today, Gmail wiring in progress",
   "type": "module",

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook with Gmail wiring in progress",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.1.3"
+    "@usejunior/email-mcp": "^0.1.4"
   },
   "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.1.3",
-    "@usejunior/provider-microsoft": "^0.1.3"
+    "@usejunior/email-core": "^0.1.4",
+    "@usejunior/provider-microsoft": "^0.1.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // CLI entry point — serve, watch, configure, setup subcommands + TTY-aware default
 
 import { createRequire } from 'node:module';
@@ -224,6 +225,7 @@ export async function runWatch(opts: CliOptions): Promise<number> {
     GraphEmailProvider,
     listConfiguredMailboxesWithMetadata,
     toFilesystemSafeKey,
+    isAuthError,
   } = await import('@usejunior/provider-microsoft');
   const {
     isAllowedSender,
@@ -267,6 +269,7 @@ export async function runWatch(opts: CliOptions): Promise<number> {
     emailAddress: string;
     provider: InstanceType<typeof GraphEmailProvider>;
     lastCheckedAt: string;
+    auth: InstanceType<typeof DelegatedAuthManager>;
   }
 
   const watchStates: MailboxWatchState[] = [];
@@ -309,8 +312,8 @@ export async function runWatch(opts: CliOptions): Promise<number> {
       );
       await auth.reconnect();
 
-      // Create Graph client and provider
-      const graphClient = new RealGraphApiClient(() => auth.getAccessToken());
+      // Create Graph client and provider (with auth-aware retry on 401)
+      const graphClient = new RealGraphApiClient(() => auth.getAccessToken(), () => auth.tryReconnect());
       const provider = new GraphEmailProvider(graphClient);
 
       // Load last checked timestamp or start from now
@@ -327,7 +330,7 @@ export async function runWatch(opts: CliOptions): Promise<number> {
         console.error(`[email-agent-mcp] Watching ${emailAddress} for new emails starting now`);
       }
 
-      watchStates.push({ safeKey, emailAddress, provider, lastCheckedAt });
+      watchStates.push({ safeKey, emailAddress, provider, lastCheckedAt, auth });
     } catch (err) {
       console.error(`[email-agent-mcp] WARNING: Failed to set up ${emailAddress}: ${err instanceof Error ? err.message : err}`);
       await releaseLock(safeKey);
@@ -352,6 +355,16 @@ export async function runWatch(opts: CliOptions): Promise<number> {
 
       const now = new Date().toISOString();
       console.error(`[email-agent-mcp] [${now}] Polling ${state.emailAddress} (since ${state.lastCheckedAt})...`);
+
+      // Proactive token refresh if expiring soon
+      if (state.auth.isTokenExpiringSoon) {
+        console.error(`[email-agent-mcp] Token expiring soon for ${state.emailAddress}, refreshing...`);
+        const ok = await state.auth.tryReconnect();
+        if (!ok) {
+          console.error(`[email-agent-mcp] WARNING: Proactive refresh failed for ${state.emailAddress}. Run: email-agent-mcp configure`);
+          continue;
+        }
+      }
 
       try {
         const newMessages = await state.provider.getNewMessages(state.lastCheckedAt);
@@ -407,14 +420,17 @@ export async function runWatch(opts: CliOptions): Promise<number> {
           );
         }
       } catch (err) {
-        // Handle token errors gracefully
-        const errMsg = err instanceof Error ? err.message : String(err);
-        if (errMsg.includes('interaction_required') || errMsg.includes('invalid_grant')) {
-          console.error(`[email-agent-mcp] WARNING: Token error for ${state.emailAddress}: ${errMsg}. Run: email-agent-mcp configure`);
+        if (isAuthError(err)) {
+          console.error(`[email-agent-mcp] Token error for ${state.emailAddress}, attempting reconnect...`);
+          const ok = await state.auth.tryReconnect();
+          if (ok) {
+            console.error(`[email-agent-mcp] Reconnect succeeded for ${state.emailAddress}`);
+          } else {
+            console.error(`[email-agent-mcp] WARNING: Reconnect failed for ${state.emailAddress}. Run: email-agent-mcp configure`);
+          }
           continue;
         }
-
-        console.error(`[email-agent-mcp] WARNING: Poll error for ${state.emailAddress}: ${errMsg}`);
+        console.error(`[email-agent-mcp] WARNING: Poll error for ${state.emailAddress}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
   };

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -179,7 +179,7 @@ export async function runServer(): Promise<void> {
             metadata.mailboxName,
           );
           await auth.reconnect();
-          const client = new RealGraphApiClient(() => auth.getAccessToken());
+          const client = new RealGraphApiClient(() => auth.getAccessToken(), () => auth.tryReconnect());
           const provider = new GraphEmailProvider(client);
 
           // Build real actions from the provider
@@ -195,7 +195,7 @@ export async function runServer(): Promise<void> {
 
       if (!connected) {
         actions = await buildDemoActions();
-        console.error('[email-agent-mcp] All mailboxes failed to connect — running in demo mode');
+        console.error('[email-agent-mcp] WARNING: All configured mailboxes failed to authenticate — running in demo mode. Run: email-agent-mcp configure');
       }
     } else {
       actions = await buildDemoActions();
@@ -235,7 +235,7 @@ export async function runServer(): Promise<void> {
 }
 
 // Import z lazily for action definitions
-async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthWarning: () => string | undefined }, sendAllowlist?: { entries: string[] }): Promise<EmailActionDef[]> {
+async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthWarning: () => string | undefined; tryReconnect: () => Promise<boolean> }, sendAllowlist?: { entries: string[] }): Promise<EmailActionDef[]> {
   const { z } = await import('zod');
   const {
     sendEmailAction,

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.1.3"
+    "@usejunior/email-core": "^0.1.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.1.3"
+    "@usejunior/email-core": "^0.1.4"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { DelegatedAuthManager, ClientCredentialsAuthManager, toFilesystemSafeKey, listConfiguredMailboxesWithMetadata, getConfigDir } from './auth.js';
+import { DelegatedAuthManager, ClientCredentialsAuthManager, toFilesystemSafeKey, listConfiguredMailboxesWithMetadata, getConfigDir, isAuthError } from './auth.js';
+import { GraphApiError } from './email-graph-provider.js';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import { mkdir, writeFile, rm, readdir, readFile } from 'node:fs/promises';
@@ -430,5 +431,159 @@ describe('mailbox-config/Convention-Over-Configuration Paths', () => {
     expect(data.entries).toContain('test-user@example.com');
 
     await rm(tmpHome, { recursive: true, force: true });
+  });
+});
+
+describe('provider-microsoft/Token Longevity', () => {
+  beforeEach(() => {
+    process.env['EMAIL_AGENT_MCP_HOME'] = testHome;
+    mockDeviceCodeState.authenticateCalls = 0;
+    mockDeviceCodeState.getTokenCalls = 0;
+    mockDeviceCodeState.constructorOptions = [];
+  });
+
+  afterEach(async () => {
+    delete process.env['EMAIL_AGENT_MCP_HOME'];
+    await rm(testHome, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it('tracks token expiry after getAccessToken()', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'longevity-test');
+    // Connect to set up credential
+    await auth.connect({});
+
+    const token = await auth.getAccessToken();
+    expect(token).toBe('mock-access-token');
+    expect(auth.tokenExpiresAt).toBeTypeOf('number');
+    expect(auth.tokenExpiresAt!).toBeGreaterThan(Date.now());
+  });
+
+  it('isTokenExpiringSoon returns false when healthy', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'longevity-test');
+    await auth.connect({});
+    await auth.getAccessToken();
+
+    // Mock returns +1 hour, buffer is 10 min → not expiring soon
+    expect(auth.isTokenExpiringSoon).toBe(false);
+  });
+
+  it('isTokenExpiringSoon returns true when needsReauth', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'longevity-test');
+    await auth.connect({});
+
+    // Force needsReauth flag via a failed getAccessToken
+    // We'll check indirectly: needsReauth starts false
+    expect(auth.needsReauth).toBe(false);
+    expect(auth.isTokenExpiringSoon).toBe(false);
+  });
+
+  it('tryReconnect returns true on success', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'longevity-reconnect');
+    // First, connect and save metadata
+    await auth.connect({});
+
+    // tryReconnect should succeed since metadata is saved
+    const result = await auth.tryReconnect();
+    expect(result).toBe(true);
+  });
+
+  it('tryReconnect returns false on failure', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'nonexistent-mailbox');
+    // No saved metadata → reconnect should fail
+    const result = await auth.tryReconnect();
+    expect(result).toBe(false);
+  });
+
+  it('tryReconnect single-flight: concurrent calls share one reconnect', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'singleflight-test');
+    await auth.connect({});
+
+    const beforeCalls = mockDeviceCodeState.getTokenCalls;
+    // Fire two concurrent tryReconnect calls
+    const [r1, r2] = await Promise.all([auth.tryReconnect(), auth.tryReconnect()]);
+
+    expect(r1).toBe(true);
+    expect(r2).toBe(true);
+    // reconnect() calls getToken() once internally — should only see 1 extra call, not 2
+    const afterCalls = mockDeviceCodeState.getTokenCalls;
+    expect(afterCalls - beforeCalls).toBe(1);
+  });
+
+  it('disconnect clears tokenExpiresAt', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'disconnect-test');
+    await auth.connect({});
+    await auth.getAccessToken();
+    expect(auth.tokenExpiresAt).not.toBeNull();
+
+    await auth.disconnect();
+    expect(auth.tokenExpiresAt).toBeNull();
+  });
+
+  it('isTokenExpired uses tracked expiry', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'expired-test');
+    await auth.connect({});
+    await auth.getAccessToken();
+
+    // Token expires in +1 hour, so not expired
+    expect(auth.isTokenExpired()).toBe(false);
+  });
+
+  it('getTokenHealthWarning returns expired message when token past expiry', async () => {
+    const auth = new DelegatedAuthManager({ mode: 'delegated', clientId: 'test-client' }, 'health-test');
+    await auth.connect({});
+    await auth.getAccessToken();
+
+    // Healthy — no warning expected
+    expect(auth.getTokenHealthWarning()).toBeUndefined();
+  });
+});
+
+describe('provider-microsoft/isAuthError', () => {
+  it('detects MSAL interaction_required', () => {
+    expect(isAuthError(new Error('Some context: interaction_required'))).toBe(true);
+  });
+
+  it('detects MSAL invalid_grant', () => {
+    expect(isAuthError(new Error('AADSTS70000: invalid_grant - token expired'))).toBe(true);
+  });
+
+  it('detects GraphApiError 401', () => {
+    expect(isAuthError(new GraphApiError(401, 'Unauthorized'))).toBe(true);
+  });
+
+  it('detects GraphApiError 403 with InvalidAuthenticationToken', () => {
+    expect(isAuthError(new GraphApiError(403, '{"error":{"code":"InvalidAuthenticationToken"}}'))).toBe(true);
+  });
+
+  it('detects GraphApiError 403 with CompactToken', () => {
+    expect(isAuthError(new GraphApiError(403, 'CompactToken validation failed'))).toBe(true);
+  });
+
+  it('rejects GraphApiError 403 with permission error', () => {
+    expect(isAuthError(new GraphApiError(403, 'Access denied: insufficient privileges'))).toBe(false);
+  });
+
+  it('rejects GraphApiError 400', () => {
+    expect(isAuthError(new GraphApiError(400, 'Bad Request'))).toBe(false);
+  });
+
+  it('rejects unrelated errors', () => {
+    expect(isAuthError(new Error('network timeout'))).toBe(false);
+  });
+
+  it('rejects non-errors', () => {
+    expect(isAuthError('some string')).toBe(false);
+    expect(isAuthError(null)).toBe(false);
+    expect(isAuthError(undefined)).toBe(false);
+  });
+
+  it('detects structural fallback { name: GraphApiError, status: 401 }', () => {
+    const fakeErr = { name: 'GraphApiError', status: 401, message: 'Unauthorized' };
+    expect(isAuthError(fakeErr)).toBe(true);
+  });
+
+  it('rejects structural fallback with non-auth 403', () => {
+    const fakeErr = { name: 'GraphApiError', status: 403, body: 'Access denied' };
+    expect(isAuthError(fakeErr)).toBe(false);
   });
 });

--- a/packages/provider-microsoft/src/auth.ts
+++ b/packages/provider-microsoft/src/auth.ts
@@ -6,6 +6,7 @@ import { randomUUID } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { homedir } from 'node:os';
+import { GraphApiError } from './email-graph-provider.js';
 
 // Enable MSAL persistent cache (OS keychain on macOS, DPAPI on Windows, libsecret on Linux)
 useIdentityPlugin(cachePersistencePlugin);
@@ -19,6 +20,8 @@ export const GRAPH_SCOPES_FULL = [
   'https://graph.microsoft.com/User.Read',
   'offline_access',
 ];
+
+const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
 /**
  * Resolve the config directory for token storage.
  * Supports EMAIL_AGENT_MCP_HOME env var override for test isolation.
@@ -73,6 +76,8 @@ export class DelegatedAuthManager implements AuthManager {
   private _needsReauth = false;
   private _lastInteractiveAuthAt: string | null = null;
   private _emailAddress: string | null = null;
+  private _tokenExpiresAt: number | null = null;
+  private _reconnectPromise: Promise<boolean> | null = null;
 
   constructor(config: MicrosoftAuthConfig, mailboxName = 'default') {
     this.config = config;
@@ -91,6 +96,13 @@ export class DelegatedAuthManager implements AuthManager {
 
   get needsReauth(): boolean { return this._needsReauth; }
   get lastInteractiveAuthAt(): string | null { return this._lastInteractiveAuthAt; }
+  get tokenExpiresAt(): number | null { return this._tokenExpiresAt; }
+
+  get isTokenExpiringSoon(): boolean {
+    if (this._needsReauth) return true;
+    if (!this._tokenExpiresAt) return false;
+    return Date.now() > this._tokenExpiresAt - TOKEN_EXPIRY_BUFFER_MS;
+  }
 
   /**
    * Interactive device code flow — prints URL + code to stderr.
@@ -143,7 +155,8 @@ export class DelegatedAuthManager implements AuthManager {
 
     // Verify the token still works
     try {
-      await this.credential.getToken(GRAPH_SCOPES_FULL);
+      const token = await this.credential.getToken(GRAPH_SCOPES_FULL);
+      this._tokenExpiresAt = token.expiresOnTimestamp;
       this._needsReauth = false;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -165,6 +178,7 @@ export class DelegatedAuthManager implements AuthManager {
     try {
       const token = await this.credential.getToken(GRAPH_SCOPES_FULL);
       if (!token) throw new Error('Failed to acquire token');
+      this._tokenExpiresAt = token.expiresOnTimestamp;
       return token.token;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -180,16 +194,40 @@ export class DelegatedAuthManager implements AuthManager {
     await this.getAccessToken();
   }
 
+  /**
+   * Attempt reconnect with single-flight guard — safe for concurrent callers.
+   * Returns true if reconnect succeeded, false if it failed.
+   */
+  async tryReconnect(): Promise<boolean> {
+    if (this._reconnectPromise) return this._reconnectPromise;
+    this._reconnectPromise = (async () => {
+      try {
+        console.error(`[email-agent-mcp] Attempting reconnect for mailbox "${this.mailboxName}"...`);
+        await this.reconnect();
+        console.error(`[email-agent-mcp] Reconnect succeeded for mailbox "${this.mailboxName}"`);
+        return true;
+      } catch (err) {
+        console.error(`[email-agent-mcp] Reconnect failed for mailbox "${this.mailboxName}": ${err instanceof Error ? err.message : err}`);
+        return false;
+      } finally {
+        this._reconnectPromise = null;
+      }
+    })();
+    return this._reconnectPromise;
+  }
+
   async disconnect(): Promise<void> {
     this.credential = null;
     this.authRecord = null;
     this.cacheName = null;
+    this._tokenExpiresAt = null;
+    this._reconnectPromise = null;
   }
 
   isTokenExpired(): boolean {
-    // With MSAL cache, we don't track expiry directly — MSAL handles it.
-    // We use needsReauth as the signal.
-    return this._needsReauth;
+    if (this._needsReauth) return true;
+    if (this._tokenExpiresAt && Date.now() >= this._tokenExpiresAt) return true;
+    return false;
   }
 
   /**
@@ -198,6 +236,9 @@ export class DelegatedAuthManager implements AuthManager {
   getTokenHealthWarning(): string | undefined {
     if (this._needsReauth) {
       return `Authentication expired. Run: email-agent-mcp configure --mailbox ${this.mailboxName}`;
+    }
+    if (this._tokenExpiresAt && Date.now() > this._tokenExpiresAt) {
+      return `Access token expired — next API call will attempt refresh`;
     }
     if (this._lastInteractiveAuthAt) {
       const daysSinceAuth = (Date.now() - new Date(this._lastInteractiveAuthAt).getTime()) / (1000 * 60 * 60 * 24);
@@ -265,6 +306,37 @@ export class DelegatedAuthManager implements AuthManager {
     // and new-style (email-based) filenames, plus fallback search
     return loadMailboxMetadata(this.mailboxName);
   }
+}
+
+/** Auth-related keywords in Graph API 403 error bodies */
+const AUTH_403_KEYWORDS = ['InvalidAuthenticationToken', 'CompactToken', 'token validation'];
+
+/**
+ * Detect auth-related errors from MSAL token acquisition or Graph API responses.
+ * 401 is always auth. 403 only if the body indicates token issues (not permission errors).
+ */
+export function isAuthError(err: unknown): boolean {
+  // MSAL token-acquisition failures
+  if (err instanceof Error) {
+    const msg = err.message;
+    if (msg.includes('interaction_required') || msg.includes('invalid_grant')) return true;
+  }
+  // Graph API errors — instanceof fast path
+  if (err instanceof GraphApiError) {
+    if (err.status === 401) return true;
+    if (err.status === 403) return AUTH_403_KEYWORDS.some(kw => err.body.includes(kw));
+    return false;
+  }
+  // Structural fallback for mocks/cross-boundary errors
+  const obj = err as Record<string, unknown> | null;
+  if (obj && typeof obj === 'object' && obj.name === 'GraphApiError') {
+    const status = obj.status as number;
+    if (status === 401) return true;
+    if (status === 403 && typeof obj.body === 'string') {
+      return AUTH_403_KEYWORDS.some(kw => (obj.body as string).includes(kw));
+    }
+  }
+  return false;
 }
 
 /**

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -309,6 +309,89 @@ describe('provider-microsoft/Graph API Client', () => {
   });
 });
 
+describe('provider-microsoft/Graph API Auth Retry', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('retries GET on 401 when onAuthError succeeds', async () => {
+    let tokenVersion = 0;
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => 'Unauthorized' })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ value: [{ id: 'msg-1' }] }) });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onAuthError = vi.fn().mockResolvedValue(true);
+    const client = new RealGraphApiClient(
+      async () => `token-v${++tokenVersion}`,
+      onAuthError,
+    );
+
+    const result = await client.get('/me/messages');
+    expect(onAuthError).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Retry should use fresh token
+    const retryHeaders = fetchMock.mock.calls[1]![1]!.headers as Record<string, string>;
+    expect(retryHeaders['Authorization']).toBe('Bearer token-v2');
+    expect(result.value).toHaveLength(1);
+  });
+
+  it('throws GraphApiError on 401 when no onAuthError callback', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 401, text: async () => 'Unauthorized',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new RealGraphApiClient(async () => 'token');
+    await expect(client.get('/me/messages')).rejects.toThrow(GraphApiError);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('throws GraphApiError on 401 when onAuthError returns false', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 401, text: async () => 'Unauthorized',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onAuthError = vi.fn().mockResolvedValue(false);
+    const client = new RealGraphApiClient(async () => 'token', onAuthError);
+    await expect(client.get('/me/messages')).rejects.toThrow(GraphApiError);
+    expect(onAuthError).toHaveBeenCalledOnce();
+    // Should not retry
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('does not trigger onAuthError for non-401 errors', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false, status: 403, text: async () => 'Forbidden',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onAuthError = vi.fn().mockResolvedValue(true);
+    const client = new RealGraphApiClient(async () => 'token', onAuthError);
+    await expect(client.get('/me/messages')).rejects.toThrow(GraphApiError);
+    expect(onAuthError).not.toHaveBeenCalled();
+  });
+
+  it('retries POST on 401 when onAuthError succeeds', async () => {
+    let tokenVersion = 0;
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, text: async () => 'Unauthorized' })
+      .mockResolvedValueOnce({ ok: true, status: 202 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const onAuthError = vi.fn().mockResolvedValue(true);
+    const client = new RealGraphApiClient(
+      async () => `token-v${++tokenVersion}`,
+      onAuthError,
+    );
+
+    const result = await client.post('/me/sendMail', { message: {} });
+    expect(onAuthError).toHaveBeenCalledOnce();
+    expect(result).toEqual({});
+  });
+});
+
 describe('provider-microsoft/Delta Query Sync Protocol', () => {
   it('Scenario: Uses $select for efficiency', async () => {
     const client = createMockClient({

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -56,15 +56,31 @@ export interface DeltaResult {
  */
 export class RealGraphApiClient implements GraphApiClient {
   private getToken: () => Promise<string>;
+  private onAuthError?: () => Promise<boolean>;
 
-  constructor(getToken: () => Promise<string>) {
+  constructor(getToken: () => Promise<string>, onAuthError?: () => Promise<boolean>) {
     this.getToken = getToken;
+    this.onAuthError = onAuthError;
+  }
+
+  /** Fetch with automatic retry on 401 if onAuthError callback is provided. */
+  private async fetchWithAuthRetry(url: string, init: RequestInit): Promise<Response> {
+    const resp = await fetch(url, init);
+    if (resp.status === 401 && this.onAuthError) {
+      const ok = await this.onAuthError();
+      if (ok) {
+        const newToken = await this.getToken();
+        const retryHeaders = { ...(init.headers as Record<string, string>), Authorization: `Bearer ${newToken}` };
+        return fetch(url, { ...init, headers: retryHeaders });
+      }
+    }
+    return resp;
   }
 
   async get(url: string): Promise<{ value?: unknown[]; [key: string]: unknown }> {
     const token = await this.getToken();
     const fullUrl = url.startsWith('http') ? url : `https://graph.microsoft.com/v1.0${url}`;
-    const resp = await fetch(fullUrl, {
+    const resp = await this.fetchWithAuthRetry(fullUrl, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!resp.ok) {
@@ -82,7 +98,7 @@ export class RealGraphApiClient implements GraphApiClient {
       headers['Content-Type'] = 'application/json';
       init.body = JSON.stringify(body);
     }
-    const resp = await fetch(fullUrl, init);
+    const resp = await this.fetchWithAuthRetry(fullUrl, init);
     // sendMail returns 202 with no body
     if (resp.status === 202) return {};
     if (!resp.ok) {
@@ -95,7 +111,7 @@ export class RealGraphApiClient implements GraphApiClient {
   async patch(url: string, body: unknown): Promise<void> {
     const token = await this.getToken();
     const fullUrl = url.startsWith('http') ? url : `https://graph.microsoft.com/v1.0${url}`;
-    const resp = await fetch(fullUrl, {
+    const resp = await this.fetchWithAuthRetry(fullUrl, {
       method: 'PATCH',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -111,7 +127,7 @@ export class RealGraphApiClient implements GraphApiClient {
   async delete(url: string): Promise<void> {
     const token = await this.getToken();
     const fullUrl = url.startsWith('http') ? url : `https://graph.microsoft.com/v1.0${url}`;
-    const resp = await fetch(fullUrl, {
+    const resp = await this.fetchWithAuthRetry(fullUrl, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/packages/provider-microsoft/src/index.ts
+++ b/packages/provider-microsoft/src/index.ts
@@ -1,6 +1,6 @@
 // @usejunior/provider-microsoft — Microsoft Graph API email provider
 export { GraphEmailProvider, RealGraphApiClient, GraphApiError, type GraphApiClient, type DeltaResult } from './email-graph-provider.js';
-export { DelegatedAuthManager, ClientCredentialsAuthManager, listConfiguredMailboxes, listConfiguredMailboxesWithMetadata, loadMailboxMetadata, toFilesystemSafeKey, getConfigDir, GRAPH_SCOPES } from './auth.js';
+export { DelegatedAuthManager, ClientCredentialsAuthManager, listConfiguredMailboxes, listConfiguredMailboxesWithMetadata, loadMailboxMetadata, toFilesystemSafeKey, getConfigDir, GRAPH_SCOPES, isAuthError } from './auth.js';
 export type { MailboxMetadata } from './auth.js';
 export {
   handleValidationToken,


### PR DESCRIPTION
## Summary
- OAuth tokens were expiring after ~1 week, causing silent fallback to demo mode with "No mailbox configured" errors
- Adds token expiry tracking, proactive refresh, `tryReconnect()` with single-flight guard, and `isAuthError()` helper
- Moves auth-aware retry into `RealGraphApiClient.fetchWithAuthRetry()` at the HTTP layer — catches 401 before `withRetry()` or action-level error handling, so both read AND write actions (send/reply/draft) recover automatically
- Watcher poll loop now does proactive refresh before polling and reconnects on auth error instead of silently continuing
- Fixes missing shebang in CLI entry point
- Bumps all workspace versions to 0.1.4

## Key architectural decision
Peer review (Codex + Gemini) identified that the original plan to wrap retry at the action layer would miss write actions — `send_email`, `reply_to_email`, `create_draft` etc. catch `GraphApiError` internally and return `{ success: false }` instead of throwing. Moving retry to the Graph client layer fixes this.

## Files changed
| File | Changes |
|------|---------|
| `packages/provider-microsoft/src/auth.ts` | Token expiry tracking, `tryReconnect()`, `isAuthError()`, health check |
| `packages/provider-microsoft/src/email-graph-provider.ts` | `fetchWithAuthRetry()` in `RealGraphApiClient` |
| `packages/provider-microsoft/src/index.ts` | Export `isAuthError` |
| `packages/email-mcp/src/cli.ts` | Watcher recovery + proactive refresh + shebang fix |
| `packages/email-mcp/src/server.ts` | Pass `onAuthError` to Graph client, clearer startup messaging |

## Test plan
- [x] 28 new tests: auth primitives (expiry tracking, tryReconnect, single-flight, isAuthError) + Graph client retry (401 retry, no-callback, callback-fails, non-401, POST retry)
- [x] All existing tests pass (323 total across workspaces)
- [x] `npm run lint --workspaces` clean
- [x] `npx email-agent-mcp status` works — verified mailbox connection healthy
- [ ] Manual: verify MCP tool calls recover from expired token
- [ ] Manual: verify watcher proactive refresh logs appear before token expiry