### PR TITLE
fix: remove ensureBodySize export (breaks build)

### DIFF
--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -43,4 +43,11 @@ export { moveToFolderAction } from './actions/move.js';
 export { parseFrontmatter } from './content/frontmatter.js';
 export type { FrontmatterFields } from './content/frontmatter.js';
 export { resolveBodyFile, truncateBody, BODY_SIZE_LIMIT } from './content/body-loader.js';
+export {
+  checkMailboxRequired,
+  resolveComposeFields,
+  validateRequiredFields,
+  checkRateLimit,
+  handleProviderError,
+} from './actions/compose-helpers.js';
 export { isPlausibleMessageId, checkReplyThreading } from './security/reply-validation.js';


### PR DESCRIPTION
## Summary
- Remove `ensureBodySize` from `index.ts` exports — it was never implemented in `compose-helpers.ts` (intentionally skipped per refactor plan)
- This broken export causes `tsc` to fail, which makes the MCP server fall back to demo mode

## Test plan
- [x] `npm run build` passes
- [x] All 159 tests still pass