### PR TITLE
feat: add offset pagination to list_emails and search_emails

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -4070,10 +4070,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.1.4"
+        "@usejunior/email-mcp": "^0.1.5"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -4084,7 +4084,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "node-html-markdown": "^2.0.0",
@@ -4102,13 +4102,13 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.1.4",
-        "@usejunior/provider-microsoft": "^0.1.4"
+        "@usejunior/email-core": "^0.1.5",
+        "@usejunior/provider-microsoft": "^0.1.5"
       },
       "bin": {
         "email-agent-mcp": "dist/cli.js"
@@ -4125,11 +4125,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.1.4"
+        "@usejunior/email-core": "^0.1.5"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -4143,13 +4143,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.1.4"
+        "@usejunior/email-core": "^0.1.5"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 today, Gmail wiring in progress",
   "type": "module",

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook with Gmail wiring in progress",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.1.4"
+    "@usejunior/email-mcp": "^0.1.5"
   },
   "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-core/src/actions/list.ts
+++ b/packages/email-core/src/actions/list.ts
@@ -6,6 +6,7 @@ const ListEmailsInput = z.object({
   mailbox: z.string().optional(),
   unread: z.boolean().optional(),
   limit: z.number().optional().default(25),
+  offset: z.number().optional().default(0),
   folder: z.string().optional().default('inbox'),
   from: z.string().optional(),
 });
@@ -36,6 +37,7 @@ export const listEmailsAction: EmailAction<
       folder: input.folder,
       unread: input.unread,
       limit: input.limit,
+      offset: input.offset,
       from: input.from,
     });
 

--- a/packages/email-core/src/actions/search.ts
+++ b/packages/email-core/src/actions/search.ts
@@ -7,6 +7,7 @@ const SearchEmailsInput = z.object({
   mailbox: z.string().nullable().optional(),
   folder: z.string().optional(),
   limit: z.number().optional().default(25),
+  offset: z.number().optional().default(0),
 });
 
 const SearchEmailsOutput = z.object({
@@ -40,9 +41,10 @@ export const searchEmailsAction: EmailAction<
           return results.map(m => ({ ...m, mailbox: mb.name }));
         }),
       );
+      const start = input.offset ?? 0;
       const merged = allResults.flat()
         .sort((a, b) => new Date(b.receivedAt).getTime() - new Date(a.receivedAt).getTime())
-        .slice(0, input.limit);
+        .slice(start, start + (input.limit ?? 25));
 
       return {
         emails: merged.map(m => ({
@@ -58,9 +60,9 @@ export const searchEmailsAction: EmailAction<
       };
     }
 
-    const results = await ctx.provider.searchMessages(input.query, input.folder);
+    const results = await ctx.provider.searchMessages(input.query, input.folder, input.limit, input.offset);
     return {
-      emails: results.slice(0, input.limit).map(m => ({
+      emails: results.map(m => ({
         id: m.id,
         subject: m.subject,
         from: m.from.name ? `${m.from.name} <${m.from.email}>` : m.from.email,

--- a/packages/email-core/src/providers/provider.ts
+++ b/packages/email-core/src/providers/provider.ts
@@ -14,7 +14,7 @@ import type {
 export interface EmailReader {
   listMessages(opts: ListOptions): Promise<EmailMessage[]>;
   getMessage(id: string): Promise<EmailMessage>;
-  searchMessages(query: string, mailbox?: string): Promise<EmailMessage[]>;
+  searchMessages(query: string, folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]>;
   getThread(messageId: string): Promise<EmailThread>;
 }
 

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -105,14 +105,16 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
     return { ...msg };
   }
 
-  async searchMessages(query: string): Promise<EmailMessage[]> {
+  async searchMessages(query: string, _folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]> {
     this.maybeThrow();
     const lowerQuery = query.toLowerCase();
-    return this.messages.filter(m =>
+    const filtered = this.messages.filter(m =>
       m.subject.toLowerCase().includes(lowerQuery) ||
       (m.body ?? '').toLowerCase().includes(lowerQuery) ||
       m.from.email.toLowerCase().includes(lowerQuery),
     );
+    const start = offset ?? 0;
+    return filtered.slice(start, limit ? start + limit : undefined);
   }
 
   async getThread(messageId: string): Promise<EmailThread> {

--- a/packages/email-core/src/types.ts
+++ b/packages/email-core/src/types.ts
@@ -90,6 +90,7 @@ export interface ListOptions {
   folder?: string;
   unread?: boolean;
   limit?: number;
+  offset?: number;
   from?: string;
   dateFrom?: string;
   dateTo?: string;

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -24,8 +24,8 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.1.4",
-    "@usejunior/provider-microsoft": "^0.1.4"
+    "@usejunior/email-core": "^0.1.5",
+    "@usejunior/provider-microsoft": "^0.1.5"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -265,13 +265,13 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
   return [
     {
       name: 'list_emails',
-      description: 'List recent emails with filtering by unread status, folder, sender, and limit',
-      input: z.object({ mailbox: z.string().optional(), unread: z.boolean().optional(), limit: z.number().optional(), folder: z.string().optional() }),
+      description: 'List recent emails with filtering by unread status, folder, sender, and limit. Use offset for pagination.',
+      input: z.object({ mailbox: z.string().optional(), unread: z.boolean().optional(), limit: z.number().optional(), offset: z.number().optional(), folder: z.string().optional() }),
       output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
-        const inp = input as { unread?: boolean; limit?: number; folder?: string };
-        const messages = await provider.listMessages({ unread: inp.unread, limit: inp.limit ?? 25, folder: inp.folder ?? 'inbox' });
+        const inp = input as { unread?: boolean; limit?: number; offset?: number; folder?: string };
+        const messages = await provider.listMessages({ unread: inp.unread, limit: inp.limit ?? 25, offset: inp.offset, folder: inp.folder ?? 'inbox' });
         return {
           emails: (messages as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>).map(m => ({
             id: m.id,
@@ -319,13 +319,13 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
     },
     {
       name: 'search_emails',
-      description: 'Search emails using full-text query across one or all mailboxes',
-      input: z.object({ query: z.string(), mailbox: z.string().optional(), limit: z.number().optional() }),
+      description: 'Search emails using full-text query across one or all mailboxes. Use offset for pagination.',
+      input: z.object({ query: z.string(), mailbox: z.string().optional(), limit: z.number().optional(), offset: z.number().optional() }),
       output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
-        const inp = input as { query: string };
-        const results = await provider.searchMessages(inp.query) as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>;
+        const inp = input as { query: string; limit?: number; offset?: number };
+        const results = await provider.searchMessages(inp.query, undefined, inp.limit, inp.offset) as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>;
         return {
           emails: results.map(m => ({
             id: m.id,

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.1.4"
+    "@usejunior/email-core": "^0.1.5"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -51,16 +51,19 @@ export class GmailEmailProvider {
   async listMessages(opts: ListOptions): Promise<EmailMessage[]> {
     const folder = opts.folder ?? 'inbox';
     const label = FOLDER_TO_LABEL[folder] ?? folder.toUpperCase();
+    const limit = opts.limit ?? 25;
+    const offset = opts.offset ?? 0;
 
     const response = await this.client.listMessages({
       labelIds: [label],
-      maxResults: opts.limit ?? 25,
+      maxResults: offset + limit,
     });
 
     if (!response.messages?.length) return [];
 
+    const page = response.messages.slice(offset);
     const messages = await Promise.all(
-      response.messages.map(m => this.client.getMessage(m.id)),
+      page.map(m => this.client.getMessage(m.id)),
     );
 
     return messages.map(m => mapGmailMessage(m));
@@ -71,12 +74,13 @@ export class GmailEmailProvider {
     return mapGmailMessage(msg);
   }
 
-  async searchMessages(query: string): Promise<EmailMessage[]> {
-    const response = await this.client.listMessages({ q: query });
+  async searchMessages(query: string, _folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]> {
+    const response = await this.client.listMessages({ q: query, maxResults: (offset ?? 0) + (limit ?? 50) });
     if (!response.messages?.length) return [];
 
+    const page = response.messages.slice(offset ?? 0);
     const messages = await Promise.all(
-      response.messages.map(m => this.client.getMessage(m.id)),
+      page.map(m => this.client.getMessage(m.id)),
     );
     return messages.map(m => mapGmailMessage(m));
   }

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.1.4"
+    "@usejunior/email-core": "^0.1.5"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -742,6 +742,54 @@ describe('provider-microsoft/Email Address Retrieval from /me', () => {
   });
 });
 
+describe('provider-microsoft/Offset Pagination', () => {
+  it('listMessages includes $skip when offset is provided', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.listMessages({ limit: 10, offset: 25 });
+
+    const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain('$top=10');
+    expect(decoded).toContain('$skip=25');
+  });
+
+  it('listMessages omits $skip when offset is not provided', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.listMessages({ limit: 10 });
+
+    const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(url).toContain('%24top=10');
+    expect(url).not.toContain('skip');
+  });
+
+  it('searchMessages includes $top and $skip when provided', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.searchMessages('budget', undefined, 20, 10);
+
+    const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain('$top=20');
+    expect(decoded).toContain('$skip=10');
+  });
+
+  it('searchMessages uses default $top=50 when limit not provided', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.searchMessages('report');
+
+    const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(url).toContain('%24top=50');
+    expect(url).not.toContain('skip');
+  });
+});
+
 describe('provider-microsoft/Watcher Timestamp Boundary', () => {
   it('Scenario: getNewMessages uses ge not gt', async () => {
     const client = createMockClient();

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -157,6 +157,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   async listMessages(opts: ListOptions): Promise<EmailMessage[]> {
     const params = new URLSearchParams();
     params.set('$top', String(opts.limit ?? 25));
+    if (opts.offset) params.set('$skip', String(opts.offset));
     params.set('$orderby', 'receivedDateTime desc');
 
     const filters: string[] = [];
@@ -175,12 +176,13 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     return mapGraphMessage(response);
   }
 
-  async searchMessages(query: string, folder?: string): Promise<EmailMessage[]> {
+  async searchMessages(query: string, folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]> {
     if (!query || !query.trim()) return [];
 
     const params = new URLSearchParams();
     params.set('$search', `"${query}"`);
-    params.set('$top', '50');
+    params.set('$top', String(limit ?? 50));
+    if (offset) params.set('$skip', String(offset));
     const normalizedFolder = folder ? normalizeFolderId(folder) : undefined;
     const base = normalizedFolder
       ? `${this.basePath}/mailFolders/${normalizedFolder}/messages`
@@ -196,7 +198,8 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
         if (simplified && simplified !== query) {
           const retryParams = new URLSearchParams();
           retryParams.set('$search', `"${simplified}"`);
-          retryParams.set('$top', '50');
+          retryParams.set('$top', String(limit ?? 50));
+          if (offset) retryParams.set('$skip', String(offset));
           const response = await this.client.get(`${base}?${retryParams}`);
           return ((response.value ?? []) as GraphMessage[]).map(mapGraphMessage);
         }


### PR DESCRIPTION
## Summary
- Adds `offset` parameter to `list_emails` and `search_emails` MCP tools for pagination
- Maps to Graph API `$skip` for server-side pagination (no client-side workarounds)
- AI agents can now page through results: `list_emails(offset: 25, limit: 25)` for page 2
- Gmail provider uses client-side slice since Gmail API lacks `$skip`
- Bumps to v0.1.5

## Files changed
| File | Changes |
|------|---------|
| `packages/email-core/src/types.ts` | Add `offset` to `ListOptions` |
| `packages/email-core/src/providers/provider.ts` | Update `searchMessages` signature |
| `packages/email-core/src/actions/list.ts` | Add `offset` to input schema |
| `packages/email-core/src/actions/search.ts` | Add `offset` to input schema + apply |
| `packages/email-core/src/testing/mock-provider.ts` | Update mock to match new interface |
| `packages/provider-microsoft/src/email-graph-provider.ts` | Add `$skip` to list + search |
| `packages/provider-gmail/src/email-gmail-provider.ts` | Client-side offset |
| `packages/email-mcp/src/server.ts` | Add `offset` to inline MCP actions |

## Test plan
- [x] 4 new pagination tests (listMessages with/without offset, searchMessages with/without limit+offset)
- [x] All 343 tests pass across all workspaces
- [x] All workspaces build and lint clean
- [ ] Manual: `list_emails(offset: 0, limit: 10)` returns first 10
- [ ] Manual: `list_emails(offset: 10, limit: 10)` returns next 10