### PR TITLE
fix(provider-microsoft): add missing afterEach import in test

### DIFF
--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GraphEmailProvider, GraphApiError, RealGraphApiClient, simplifySearchQuery, type GraphApiClient } from './email-graph-provider.js';
 
 // Linux CI runners do not provide libsecret, so auth imports must not load the real cache plugin.


### PR DESCRIPTION
## Summary
- Adds `afterEach` to the vitest import in `email-graph-provider.test.ts`, fixing `ReferenceError: afterEach is not defined` that has been failing CI since PR #9.

## Test plan
- [ ] CI passes (the only failing test suite was this file)