### PR TITLE
feat: hot-reload send and receive allowlists on file change

### DIFF
--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -32,6 +32,7 @@ export {
   checkSendAllowlist,
   SendRateLimiter,
 } from './security/send-allowlist.js';
+export { WatchedAllowlist } from './security/watched-allowlist.js';
 export { htmlToMarkdown, transformEmailContent } from './content/sanitize.js';
 export { sendEmailAction } from './actions/send.js';
 export { replyToEmailAction } from './actions/reply.js';

--- a/packages/email-core/src/security/watched-allowlist.test.ts
+++ b/packages/email-core/src/security/watched-allowlist.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { WatchedAllowlist } from './watched-allowlist.js';
+import { writeFile, rm, mkdtemp, rename, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AllowlistConfig } from '../actions/registry.js';
+
+// Reuse the same loader pattern as the real allowlist files
+async function testLoader(filePath: string): Promise<AllowlistConfig | undefined> {
+  try {
+    const { readFile } = await import('node:fs/promises');
+    const content = await readFile(filePath, 'utf-8');
+    const data = JSON.parse(content) as { entries?: string[] };
+    return { entries: data.entries ?? [] };
+  } catch {
+    return undefined;
+  }
+}
+
+// Condition-based waiting — avoids flaky fixed sleeps
+async function waitFor(fn: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise(r => setTimeout(r, 10));
+  }
+}
+
+describe('security/WatchedAllowlist', () => {
+  let tmpDir: string;
+  let watcher: WatchedAllowlist | null = null;
+
+  afterEach(async () => {
+    watcher?.close();
+    watcher = null;
+    if (tmpDir) {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Scenario: Initial load from existing file', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['*@example.com'] }));
+
+    watcher = new WatchedAllowlist(filePath, testLoader);
+    await watcher.start();
+
+    expect(watcher.config).toBeDefined();
+    expect(watcher.config!.entries).toEqual(['*@example.com']);
+  });
+
+  it('Scenario: Initial load when file does not exist', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'nonexistent.json');
+
+    watcher = new WatchedAllowlist(filePath, testLoader);
+    await watcher.start();
+
+    expect(watcher.config).toBeUndefined();
+  });
+
+  it('Scenario: Hot reload on in-place write', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['alice@test.com'] }));
+
+    watcher = new WatchedAllowlist(filePath, testLoader, 50);
+    await watcher.start();
+
+    expect(watcher.config!.entries).toEqual(['alice@test.com']);
+
+    // Update the file in place
+    await writeFile(filePath, JSON.stringify({ entries: ['alice@test.com', 'bob@test.com'] }));
+
+    // Wait for debounce + reload
+    await waitFor(() => watcher!.config?.entries.length === 2);
+
+    expect(watcher.config!.entries).toEqual(['alice@test.com', 'bob@test.com']);
+  });
+
+  it('Scenario: Hot reload on atomic temp+rename', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    const tmpFile = join(tmpDir, 'allowlist.tmp');
+    await writeFile(filePath, JSON.stringify({ entries: ['initial@test.com'] }));
+
+    watcher = new WatchedAllowlist(filePath, testLoader, 50);
+    await watcher.start();
+
+    expect(watcher.config!.entries).toEqual(['initial@test.com']);
+
+    // Atomic save: write temp file, then rename over target
+    await writeFile(tmpFile, JSON.stringify({ entries: ['atomic@test.com'] }));
+    await rename(tmpFile, filePath);
+
+    await waitFor(() => watcher!.config?.entries[0] === 'atomic@test.com');
+
+    expect(watcher.config!.entries).toEqual(['atomic@test.com']);
+  });
+
+  it('Scenario: Keeps last known config on malformed JSON', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['valid@test.com'] }));
+
+    watcher = new WatchedAllowlist(filePath, testLoader, 50);
+    await watcher.start();
+
+    expect(watcher.config!.entries).toEqual(['valid@test.com']);
+
+    // Write malformed JSON
+    await writeFile(filePath, '{ broken json !!!');
+
+    // Wait for debounce to fire + reload attempt
+    await new Promise(r => setTimeout(r, 200));
+
+    // Should retain last known good config (file exists but malformed)
+    expect(watcher.config!.entries).toEqual(['valid@test.com']);
+  });
+
+  it('Scenario: Resets config on file deletion', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['keep-me@test.com'] }));
+
+    watcher = new WatchedAllowlist(filePath, testLoader, 50);
+    await watcher.start();
+
+    expect(watcher.config!.entries).toEqual(['keep-me@test.com']);
+
+    // Delete the file
+    await unlink(filePath);
+
+    // Config should reset to undefined
+    await waitFor(() => watcher!.config === undefined);
+
+    expect(watcher.config).toBeUndefined();
+  });
+
+  it('Scenario: close() stops watching', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['initial@test.com'] }));
+
+    watcher = new WatchedAllowlist(filePath, testLoader, 50);
+    await watcher.start();
+
+    expect(watcher.config!.entries).toEqual(['initial@test.com']);
+
+    // Close the watcher
+    watcher.close();
+
+    // Update file after close — should NOT be picked up
+    await writeFile(filePath, JSON.stringify({ entries: ['updated@test.com'] }));
+    await new Promise(r => setTimeout(r, 200));
+
+    expect(watcher.config!.entries).toEqual(['initial@test.com']);
+  });
+
+  it('Scenario: Handles parent directory not existing at startup', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    // Point to a nested directory that doesn't exist — mkdir will create it
+    const nestedDir = join(tmpDir, 'nested', 'deep');
+    const filePath = join(nestedDir, 'allowlist.json');
+
+    watcher = new WatchedAllowlist(filePath, testLoader);
+    await watcher.start();
+
+    // Should not throw, config should be undefined
+    expect(watcher.config).toBeUndefined();
+  });
+
+  it('Scenario: File created after watcher starts', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+
+    // Start watcher before file exists
+    watcher = new WatchedAllowlist(filePath, testLoader, 50);
+    await watcher.start();
+
+    expect(watcher.config).toBeUndefined();
+
+    // Create the file — watcher should pick it up
+    await writeFile(filePath, JSON.stringify({ entries: ['new@test.com'] }));
+
+    await waitFor(() => watcher!.config !== undefined);
+
+    expect(watcher.config!.entries).toEqual(['new@test.com']);
+  });
+});

--- a/packages/email-core/src/security/watched-allowlist.ts
+++ b/packages/email-core/src/security/watched-allowlist.ts
@@ -1,0 +1,102 @@
+// Hot-reloading file watcher for allowlist configuration files.
+// Watches the PARENT directory for robustness with atomic writes,
+// file creation, and deletion.
+
+import { watch, existsSync, type FSWatcher } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname, basename } from 'node:path';
+import type { AllowlistConfig } from '../actions/registry.js';
+
+export class WatchedAllowlist {
+  private _config: AllowlistConfig | undefined;
+  private _watcher: FSWatcher | undefined;
+  private _debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(
+    private readonly filePath: string,
+    private readonly loader: (path: string) => Promise<AllowlistConfig | undefined>,
+    private readonly debounceMs = 150,
+  ) {}
+
+  /** Current allowlist config. undefined if file doesn't exist or hasn't been loaded. */
+  get config(): AllowlistConfig | undefined {
+    return this._config;
+  }
+
+  /**
+   * Load initial config and start watching for changes.
+   * Startup order: mkdir → arm watch → load (eliminates race window).
+   */
+  async start(): Promise<void> {
+    const dir = dirname(this.filePath);
+    const name = basename(this.filePath);
+
+    // 1. Ensure parent directory exists
+    try {
+      await mkdir(dir, { recursive: true });
+    } catch (err) {
+      console.error(`[email-agent-mcp] Cannot create allowlist directory ${dir}: ${err instanceof Error ? err.message : err}`);
+      // Still load the initial config even if we can't watch
+      this._config = await this.loader(this.filePath);
+      return;
+    }
+
+    // 2. Arm the watch BEFORE loading — eliminates the startup race window
+    try {
+      this._watcher = watch(dir, (_event, filename) => {
+        // filename can be null on some platforms — treat as possible target change
+        if (!filename || filename === name) {
+          this.scheduleReload();
+        }
+      });
+      this._watcher.on('error', (err) => {
+        console.error(`[email-agent-mcp] Allowlist watcher error for ${this.filePath}: ${err.message}`);
+      });
+      this._watcher.unref();
+    } catch (err) {
+      console.error(`[email-agent-mcp] Cannot watch allowlist directory ${dir}: ${err instanceof Error ? err.message : err}`);
+    }
+
+    // 3. Load initial config AFTER watch is armed
+    this._config = await this.loader(this.filePath);
+  }
+
+  /** Stop watching and clean up resources. */
+  close(): void {
+    if (this._debounceTimer) {
+      clearTimeout(this._debounceTimer);
+      this._debounceTimer = undefined;
+    }
+    if (this._watcher) {
+      this._watcher.close();
+      this._watcher = undefined;
+    }
+  }
+
+  private scheduleReload(): void {
+    if (this._debounceTimer) clearTimeout(this._debounceTimer);
+    this._debounceTimer = setTimeout(() => { void this.reload(); }, this.debounceMs);
+    this._debounceTimer.unref();
+  }
+
+  private async reload(): Promise<void> {
+    try {
+      const newConfig = await this.loader(this.filePath);
+      if (newConfig !== undefined) {
+        // Valid config loaded — update
+        this._config = newConfig;
+        console.error(`[email-agent-mcp] Allowlist reloaded: ${newConfig.entries.length} entries from ${this.filePath}`);
+      } else {
+        // Loader returned undefined — distinguish deletion from corruption
+        if (!existsSync(this.filePath)) {
+          // File deleted → reset to undefined (respects default policies)
+          this._config = undefined;
+          console.error(`[email-agent-mcp] Allowlist file removed: ${this.filePath}`);
+        }
+        // File exists but malformed → keep last known good config (no update)
+      }
+    } catch {
+      // Keep previous config on unexpected error
+    }
+  }
+}

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -231,6 +231,7 @@ export async function runWatch(opts: CliOptions): Promise<number> {
     isAllowedSender,
     loadReceiveAllowlist,
     getReceiveAllowlistPath,
+    WatchedAllowlist,
   } = await import('@usejunior/email-core');
   const {
     buildWakePayload,
@@ -244,10 +245,11 @@ export async function runWatch(opts: CliOptions): Promise<number> {
     releaseAllLocks,
   } = await import('./watcher.js');
 
-  // Load receive allowlist
+  // Load receive allowlist with hot-reload
   const allowlistPath = getReceiveAllowlistPath();
-  const allowlist = await loadReceiveAllowlist(allowlistPath);
-  if (!allowlist) {
+  const receiveWatcher = new WatchedAllowlist(allowlistPath, loadReceiveAllowlist);
+  await receiveWatcher.start();
+  if (!receiveWatcher.config) {
     console.error('[email-agent-mcp] WARNING: No receive allowlist configured — accepting all senders');
   }
 
@@ -280,6 +282,7 @@ export async function runWatch(opts: CliOptions): Promise<number> {
     if (shuttingDown) return;
     shuttingDown = true;
     console.error('\n[email-agent-mcp] Shutting down watcher...');
+    receiveWatcher.close();
     await releaseAllLocks();
     console.error('[email-agent-mcp] Lock files cleaned up. Goodbye.');
     process.exit(0);
@@ -383,7 +386,7 @@ export async function runWatch(opts: CliOptions): Promise<number> {
 
           // Receive allowlist check
           const senderEmail = msg.from?.email ?? '';
-          if (!isAllowedSender(senderEmail, allowlist)) {
+          if (!isAllowedSender(senderEmail, receiveWatcher.config)) {
             skippedAllowlist++;
             markProcessed(msg.id);
             console.error(`[email-agent-mcp] Skipping email from ${senderEmail} (not on receive allowlist)`);

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -149,12 +149,14 @@ export async function runServer(): Promise<void> {
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
   const { ListToolsRequestSchema, CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
 
-  // Load send allowlist at startup (convention: ~/.email-agent-mcp/send-allowlist.json)
-  const { loadSendAllowlist, getSendAllowlistPath } = await import('@usejunior/email-core');
+  // Load send allowlist with hot-reload (convention: ~/.email-agent-mcp/send-allowlist.json)
+  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist } = await import('@usejunior/email-core');
   const sendAllowlistPath = getSendAllowlistPath();
-  const sendAllowlist = await loadSendAllowlist(sendAllowlistPath);
-  if (sendAllowlist && sendAllowlist.entries.length > 0) {
-    console.error(`[email-agent-mcp] Send allowlist loaded: ${sendAllowlist.entries.length} entries from ${sendAllowlistPath}`);
+  const sendAllowlistWatcher = new WatchedAllowlist(sendAllowlistPath, loadSendAllowlist);
+  await sendAllowlistWatcher.start();
+  const getSendAllowlist = () => sendAllowlistWatcher.config;
+  if (sendAllowlistWatcher.config && sendAllowlistWatcher.config.entries.length > 0) {
+    console.error(`[email-agent-mcp] Send allowlist loaded (watched): ${sendAllowlistWatcher.config.entries.length} entries from ${sendAllowlistPath}`);
   } else {
     console.error(`[email-agent-mcp] WARNING: Send allowlist empty or not found at ${sendAllowlistPath} — all outbound email is disabled`);
   }
@@ -183,7 +185,7 @@ export async function runServer(): Promise<void> {
           const provider = new GraphEmailProvider(client);
 
           // Build real actions from the provider
-          actions = await buildRealActions(provider, auth, sendAllowlist);
+          actions = await buildRealActions(provider, auth, getSendAllowlist);
           console.error(`[email-agent-mcp] Connected to mailbox "${displayName}" (${metadata.clientId})`);
           connected = true;
           break;
@@ -235,7 +237,7 @@ export async function runServer(): Promise<void> {
 }
 
 // Import z lazily for action definitions
-async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthWarning: () => string | undefined; tryReconnect: () => Promise<boolean> }, sendAllowlist?: { entries: string[] }): Promise<EmailActionDef[]> {
+async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthWarning: () => string | undefined; tryReconnect: () => Promise<boolean> }, getSendAllowlist: () => { entries: string[] } | undefined): Promise<EmailActionDef[]> {
   const { z } = await import('zod');
   const {
     sendEmailAction,
@@ -251,8 +253,11 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
     deleteEmailAction,
   } = await import('@usejunior/email-core');
 
-  // Build ActionContext for send/reply actions
-  const actionCtx = { provider: provider as never, sendAllowlist };
+  // Build ActionContext for send/reply actions — getter ensures hot-reloaded allowlist
+  const actionCtx = {
+    provider: provider as never,
+    get sendAllowlist() { return getSendAllowlist(); },
+  };
   const wrapAction = (action: EmailAction<any, any>): EmailActionDef => ({
     name: action.name,
     description: action.description,
@@ -348,7 +353,8 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
         const warnings: string[] = [];
         const healthWarning = auth.getTokenHealthWarning();
         if (healthWarning) warnings.push(healthWarning);
-        if (!sendAllowlist || sendAllowlist.entries.length === 0) {
+        const currentAllowlist = getSendAllowlist();
+        if (!currentAllowlist || currentAllowlist.entries.length === 0) {
           warnings.push('Send allowlist not configured — all outbound email is disabled. Run: email-agent-mcp configure');
         }
         return { name: 'default', provider: 'microsoft', status: 'connected', isDefault: true, warnings };


### PR DESCRIPTION
## Summary
- Add `WatchedAllowlist` class that watches allowlist JSON files for changes using `fs.watch` on the parent directory, with debounced reload (150ms)
- Send allowlist in MCP server (`server.ts`) and receive allowlist in watcher CLI (`cli.ts`) now hot-reload automatically — no restart needed to add recipients
- Uses getter property on `actionCtx.sendAllowlist` so all actions transparently read the latest config with zero changes to action files

## Design decisions
- **Parent directory watch** (not file): survives atomic saves (editor write-temp-then-rename), handles file creation/deletion, works across macOS kqueue and Linux inotify
- **Startup order**: mkdir → arm watch → load (eliminates race window between load and watch)
- **Deletion vs corruption**: file removed → reset to `undefined` (respects default policies); file exists but malformed → keep last known good config
- **Null filename handling**: `fs.watch` may report null filename on some platforms → treated as "possible target change", triggers reload
- **FSWatcher error listener**: prevents process crash on `EMFILE` or other watch errors
- **`unref()`** on both watcher and debounce timer to not prevent process exit

## Files changed
| File | Change |
|------|--------|
| `packages/email-core/src/security/watched-allowlist.ts` | **NEW** — `WatchedAllowlist` class |
| `packages/email-core/src/security/watched-allowlist.test.ts` | **NEW** — 9 test scenarios |
| `packages/email-core/src/index.ts` | Export `WatchedAllowlist` |
| `packages/email-mcp/src/server.ts` | Use `WatchedAllowlist` for send allowlist, getter on `actionCtx` |
| `packages/email-mcp/src/cli.ts` | Use `WatchedAllowlist` for receive allowlist, cleanup in shutdown |

## Test plan
- [x] All 352 existing tests pass unchanged (164 + 81 + 12 + 95)
- [x] 9 new `WatchedAllowlist` tests pass (initial load, hot reload, atomic rename, malformed JSON, file deletion, close, missing parent dir, file creation after start)
- [x] TypeScript compiles cleanly (`tsc --build`)
- [ ] Manual verification: start server, modify `~/.email-agent-mcp/send-allowlist.json`, observe reload log on stderr