### PR TITLE
refactor: DRY compose helpers + simplify draft allowlist

### DIFF
--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -1,0 +1,158 @@
+// Shared helpers for compose actions — internal module, NOT exported from package root
+import type { RateLimiter, MailboxEntry } from './registry.js';
+import { ProviderError } from '../providers/provider.js';
+import { resolveBodyFile } from '../content/body-loader.js';
+
+// --- Error shape used by all actions ---
+
+interface ActionError {
+  code: string;
+  message: string;
+  recoverable: boolean;
+}
+
+// --- checkMailboxRequired ---
+
+export function checkMailboxRequired(
+  mailbox: string | undefined,
+  allMailboxes: MailboxEntry[] | undefined,
+): ActionError | null {
+  if (!mailbox && allMailboxes && allMailboxes.length > 1) {
+    return {
+      code: 'MAILBOX_REQUIRED',
+      message: 'mailbox parameter required when multiple mailboxes are configured',
+      recoverable: false,
+    };
+  }
+  return null;
+}
+
+// --- resolveComposeFields ---
+
+export interface ComposeFields {
+  body: string;
+  to?: string | string[];
+  cc?: string[];
+  subject?: string;
+  replyTo?: string;
+  draft?: boolean;
+  error?: ActionError;
+}
+
+/**
+ * Resolve body content from body/body_file and merge frontmatter.
+ * Stays narrow: body resolution + frontmatter merge only.
+ * Does NOT do required-field validation or mode branching.
+ *
+ * For update_draft where body is optional, pass `bodyOptional: true`.
+ */
+export async function resolveComposeFields(
+  input: {
+    body?: string;
+    body_file?: string;
+    to?: string | string[];
+    cc?: string[];
+    subject?: string;
+    reply_to?: string;
+    draft?: boolean;
+  },
+  safeDir?: string,
+  opts?: { bodyOptional?: boolean },
+): Promise<ComposeFields> {
+  let body: string | undefined;
+  let to = input.to;
+  let cc = input.cc;
+  let subject = input.subject;
+  let replyTo = input.reply_to;
+  let draft = input.draft;
+
+  if (input.body_file) {
+    const bodyResult = await resolveBodyFile(input.body_file, safeDir);
+    if (bodyResult.error) {
+      return { body: '', error: bodyResult.error };
+    }
+    body = bodyResult.content!;
+
+    // Frontmatter is authoritative
+    if (bodyResult.frontmatter) {
+      const fm = bodyResult.frontmatter;
+      if (fm.to !== undefined) to = fm.to;
+      if (fm.cc !== undefined) cc = Array.isArray(fm.cc) ? fm.cc : [fm.cc];
+      if (fm.subject !== undefined) subject = fm.subject;
+      if (fm.reply_to !== undefined) replyTo = fm.reply_to;
+      if (fm.draft !== undefined) draft = fm.draft;
+    }
+  } else if (input.body) {
+    body = input.body;
+  } else if (!opts?.bodyOptional) {
+    return {
+      body: '',
+      error: { code: 'MISSING_BODY', message: 'Either body or body_file is required', recoverable: false },
+    };
+  }
+
+  return { body: body ?? '', to, cc, subject, replyTo, draft };
+}
+
+// --- validateRequiredFields ---
+
+export function validateRequiredFields(
+  to: string | string[] | undefined,
+  subject: string | undefined,
+): ActionError | null {
+  if (!to) {
+    return {
+      code: 'MISSING_FIELD',
+      message: 'to is required — provide it as a parameter or in body_file frontmatter',
+      recoverable: false,
+    };
+  }
+  if (!subject) {
+    return {
+      code: 'MISSING_FIELD',
+      message: 'subject is required — provide it as a parameter or in body_file frontmatter',
+      recoverable: false,
+    };
+  }
+  return null;
+}
+
+// --- checkRateLimit ---
+
+export function checkRateLimit(
+  rateLimiter: RateLimiter | undefined,
+  actionName: string,
+): { success: false; error: ActionError } | null {
+  if (!rateLimiter) return null;
+  const rateCheck = rateLimiter.checkLimit(actionName);
+  if (!rateCheck.allowed) {
+    return {
+      success: false,
+      error: {
+        code: 'RATE_LIMITED',
+        message: `Send rate limit exceeded. Retry after ${rateCheck.retryAfter}s`,
+        recoverable: true,
+      },
+    };
+  }
+  return null;
+}
+
+// --- handleProviderError ---
+
+export function handleProviderError(err: unknown, fallbackCode: string) {
+  if (err instanceof ProviderError) {
+    return {
+      success: false as const,
+      error: { code: err.code, message: err.message, recoverable: err.recoverable },
+    };
+  }
+  return {
+    success: false as const,
+    error: {
+      code: fallbackCode,
+      message: err instanceof Error ? err.message : String(err),
+      recoverable: false,
+    },
+  };
+}

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -34,15 +34,16 @@ describe('email-write/Create Draft', () => {
     expect(provider.getDrafts().size).toBe(1);
   });
 
-  it('Scenario: Create draft blocked by allowlist', async () => {
+  it('Scenario: Create draft to blocked recipient succeeds (drafts bypass allowlist)', async () => {
     const result = await createDraftAction.run(ctx, {
       to: 'alice@blocked.com',
       subject: 'Blocked Draft',
       body: 'Draft body',
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(result.success).toBe(true);
+    expect(result.draftId).toBeDefined();
+    expect(provider.getDrafts().size).toBe(1);
   });
 
   it('Scenario: Create draft from body_file with frontmatter', async () => {
@@ -190,6 +191,34 @@ describe('email-write/Send Draft', () => {
     expect(result.success).toBe(false);
     expect(result.error!.code).toBe('RATE_LIMITED');
   });
+
+  it('Scenario: send_draft with blocked recipient is blocked by allowlist', async () => {
+    // Create a draft to a blocked recipient (succeeds — drafts bypass allowlist)
+    const draftResult = await createDraftAction.run(ctx, {
+      to: 'hacker@evil.com',
+      subject: 'Blocked at send time',
+      body: 'Body',
+    });
+    expect(draftResult.success).toBe(true);
+
+    // Attempt to send — blocked by allowlist enforcement
+    const result = await sendDraftAction.run(ctx, {
+      draft_id: draftResult.draftId!,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+  });
+
+  it('Scenario: send_draft when draft lookup fails is blocked (fail closed)', async () => {
+    // Use a draft_id that doesn't exist in drafts or messages
+    const result = await sendDraftAction.run(ctx, {
+      draft_id: 'nonexistent-draft-id',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('DRAFT_LOOKUP_FAILED');
+  });
 });
 
 describe('email-write/Update Draft', () => {
@@ -211,7 +240,7 @@ describe('email-write/Update Draft', () => {
     expect(draft.body).toBe('Updated body');
   });
 
-  it('Scenario: Update draft recipients re-checks allowlist', async () => {
+  it('Scenario: Update draft recipients to blocked address succeeds (drafts bypass allowlist)', async () => {
     const draftResult = await createDraftAction.run(ctx, {
       to: 'alice@allowed.com',
       subject: 'Test',
@@ -223,8 +252,10 @@ describe('email-write/Update Draft', () => {
       to: 'hacker@evil.com',
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(result.success).toBe(true);
+    const drafts = provider.getDrafts();
+    const draft = drafts.get(draftResult.draftId!)!;
+    expect(draft.to[0]!.email).toBe('hacker@evil.com');
   });
 
   it('Scenario: Provider lacks updateDraft', async () => {

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -3,8 +3,15 @@ import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { checkReplyThreading } from '../security/reply-validation.js';
-import { ProviderError, withRetry } from '../providers/provider.js';
-import { resolveBodyFile, truncateBody, BODY_SIZE_LIMIT } from '../content/body-loader.js';
+import { withRetry } from '../providers/provider.js';
+import { truncateBody, BODY_SIZE_LIMIT } from '../content/body-loader.js';
+import {
+  checkMailboxRequired,
+  resolveComposeFields,
+  validateRequiredFields,
+  checkRateLimit,
+  handleProviderError,
+} from './compose-helpers.js';
 
 // --- Shared schemas ---
 
@@ -41,71 +48,32 @@ export const createDraftAction: EmailAction<
   annotations: { readOnlyHint: false, destructiveHint: false },
   run: async (ctx, input) => {
     // Check mailbox requirement
-    if (!input.mailbox && ctx.allMailboxes && ctx.allMailboxes.length > 1) {
-      return {
-        success: false,
-        error: { code: 'MAILBOX_REQUIRED', message: 'mailbox parameter required when multiple mailboxes are configured', recoverable: false },
-      };
+    const mailboxError = checkMailboxRequired(input.mailbox, ctx.allMailboxes);
+    if (mailboxError) {
+      return { success: false, error: mailboxError };
     }
 
     // Resolve body and frontmatter
-    let body: string;
-    let to = input.to;
-    let cc = input.cc;
-    let subject = input.subject;
-    let replyTo = input.reply_to;
-
-    if (input.body_file) {
-      const bodyResult = await resolveBodyFile(input.body_file, ctx.safeDir);
-      if (bodyResult.error) {
-        return { success: false, error: bodyResult.error };
-      }
-      body = bodyResult.content!;
-
-      // Frontmatter is authoritative
-      if (bodyResult.frontmatter) {
-        const fm = bodyResult.frontmatter;
-        if (fm.to !== undefined) to = fm.to;
-        if (fm.cc !== undefined) cc = Array.isArray(fm.cc) ? fm.cc : [fm.cc];
-        if (fm.subject !== undefined) subject = fm.subject;
-        if (fm.reply_to !== undefined) replyTo = fm.reply_to;
-      }
-    } else if (input.body) {
-      body = input.body;
-    } else {
-      return {
-        success: false,
-        error: { code: 'MISSING_BODY', message: 'Either body or body_file is required', recoverable: false },
-      };
+    const fields = await resolveComposeFields(input, ctx.safeDir);
+    if (fields.error) {
+      return { success: false, error: fields.error };
     }
+
+    const { to, cc, subject, replyTo } = fields;
+    let { body } = fields;
 
     // Validate required fields
-    if (!to) {
-      return {
-        success: false,
-        error: { code: 'MISSING_FIELD', message: 'to is required — provide it as a parameter or in body_file frontmatter', recoverable: false },
-      };
-    }
-    if (!subject) {
-      return {
-        success: false,
-        error: { code: 'MISSING_FIELD', message: 'subject is required — provide it as a parameter or in body_file frontmatter', recoverable: false },
-      };
+    const requiredError = validateRequiredFields(to, subject);
+    if (requiredError) {
+      return { success: false, error: requiredError };
     }
 
-    const recipients = Array.isArray(to) ? to : [to];
+    const recipients = Array.isArray(to) ? to : [to!];
 
-    // Check allowlist
-    const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
-    if (allowlistError) {
-      return {
-        success: false,
-        error: { code: 'ALLOWLIST_BLOCKED', message: allowlistError, recoverable: false },
-      };
-    }
+    // Drafts bypass allowlist — enforcement happens at send_draft time
 
     // Re: threading guardrail
-    const threadingError = checkReplyThreading(subject, replyTo);
+    const threadingError = checkReplyThreading(subject!, replyTo);
     if (threadingError) {
       return { success: false, error: threadingError };
     }
@@ -142,7 +110,7 @@ export const createDraftAction: EmailAction<
       const result = await ctx.provider.createDraft({
         to: recipients.map(email => ({ email })),
         cc: cc?.map(email => ({ email })),
-        subject,
+        subject: subject!,
         body,
       });
       return {
@@ -178,32 +146,55 @@ export const sendDraftAction: EmailAction<
   z.infer<typeof SendDraftOutput>
 > = {
   name: 'send_draft',
-  description: 'Send a previously created draft. Rate-limited.',
+  description: 'Send a previously created draft. Enforces send allowlist before sending. Rate-limited.',
   input: SendDraftInput,
   output: SendDraftOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
   run: async (ctx, input) => {
     // Check mailbox requirement
-    if (!input.mailbox && ctx.allMailboxes && ctx.allMailboxes.length > 1) {
+    const mailboxError = checkMailboxRequired(input.mailbox, ctx.allMailboxes);
+    if (mailboxError) {
+      return { success: false, error: mailboxError };
+    }
+
+    // Fetch draft to check recipients against allowlist (fail closed)
+    let draftMessage;
+    try {
+      draftMessage = await ctx.provider.getMessage(input.draft_id);
+    } catch (err) {
       return {
         success: false,
-        error: { code: 'MAILBOX_REQUIRED', message: 'mailbox parameter required when multiple mailboxes are configured', recoverable: false },
+        error: {
+          code: 'DRAFT_LOOKUP_FAILED',
+          message: `Cannot verify draft recipients before sending: ${err instanceof Error ? err.message : String(err)}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    const recipients = [
+      ...(draftMessage.to?.map(a => a.email) ?? []),
+      ...(draftMessage.cc?.map(a => a.email) ?? []),
+    ];
+    if (recipients.length === 0) {
+      return {
+        success: false,
+        error: { code: 'NO_RECIPIENTS', message: 'Draft has no recipients', recoverable: false },
+      };
+    }
+
+    const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
+    if (allowlistError) {
+      return {
+        success: false,
+        error: { code: 'ALLOWLIST_BLOCKED', message: allowlistError, recoverable: false },
       };
     }
 
     // Check rate limit
-    if (ctx.rateLimiter) {
-      const rateCheck = ctx.rateLimiter.checkLimit('send_draft');
-      if (!rateCheck.allowed) {
-        return {
-          success: false,
-          error: {
-            code: 'RATE_LIMITED',
-            message: `Send rate limit exceeded. Retry after ${rateCheck.retryAfter}s`,
-            recoverable: true,
-          },
-        };
-      }
+    const rateLimitError = checkRateLimit(ctx.rateLimiter, 'send_draft');
+    if (rateLimitError) {
+      return rateLimitError;
     }
 
     try {
@@ -244,17 +235,15 @@ export const updateDraftAction: EmailAction<
   z.infer<typeof DraftOutput>
 > = {
   name: 'update_draft',
-  description: 'Update a draft email. Re-checks allowlist if recipients change.',
+  description: 'Update a draft email. Allowlist is enforced at send_draft time, not here.',
   input: UpdateDraftInput,
   output: DraftOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
   run: async (ctx, input) => {
     // Check mailbox requirement
-    if (!input.mailbox && ctx.allMailboxes && ctx.allMailboxes.length > 1) {
-      return {
-        success: false,
-        error: { code: 'MAILBOX_REQUIRED', message: 'mailbox parameter required when multiple mailboxes are configured', recoverable: false },
-      };
+    const mailboxError = checkMailboxRequired(input.mailbox, ctx.allMailboxes);
+    if (mailboxError) {
+      return { success: false, error: mailboxError };
     }
 
     // Check provider supports updateDraft
@@ -265,39 +254,16 @@ export const updateDraftAction: EmailAction<
       };
     }
 
-    // Resolve body from file if provided
-    let body = input.body;
-    let to = input.to;
-    let cc = input.cc;
-    let subject = input.subject;
-
-    if (input.body_file) {
-      const bodyResult = await resolveBodyFile(input.body_file, ctx.safeDir);
-      if (bodyResult.error) {
-        return { success: false, error: bodyResult.error };
-      }
-      body = bodyResult.content!;
-
-      // Frontmatter is authoritative
-      if (bodyResult.frontmatter) {
-        const fm = bodyResult.frontmatter;
-        if (fm.to !== undefined) to = fm.to;
-        if (fm.cc !== undefined) cc = Array.isArray(fm.cc) ? fm.cc : [fm.cc];
-        if (fm.subject !== undefined) subject = fm.subject;
-      }
+    // Resolve body from file if provided (body is optional for updates)
+    const fields = await resolveComposeFields(input, ctx.safeDir, { bodyOptional: true });
+    if (fields.error) {
+      return { success: false, error: fields.error };
     }
 
-    // Re-check allowlist if recipients changed
-    if (to) {
-      const recipients = Array.isArray(to) ? to : [to];
-      const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
-      if (allowlistError) {
-        return {
-          success: false,
-          error: { code: 'ALLOWLIST_BLOCKED', message: allowlistError, recoverable: false },
-        };
-      }
-    }
+    const { to, cc, subject } = fields;
+    let { body } = fields;
+
+    // Drafts bypass allowlist — enforcement happens at send_draft time
 
     // Re: threading guardrail on subject if changed
     if (subject) {
@@ -334,22 +300,3 @@ export const updateDraftAction: EmailAction<
     }
   },
 };
-
-// --- Shared error handler ---
-
-function handleProviderError(err: unknown, fallbackCode: string) {
-  if (err instanceof ProviderError) {
-    return {
-      success: false as const,
-      error: { code: err.code, message: err.message, recoverable: err.recoverable },
-    };
-  }
-  return {
-    success: false as const,
-    error: {
-      code: fallbackCode,
-      message: err instanceof Error ? err.message : String(err),
-      recoverable: false,
-    },
-  };
-}

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -91,6 +91,30 @@ describe('email-write/Reply Draft', () => {
     expect(provider.getSentMessages()).toHaveLength(0);
   });
 
+  it('Scenario: Reply draft to blocked recipient succeeds (drafts bypass allowlist)', async () => {
+    const blockedMsgId = 'blocked_msg_1234567890ab';
+    provider.addMessage({
+      id: blockedMsgId,
+      subject: 'From blocked sender',
+      from: { email: 'hacker@evil.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: false,
+      hasAttachments: false,
+    });
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: blockedMsgId,
+      body: 'Draft reply to blocked sender',
+      draft: true,
+    });
+
+    // Draft bypasses allowlist — succeeds
+    expect(result.success).toBe(true);
+    expect(result.draftId).toBeDefined();
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
   it('Scenario: Reply draft when provider lacks createReplyDraft', async () => {
     (provider as Record<string, unknown>).createReplyDraft = undefined;
 

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -3,7 +3,12 @@ import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { isPlausibleMessageId } from '../security/reply-validation.js';
-import { ProviderError, withRetry } from '../providers/provider.js';
+import { withRetry } from '../providers/provider.js';
+import {
+  checkMailboxRequired,
+  checkRateLimit,
+  handleProviderError,
+} from './compose-helpers.js';
 
 const ReplyToEmailInput = z.object({
   message_id: z.string(),
@@ -29,21 +34,15 @@ export const replyToEmailAction: EmailAction<
   z.infer<typeof ReplyToEmailOutput>
 > = {
   name: 'reply_to_email',
-  description: 'Reply to an email within an existing thread. Gated by send allowlist. Supports draft mode.',
+  description: 'Reply to an email within an existing thread. Send path gated by send allowlist; draft path bypasses.',
   input: ReplyToEmailInput,
   output: ReplyToEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
   run: async (ctx, input) => {
     // Check mailbox requirement for multi-mailbox
-    if (!input.mailbox && ctx.allMailboxes && ctx.allMailboxes.length > 1) {
-      return {
-        success: false,
-        error: {
-          code: 'MAILBOX_REQUIRED',
-          message: 'mailbox parameter required when multiple mailboxes are configured',
-          recoverable: false,
-        },
-      };
+    const mailboxError = checkMailboxRequired(input.mailbox, ctx.allMailboxes);
+    if (mailboxError) {
+      return { success: false, error: mailboxError };
     }
 
     // Validate message ID plausibility
@@ -58,26 +57,7 @@ export const replyToEmailAction: EmailAction<
       };
     }
 
-    // Get the original message to check the recipient against allowlist
-    const originalMessage = await ctx.provider.getMessage(input.message_id);
-    const replyRecipient = originalMessage.from.email;
-
-    // Check send allowlist — reply recipients must also be allowed
-    const allowlistError = checkSendAllowlist([replyRecipient], ctx.sendAllowlist);
-    if (allowlistError) {
-      return {
-        success: false,
-        error: {
-          code: 'ALLOWLIST_BLOCKED',
-          message: allowlistError.includes('not configured')
-            ? allowlistError
-            : `Recipient not in send allowlist`,
-          recoverable: false,
-        },
-      };
-    }
-
-    // Draft branch — create reply draft instead of sending
+    // Draft branch — create reply draft, bypass allowlist
     if (input.draft) {
       if (!ctx.provider.createReplyDraft) {
         return {
@@ -103,36 +83,33 @@ export const replyToEmailAction: EmailAction<
           } : undefined,
         };
       } catch (err) {
-        if (err instanceof ProviderError) {
-          return {
-            success: false,
-            error: { code: err.code, message: err.message, recoverable: err.recoverable },
-          };
-        }
-        return {
-          success: false,
-          error: {
-            code: 'DRAFT_FAILED',
-            message: err instanceof Error ? err.message : String(err),
-            recoverable: false,
-          },
-        };
+        return handleProviderError(err, 'DRAFT_FAILED');
       }
     }
 
+    // Send path — get the original message to check the recipient against allowlist
+    const originalMessage = await ctx.provider.getMessage(input.message_id);
+    const replyRecipient = originalMessage.from.email;
+
+    // Check send allowlist — reply recipients must also be allowed
+    const allowlistError = checkSendAllowlist([replyRecipient], ctx.sendAllowlist);
+    if (allowlistError) {
+      return {
+        success: false,
+        error: {
+          code: 'ALLOWLIST_BLOCKED',
+          message: allowlistError.includes('not configured')
+            ? allowlistError
+            : `Recipient not in send allowlist`,
+          recoverable: false,
+        },
+      };
+    }
+
     // Check rate limit
-    if (ctx.rateLimiter) {
-      const rateCheck = ctx.rateLimiter.checkLimit('reply_to_email');
-      if (!rateCheck.allowed) {
-        return {
-          success: false,
-          error: {
-            code: 'RATE_LIMITED',
-            message: `Send rate limit exceeded. Retry after ${rateCheck.retryAfter}s`,
-            recoverable: true,
-          },
-        };
-      }
+    const rateLimitError = checkRateLimit(ctx.rateLimiter, 'reply_to_email');
+    if (rateLimitError) {
+      return rateLimitError;
     }
 
     try {
@@ -157,20 +134,7 @@ export const replyToEmailAction: EmailAction<
         } : undefined,
       };
     } catch (err) {
-      if (err instanceof ProviderError) {
-        return {
-          success: false,
-          error: { code: err.code, message: err.message, recoverable: err.recoverable },
-        };
-      }
-      return {
-        success: false,
-        error: {
-          code: 'REPLY_FAILED',
-          message: err instanceof Error ? err.message : String(err),
-          recoverable: false,
-        },
-      };
+      return handleProviderError(err, 'REPLY_FAILED');
     }
   },
 };

--- a/packages/email-core/src/actions/send.test.ts
+++ b/packages/email-core/src/actions/send.test.ts
@@ -260,6 +260,20 @@ describe('email-write/Draft Workflow', () => {
     const sendResult = await provider.sendDraft(draftResult.draftId!);
     expect(sendResult.success).toBe(true);
   });
+
+  it('Scenario: send_email with draft: true to blocked recipient succeeds (drafts bypass allowlist)', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: 'hacker@evil.com',
+      subject: 'Draft to blocked',
+      body: 'Body',
+      draft: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.draftId).toBeDefined();
+    expect(provider.getSentMessages()).toHaveLength(0);
+    expect(provider.getDrafts().size).toBe(1);
+  });
 });
 
 describe('email-write/Delivery Failure Handling', () => {

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -3,8 +3,15 @@ import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { checkReplyThreading } from '../security/reply-validation.js';
-import { ProviderError, withRetry } from '../providers/provider.js';
-import { resolveBodyFile, truncateBody, BODY_SIZE_LIMIT } from '../content/body-loader.js';
+import { withRetry } from '../providers/provider.js';
+import { truncateBody, BODY_SIZE_LIMIT } from '../content/body-loader.js';
+import {
+  checkMailboxRequired,
+  resolveComposeFields,
+  validateRequiredFields,
+  checkRateLimit,
+  handleProviderError,
+} from './compose-helpers.js';
 
 const SendEmailInput = z.object({
   to: z.string().or(z.array(z.string())).optional(),
@@ -32,101 +39,39 @@ export const sendEmailAction: EmailAction<
   z.infer<typeof SendEmailOutput>
 > = {
   name: 'send_email',
-  description: 'Compose and send a new email. Gated by send allowlist.',
+  description: 'Compose and send a new email. Gated by send allowlist. Draft mode bypasses allowlist.',
   input: SendEmailInput,
   output: SendEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
   run: async (ctx, input) => {
     // Check mailbox requirement for multi-mailbox
-    if (!input.mailbox && ctx.allMailboxes && ctx.allMailboxes.length > 1) {
-      return {
-        success: false,
-        error: {
-          code: 'MAILBOX_REQUIRED',
-          message: 'mailbox parameter required when multiple mailboxes are configured',
-          recoverable: false,
-        },
-      };
+    const mailboxError = checkMailboxRequired(input.mailbox, ctx.allMailboxes);
+    if (mailboxError) {
+      return { success: false, error: mailboxError };
     }
 
     // Resolve body content and frontmatter
-    let body: string;
-    let to = input.to;
-    let cc = input.cc;
-    let subject = input.subject;
-    let draft = input.draft;
-
-    if (input.body_file) {
-      const bodyResult = await resolveBodyFile(input.body_file, ctx.safeDir);
-      if (bodyResult.error) {
-        return { success: false, error: bodyResult.error };
-      }
-      body = bodyResult.content!;
-
-      // Frontmatter is authoritative — overrides action params for fields it declares
-      if (bodyResult.frontmatter) {
-        const fm = bodyResult.frontmatter;
-        if (fm.to !== undefined) to = fm.to;
-        if (fm.cc !== undefined) {
-          cc = Array.isArray(fm.cc) ? fm.cc : [fm.cc];
-        }
-        if (fm.subject !== undefined) subject = fm.subject;
-        if (fm.draft !== undefined) draft = fm.draft;
-      }
-    } else if (input.body) {
-      body = input.body;
-    } else {
-      return {
-        success: false,
-        error: { code: 'MISSING_BODY', message: 'Either body or body_file is required', recoverable: false },
-      };
+    const fields = await resolveComposeFields(input, ctx.safeDir);
+    if (fields.error) {
+      return { success: false, error: fields.error };
     }
+
+    const { to, cc, subject, draft } = fields;
+    let { body } = fields;
 
     // Validate required fields after merge
-    if (!to) {
-      return {
-        success: false,
-        error: { code: 'MISSING_FIELD', message: 'to is required — provide it as a parameter or in body_file frontmatter', recoverable: false },
-      };
-    }
-    if (!subject) {
-      return {
-        success: false,
-        error: { code: 'MISSING_FIELD', message: 'subject is required — provide it as a parameter or in body_file frontmatter', recoverable: false },
-      };
+    const requiredError = validateRequiredFields(to, subject);
+    if (requiredError) {
+      return { success: false, error: requiredError };
     }
 
     // Resolve recipients
-    const recipients = Array.isArray(to) ? to : [to];
-
-    // Check send allowlist
-    const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
-    if (allowlistError) {
-      return {
-        success: false,
-        error: { code: 'ALLOWLIST_BLOCKED', message: allowlistError, recoverable: false },
-      };
-    }
+    const recipients = Array.isArray(to) ? to : [to!];
 
     // Re: threading guardrail
-    const threadingError = checkReplyThreading(subject);
+    const threadingError = checkReplyThreading(subject!);
     if (threadingError) {
       return { success: false, error: threadingError };
-    }
-
-    // Check rate limit
-    if (ctx.rateLimiter) {
-      const rateCheck = ctx.rateLimiter.checkLimit('send_email');
-      if (!rateCheck.allowed) {
-        return {
-          success: false,
-          error: {
-            code: 'RATE_LIMITED',
-            message: `Send rate limit exceeded. Retry after ${rateCheck.retryAfter}s`,
-            recoverable: true,
-          },
-        };
-      }
     }
 
     // Graceful body truncation
@@ -134,12 +79,12 @@ export const sendEmailAction: EmailAction<
       body = truncateBody(body);
     }
 
-    // Draft workflow
+    // Draft workflow — skip allowlist check and rate limit
     if (draft) {
       const draftResult = await ctx.provider.createDraft({
         to: recipients.map(email => ({ email })),
         cc: cc?.map(email => ({ email })),
-        subject,
+        subject: subject!,
         body,
       });
       return {
@@ -153,13 +98,28 @@ export const sendEmailAction: EmailAction<
       };
     }
 
+    // Send path — check allowlist
+    const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
+    if (allowlistError) {
+      return {
+        success: false,
+        error: { code: 'ALLOWLIST_BLOCKED', message: allowlistError, recoverable: false },
+      };
+    }
+
+    // Check rate limit
+    const rateLimitError = checkRateLimit(ctx.rateLimiter, 'send_email');
+    if (rateLimitError) {
+      return rateLimitError;
+    }
+
     // Send with retry on transient errors
     try {
       const result = await withRetry(
         () => ctx.provider.sendMessage({
           to: recipients.map(email => ({ email })),
           cc: cc?.map(email => ({ email })),
-          subject,
+          subject: subject!,
           body,
         }),
         { maxRetries: 3, baseDelay: 1000 },
@@ -179,24 +139,7 @@ export const sendEmailAction: EmailAction<
         } : undefined,
       };
     } catch (err) {
-      if (err instanceof ProviderError) {
-        return {
-          success: false,
-          error: {
-            code: err.code,
-            message: err.message,
-            recoverable: err.recoverable,
-          },
-        };
-      }
-      return {
-        success: false,
-        error: {
-          code: 'SEND_FAILED',
-          message: err instanceof Error ? err.message : String(err),
-          recoverable: false,
-        },
-      };
+      return handleProviderError(err, 'SEND_FAILED');
     }
   },
 };

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -99,10 +99,27 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
   async getMessage(id: string): Promise<EmailMessage> {
     this.maybeThrow();
     const msg = this.messages.find(m => m.id === id);
-    if (!msg) {
-      throw new Error(`Message not found: ${id}`);
+    if (msg) {
+      return { ...msg };
     }
-    return { ...msg };
+
+    // Fall back to drafts — allows send_draft to look up draft recipients
+    const draft = this.drafts.get(id);
+    if (draft) {
+      return {
+        id,
+        subject: draft.subject,
+        from: { email: 'me@company.com' },
+        to: draft.to,
+        cc: draft.cc,
+        receivedAt: new Date().toISOString(),
+        isRead: true,
+        hasAttachments: false,
+        body: draft.body,
+      };
+    }
+
+    throw new Error(`Message not found: ${id}`);
   }
 
   async searchMessages(query: string, _folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]> {


### PR DESCRIPTION
## Summary
- Extract shared helpers (`checkMailboxRequired`, `resolveComposeFields`, `validateRequiredFields`, `checkRateLimit`, `handleProviderError`) into `compose-helpers.ts`, reducing ~200 lines of duplication across `draft.ts`, `send.ts`, `reply.ts`
- Draft creation (`create_draft`, `update_draft`, `reply_to_email` with draft:true, `send_email` with draft:true) no longer gated by send allowlist — drafts stay in the mailbox until the user manually sends from Outlook
- `send_draft` now enforces the send allowlist by fetching draft recipients via `getMessage` before sending (fail-closed: blocks if lookup fails or returns no recipients)
- `reply_to_email` draft path branches before `getMessage` call, avoiding unnecessary provider lookup

## Test plan
- [x] 159 tests pass in email-core (22 test files)
- [x] Clean TypeScript build across all workspace packages
- [x] 6 new regression tests: draft creation bypasses allowlist (4 paths), send_draft blocks disallowed recipients, send_draft fails closed on lookup failure
- [x] 2 existing tests updated to match new allowlist behavior
- [ ] Manual verification: restart MCP server, create draft to blocked recipient, confirm it succeeds