### PR TITLE
fix(email-mcp): defer provider auth so MCP handshake never blocks

### DIFF
--- a/packages/email-mcp/src/mcp-serve.ts
+++ b/packages/email-mcp/src/mcp-serve.ts
@@ -1,130 +1,13 @@
 #!/usr/bin/env node
-// Real MCP server using @modelcontextprotocol/sdk — stdio transport
-// This is the entry point for `npx email-agent-mcp serve`
+// Standalone MCP server entry point — delegates to runServer() in server.ts.
+// The real CLI dispatch (email-agent-mcp serve) goes through cli.ts → runServer,
+// which connects the MCP transport instantly and defers OAuth to the first
+// tool call. This file exists as a direct-invocation entry for tooling that
+// prefers to spawn the server script directly.
 
-import { createRequire } from 'node:module';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { z } from 'zod';
-import { actionsToMcpTools, handleToolCall, type EmailActionDef } from './server.js';
+import { runServer } from './server.js';
 
-const require = createRequire(import.meta.url);
-const { version: PACKAGE_VERSION } = require('../package.json') as { version: string };
-
-// Demo actions for E2E testing — no real email provider needed
-const demoActions: EmailActionDef[] = [
-  {
-    name: 'list_emails',
-    description: 'List recent emails with filtering by unread status, folder, sender, and limit',
-    input: z.object({
-      mailbox: z.string().optional(),
-      unread: z.boolean().optional(),
-      limit: z.number().optional(),
-      folder: z.string().optional(),
-    }),
-    output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
-    annotations: { readOnlyHint: true, destructiveHint: false },
-    run: async (_ctx, input) => {
-      const inp = input as { unread?: boolean; limit?: number; folder?: string };
-      return {
-        emails: [
-          { id: 'demo-1', subject: 'Welcome to email-agent-mcp', from: 'system@email-agent-mcp.dev', receivedAt: new Date().toISOString(), isRead: false, hasAttachments: false },
-          { id: 'demo-2', subject: 'MCP Integration Test', from: 'test@example.com', receivedAt: new Date().toISOString(), isRead: true, hasAttachments: true },
-          { id: 'demo-3', subject: 'Contract Review — Q1 2024', from: 'alice@corp.com', receivedAt: new Date().toISOString(), isRead: false, hasAttachments: true },
-        ].filter(e => inp.unread ? !e.isRead : true).slice(0, inp.limit ?? 25),
-      };
-    },
-  },
-  {
-    name: 'read_email',
-    description: 'Read the full content of an email by ID, transformed to token-efficient markdown',
-    input: z.object({ id: z.string(), mailbox: z.string().optional() }),
-    output: z.object({ id: z.string(), subject: z.string(), from: z.string(), to: z.array(z.string()), body: z.string(), receivedAt: z.string() }),
-    annotations: { readOnlyHint: true, destructiveHint: false },
-    run: async (_ctx, input) => {
-      const inp = input as { id: string };
-      const emails: Record<string, { subject: string; from: string; body: string }> = {
-        'demo-1': { subject: 'Welcome to email-agent-mcp', from: 'system@email-agent-mcp.dev', body: '# Welcome to email-agent-mcp!\n\nThis is a demo email from the MCP E2E test.\n\nThe email-agent-mcp MCP server is working correctly with stdio transport.\n\n## Features\n- Multi-mailbox support\n- Send allowlist security\n- Content engine (HTML → markdown)' },
-        'demo-2': { subject: 'MCP Integration Test', from: 'test@example.com', body: 'This is a test email to verify MCP tool call dispatch works correctly.\n\nAttachments: report.pdf (245KB)' },
-        'demo-3': { subject: 'Contract Review — Q1 2024', from: 'alice@corp.com', body: 'Hi,\n\nPlease review the attached contract for the Q1 partnership.\n\nAttachments: contract.docx (1.2MB), appendix.pdf (340KB)' },
-      };
-      const email = emails[inp.id] ?? { subject: 'Unknown', from: 'unknown@example.com', body: 'Email not found' };
-      return {
-        id: inp.id,
-        subject: email.subject,
-        from: email.from,
-        to: ['user@example.com'],
-        body: email.body,
-        receivedAt: new Date().toISOString(),
-      };
-    },
-  },
-  {
-    name: 'search_emails',
-    description: 'Search emails using full-text query across one or all mailboxes',
-    input: z.object({ query: z.string(), mailbox: z.string().optional(), limit: z.number().optional() }),
-    output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
-    annotations: { readOnlyHint: true, destructiveHint: false },
-    run: async (_ctx, input) => {
-      const inp = input as { query: string };
-      return {
-        emails: [
-          { id: 'search-1', subject: `Result for: ${inp.query}`, from: 'search@example.com', receivedAt: new Date().toISOString(), isRead: false, hasAttachments: false },
-        ],
-      };
-    },
-  },
-  {
-    name: 'get_mailbox_status',
-    description: 'Get mailbox connection status, unread count, and warnings',
-    input: z.object({ mailbox: z.string().optional() }),
-    output: z.object({ name: z.string(), provider: z.string(), status: z.string(), isDefault: z.boolean(), warnings: z.array(z.string()) }),
-    annotations: { readOnlyHint: true, destructiveHint: false },
-    run: async () => ({
-      name: 'demo',
-      provider: 'demo',
-      status: 'connected',
-      isDefault: true,
-      warnings: ['This is a demo mailbox — no real email provider configured'],
-    }),
-  },
-];
-
-async function main(): Promise<void> {
-  const server = new Server(
-    { name: 'email-agent-mcp', version: PACKAGE_VERSION },
-    { capabilities: { tools: {} } },
-  );
-
-  const tools = actionsToMcpTools(demoActions);
-
-  // Register tools/list handler
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
-
-  // Register tools/call handler
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  server.setRequestHandler(CallToolRequestSchema, (async (request: any) => {
-    const { name, arguments: args } = request.params;
-    try {
-      return await handleToolCall(demoActions, {}, name, (args ?? {}) as Record<string, unknown>);
-    } catch (err) {
-      return {
-        content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-        isError: true,
-      };
-    }
-  }) as never);
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error('[email-agent-mcp] MCP server started on stdio (4 demo tools)');
-}
-
-main().catch(err => {
-  console.error('[email-agent-mcp] Fatal error:', err);
+runServer().catch(err => {
+  console.error('[email-agent-mcp] Fatal:', err);
   process.exit(1);
 });

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1,6 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
-import { actionsToMcpTools, handleToolCall, getServerManifest, type EmailActionDef } from './server.js';
+import {
+  actionsToMcpTools,
+  handleToolCall,
+  getServerManifest,
+  createLazyProviderState,
+  waitForInit,
+  ensureProvider,
+  buildLazyActions,
+  type EmailActionDef,
+  type LazyProviderState,
+} from './server.js';
 
 // Create test actions that mimic the email-core action pattern
 const testActions: EmailActionDef[] = [
@@ -81,5 +91,170 @@ describe('mcp-transport/Server Discovery', () => {
     const transport = manifest.transport as { type: string; command: string; args: string[] };
     expect(transport.type).toBe('stdio');
     expect(transport.command).toBe('npx');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lazy provider state — tests for the instant-connect + deferred-auth refactor.
+// These exercise the seam that lets the MCP handshake complete without waiting
+// on OAuth token refresh.
+// ---------------------------------------------------------------------------
+
+describe('mcp-transport/Lazy Provider State', () => {
+  const noAllowlist = () => undefined;
+
+  it('Scenario: buildLazyActions registers all tool schemas without auth', async () => {
+    const state = createLazyProviderState();
+    // No init has been triggered — state is still 'pending'.
+    const actions = await buildLazyActions(state, noAllowlist);
+
+    // 4 custom tools + 11 email-core actions = 15 tools, no auth performed.
+    expect(actions.length).toBe(15);
+    expect(state.status).toBe('pending');
+    expect(state.initPromise).toBeNull();
+    expect(state.provider).toBeNull();
+
+    const tools = actionsToMcpTools(actions);
+    expect(tools.map(t => t.name)).toContain('list_emails');
+    expect(tools.map(t => t.name)).toContain('get_mailbox_status');
+    expect(tools.map(t => t.name)).toContain('send_email');
+  });
+
+  it('Scenario: get_mailbox_status is non-blocking during pending/connecting', async () => {
+    const state = createLazyProviderState();
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+
+    // 'pending' — init has not been triggered yet. get_mailbox_status must
+    // return immediately without awaiting ensureProvider.
+    const pendingResult = await status.run({}, {}) as { status: string; warnings: string[] };
+    expect(pendingResult.status).toBe('connecting');
+    expect(state.status).toBe('pending'); // Still pending — didn't trigger init.
+    expect(pendingResult.warnings[0]).toMatch(/warming up|Authenticating/i);
+  });
+
+  it('Scenario: concurrent ensureProvider calls share a single initPromise', async () => {
+    const state = createLazyProviderState();
+
+    // Inject a slow fake init by monkey-patching initPromise before ensureProvider runs.
+    let resolveInit!: () => void;
+    let initRuns = 0;
+    state.initPromise = new Promise<void>(resolve => {
+      resolveInit = () => {
+        initRuns++;
+        state.provider = {} as never; // pretend we connected
+        state.status = 'connected';
+        resolve();
+      };
+    });
+    state.status = 'connecting';
+
+    const callA = ensureProvider(state);
+    const callB = ensureProvider(state);
+    const callC = ensureProvider(state);
+
+    // None have resolved yet — init is still pending.
+    expect(initRuns).toBe(0);
+    resolveInit();
+    await Promise.all([callA, callB, callC]);
+
+    // Exactly one init ran, and all three callers succeeded.
+    expect(initRuns).toBe(1);
+    expect(state.status).toBe('connected');
+  });
+
+  it('Scenario: ensureProvider throws after a failed init (fail-closed, session-sticky)', async () => {
+    const state = createLazyProviderState();
+    state.status = 'error';
+    state.isDemo = true;
+    state.error = 'All configured mailboxes failed to authenticate';
+    // initPromise was already awaited and resolved (init ran and stored the error).
+    state.initPromise = Promise.resolve();
+
+    await expect(ensureProvider(state)).rejects.toThrow(/All configured mailboxes/);
+
+    // A second call must not retry — session stickiness.
+    await expect(ensureProvider(state)).rejects.toThrow(/All configured mailboxes/);
+  });
+
+  it('Scenario: email-core wrapped action returns structured error on init failure', async () => {
+    const state = createLazyProviderState();
+    // Simulate: init has run, all mailboxes failed.
+    state.status = 'error';
+    state.isDemo = true;
+    state.error = 'All configured mailboxes failed to authenticate';
+    state.initPromise = Promise.resolve();
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const sendEmail = actions.find(a => a.name === 'send_email')!;
+
+    // Must NOT throw — must return the structured error shape.
+    const result = await sendEmail.run({}, {
+      to: ['x@example.com'],
+      subject: 'test',
+      body: 'test',
+    }) as { success: boolean; error?: { code: string; message: string; recoverable: boolean } };
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('PROVIDER_UNAVAILABLE');
+    expect(result.error?.message).toMatch(/All configured mailboxes/);
+    expect(result.error?.recoverable).toBe(false);
+  });
+
+  it('Scenario: custom tools fall back to demo responses in demo mode', async () => {
+    const state = createLazyProviderState();
+    // Simulate: no mailboxes were configured.
+    state.status = 'not_configured';
+    state.isDemo = true;
+    state.initPromise = Promise.resolve();
+
+    const actions = await buildLazyActions(state, noAllowlist);
+
+    const listEmails = actions.find(a => a.name === 'list_emails')!;
+    const listResult = await listEmails.run({}, {}) as { emails: Array<{ id: string; subject: string }> };
+    expect(listResult.emails).toHaveLength(1);
+    expect(listResult.emails[0]!.subject).toMatch(/Demo mode/);
+
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const readResult = await readEmail.run({}, { id: 'demo-1' }) as { subject: string; body: string };
+    expect(readResult.subject).toMatch(/Demo mode/);
+    expect(readResult.body).toMatch(/No mailbox configured/);
+
+    const searchEmails = actions.find(a => a.name === 'search_emails')!;
+    const searchResult = await searchEmails.run({}, { query: 'anything' }) as { emails: unknown[] };
+    expect(searchResult.emails).toEqual([]);
+
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const statusResult = await status.run({}, {}) as { status: string; warnings: string[] };
+    expect(statusResult.status).toBe('not configured');
+    expect(statusResult.warnings[0]).toMatch(/No mailbox configured/);
+  });
+
+  it('Scenario: get_mailbox_status reports error state when init failed', async () => {
+    const state = createLazyProviderState();
+    state.status = 'error';
+    state.isDemo = true;
+    state.error = 'Could not load provider: missing credentials';
+    state.initPromise = Promise.resolve();
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, {}) as { status: string; warnings: string[] };
+
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toMatch(/missing credentials/);
+  });
+
+  it('Scenario: waitForInit returns immediately once a terminal state is reached', async () => {
+    const state = createLazyProviderState();
+    state.status = 'not_configured';
+    state.isDemo = true;
+    state.initPromise = Promise.resolve();
+
+    // Should be a no-op — no new initPromise is created.
+    const spy = vi.spyOn(state, 'initPromise' as never, 'get');
+    await waitForInit(state);
+    spy.mockRestore();
+    expect(state.status).toBe('not_configured');
   });
 });

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -3,6 +3,40 @@ import { createRequire } from 'node:module';
 import type { EmailAction, EmailProvider } from '@usejunior/email-core';
 import { z } from 'zod';
 
+/**
+ * Lazy provider state — tracks deferred init so the MCP handshake can complete
+ * instantly while OAuth token refresh runs in the background.
+ */
+export interface LazyProviderAuth {
+  getTokenHealthWarning: () => string | undefined;
+  tryReconnect: () => Promise<boolean>;
+}
+
+export interface LazyProviderState {
+  provider: EmailProvider | null;
+  auth: LazyProviderAuth | null;
+  initPromise: Promise<void> | null;
+  error: string | null;
+  /** True when no mailboxes are configured OR all auth attempts failed. */
+  isDemo: boolean;
+  status: 'pending' | 'connecting' | 'connected' | 'not_configured' | 'error';
+  /** Human-readable display name of the connected mailbox, if any. */
+  connectedMailbox: string | null;
+}
+
+/** Create a fresh lazy state. */
+export function createLazyProviderState(): LazyProviderState {
+  return {
+    provider: null,
+    auth: null,
+    initPromise: null,
+    error: null,
+    isDemo: false,
+    status: 'pending',
+    connectedMailbox: null,
+  };
+}
+
 const require = createRequire(import.meta.url);
 const { version: PACKAGE_VERSION } = require('../package.json') as { version: string };
 
@@ -140,105 +174,117 @@ function generateJsonSchema(schema: z.ZodType): Record<string, unknown> {
 }
 
 /**
- * Run the MCP server on stdio.
- * Checks for saved auth tokens and connects to real Graph API if available.
- * Falls back to demo mode if no tokens found.
+ * Wait for provider initialization to complete. Triggers init if not started yet.
+ * NEVER throws — callers inspect `state` to decide how to respond.
+ *
+ * Used by custom tools (list_emails/read_email/search_emails) that need to
+ * distinguish demo mode from a connected provider at call time.
  */
-export async function runServer(): Promise<void> {
-  const { Server } = await import('@modelcontextprotocol/sdk/server/index.js');
-  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
-  const { ListToolsRequestSchema, CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
-
-  // Load send allowlist with hot-reload (convention: ~/.email-agent-mcp/send-allowlist.json)
-  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist } = await import('@usejunior/email-core');
-  const sendAllowlistPath = getSendAllowlistPath();
-  const sendAllowlistWatcher = new WatchedAllowlist(sendAllowlistPath, loadSendAllowlist);
-  await sendAllowlistWatcher.start();
-  const getSendAllowlist = () => sendAllowlistWatcher.config;
-  if (sendAllowlistWatcher.config && sendAllowlistWatcher.config.entries.length > 0) {
-    console.error(`[email-agent-mcp] Send allowlist loaded (watched): ${sendAllowlistWatcher.config.entries.length} entries from ${sendAllowlistPath}`);
-  } else {
-    console.error(`[email-agent-mcp] WARNING: Send allowlist empty or not found at ${sendAllowlistPath} — all outbound email is disabled`);
+export async function waitForInit(state: LazyProviderState): Promise<void> {
+  if (
+    state.status === 'connected' ||
+    state.status === 'not_configured' ||
+    state.status === 'error'
+  ) {
+    return;
   }
-
-  // Try to load real provider from saved tokens — try each mailbox, skip failures
-  let actions: EmailActionDef[] = await buildDemoActions();
-  let actionCtx: unknown = {};
-
+  if (!state.initPromise) {
+    state.status = 'connecting';
+    state.initPromise = initProvider(state);
+  }
   try {
-    const { listConfiguredMailboxesWithMetadata, DelegatedAuthManager } = await import('@usejunior/provider-microsoft');
-    const { RealGraphApiClient, GraphEmailProvider } = await import('@usejunior/provider-microsoft');
-    const allMailboxes = await listConfiguredMailboxesWithMetadata();
-
-    if (allMailboxes.length > 0) {
-      let connected = false;
-
-      for (const metadata of allMailboxes) {
-        const displayName = metadata.emailAddress ?? metadata.mailboxName;
-        try {
-          const auth = new DelegatedAuthManager(
-            { mode: 'delegated', clientId: metadata.clientId, tenantId: metadata.tenantId },
-            metadata.mailboxName,
-          );
-          await auth.reconnect();
-          const client = new RealGraphApiClient(() => auth.getAccessToken(), () => auth.tryReconnect());
-          const provider = new GraphEmailProvider(client);
-
-          // Build real actions from the provider
-          actions = await buildRealActions(provider, auth, getSendAllowlist);
-          console.error(`[email-agent-mcp] Connected to mailbox "${displayName}" (${metadata.clientId})`);
-          connected = true;
-          break;
-        } catch (err) {
-          console.error(`[email-agent-mcp] Skipping mailbox "${displayName}": ${err instanceof Error ? err.message : err}`);
-          continue;
-        }
-      }
-
-      if (!connected) {
-        actions = await buildDemoActions();
-        console.error('[email-agent-mcp] WARNING: All configured mailboxes failed to authenticate — running in demo mode. Run: email-agent-mcp configure');
-      }
-    } else {
-      actions = await buildDemoActions();
-      console.error('[email-agent-mcp] No configured mailboxes — running in demo mode');
-      console.error('[email-agent-mcp] Run: email-agent-mcp configure --mailbox <name> --provider microsoft');
-    }
-  } catch (err) {
-    actions = await buildDemoActions();
-    console.error(`[email-agent-mcp] Could not connect to real provider: ${err instanceof Error ? err.message : err}`);
-    console.error('[email-agent-mcp] Running in demo mode');
+    await state.initPromise;
+  } catch {
+    // initProvider never throws, but belt-and-suspenders for future changes.
   }
-
-  const server = new Server(
-    { name: 'email-agent-mcp', version: PACKAGE_VERSION },
-    { capabilities: { tools: {} } },
-  );
-
-  const tools = actionsToMcpTools(actions);
-
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  server.setRequestHandler(CallToolRequestSchema, (async (request: any) => {
-    const { name, arguments: args } = request.params;
-    try {
-      return await handleToolCall(actions, actionCtx, name, (args ?? {}) as Record<string, unknown>);
-    } catch (err) {
-      return {
-        content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-        isError: true,
-      };
-    }
-  }) as never);
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error(`[email-agent-mcp] MCP server started on stdio (${tools.length} tools)`);
 }
 
-// Import z lazily for action definitions
-async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthWarning: () => string | undefined; tryReconnect: () => Promise<boolean> }, getSendAllowlist: () => { entries: string[] } | undefined): Promise<EmailActionDef[]> {
-  const { z } = await import('zod');
+/**
+ * Assert that a real provider is available. Throws if init failed or no
+ * mailbox is configured. Used by email-core action wrappers so that tool
+ * calls return a structured error in demo mode.
+ */
+export async function ensureProvider(state: LazyProviderState): Promise<void> {
+  await waitForInit(state);
+  if (!state.provider) {
+    throw new Error(
+      state.error ??
+        'No mailbox configured — run: email-agent-mcp configure --mailbox <name> --provider microsoft',
+    );
+  }
+}
+
+/**
+ * Background-safe provider initialization. Iterates configured mailboxes,
+ * records success or failure on `state`. **Never throws** — fire-and-forget
+ * callers rely on this invariant.
+ */
+export async function initProvider(state: LazyProviderState): Promise<void> {
+  try {
+    const { listConfiguredMailboxesWithMetadata, DelegatedAuthManager, RealGraphApiClient, GraphEmailProvider } =
+      await import('@usejunior/provider-microsoft');
+    const allMailboxes = await listConfiguredMailboxesWithMetadata();
+
+    if (allMailboxes.length === 0) {
+      state.isDemo = true;
+      state.status = 'not_configured';
+      console.error('[email-agent-mcp] No configured mailboxes — running in demo mode');
+      console.error('[email-agent-mcp] Run: email-agent-mcp configure --mailbox <name> --provider microsoft');
+      return;
+    }
+
+    for (const metadata of allMailboxes) {
+      const displayName = metadata.emailAddress ?? metadata.mailboxName;
+      try {
+        const auth = new DelegatedAuthManager(
+          { mode: 'delegated', clientId: metadata.clientId, tenantId: metadata.tenantId },
+          metadata.mailboxName,
+        );
+        await auth.reconnect();
+        const client = new RealGraphApiClient(() => auth.getAccessToken(), () => auth.tryReconnect());
+        const provider = new GraphEmailProvider(client);
+
+        state.provider = provider;
+        state.auth = {
+          getTokenHealthWarning: () => auth.getTokenHealthWarning(),
+          tryReconnect: () => auth.tryReconnect(),
+        };
+        state.connectedMailbox = displayName;
+        state.status = 'connected';
+        console.error(`[email-agent-mcp] Connected to mailbox "${displayName}" (${metadata.clientId})`);
+        return;
+      } catch (err) {
+        console.error(
+          `[email-agent-mcp] Skipping mailbox "${displayName}": ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
+    // All configured mailboxes failed to authenticate.
+    state.isDemo = true;
+    state.status = 'error';
+    state.error = 'All configured mailboxes failed to authenticate';
+    console.error(
+      '[email-agent-mcp] WARNING: All configured mailboxes failed to authenticate — running in demo mode. Run: email-agent-mcp configure',
+    );
+  } catch (err) {
+    state.isDemo = true;
+    state.status = 'error';
+    state.error = `Could not load provider: ${err instanceof Error ? err.message : String(err)}`;
+    console.error(`[email-agent-mcp] Could not connect to real provider: ${state.error}`);
+    console.error('[email-agent-mcp] Running in demo mode');
+  }
+}
+
+/**
+ * Build the tool registry without performing any auth. Schemas for all tools
+ * are registered immediately so `tools/list` can return instantly. Tool `run`
+ * callbacks lazily await `ensureProvider`/`waitForInit` on first invocation.
+ */
+export async function buildLazyActions(
+  state: LazyProviderState,
+  getSendAllowlist: () => { entries: string[] } | undefined,
+): Promise<EmailActionDef[]> {
   const {
     sendEmailAction,
     replyToEmailAction,
@@ -253,18 +299,59 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
     deleteEmailAction,
   } = await import('@usejunior/email-core');
 
-  // Build ActionContext for send/reply actions — getter ensures hot-reloaded allowlist
+  // Shared context for email-core actions — provider is resolved at call time.
   const actionCtx = {
-    provider: provider as never,
+    get provider() { return state.provider as never; },
     get sendAllowlist() { return getSendAllowlist(); },
   };
+
+  // Structured "provider unavailable" error — matches the shape of email-core errors.
+  const providerUnavailableError = (err: unknown) => ({
+    success: false,
+    error: {
+      code: 'PROVIDER_UNAVAILABLE',
+      message: err instanceof Error ? err.message : String(err),
+      recoverable: false,
+    },
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const wrapAction = (action: EmailAction<any, any>): EmailActionDef => ({
     name: action.name,
     description: action.description,
     input: action.input,
     output: action.output,
     annotations: action.annotations,
-    run: async (_ctx, input) => action.run(actionCtx as never, input as never),
+    run: async (_ctx, input) => {
+      try {
+        await ensureProvider(state);
+      } catch (err) {
+        return providerUnavailableError(err);
+      }
+      return action.run(actionCtx as never, input as never);
+    },
+  });
+
+  // Demo fallback responses for the 4 custom tools (preserved from buildDemoActions).
+  const demoListEmails = () => ({
+    emails: [
+      {
+        id: 'demo-1',
+        subject: 'Demo mode — run email-agent-mcp configure to connect',
+        from: 'system@email-agent-mcp.dev',
+        receivedAt: new Date().toISOString(),
+        isRead: false,
+        hasAttachments: false,
+      },
+    ],
+  });
+  const demoReadEmail = (id: string) => ({
+    id,
+    subject: 'Demo mode',
+    from: 'system@email-agent-mcp.dev',
+    to: ['user@example.com'],
+    body: 'No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft',
+    receivedAt: new Date().toISOString(),
   });
 
   return [
@@ -275,8 +362,10 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
       output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
+        await waitForInit(state);
+        if (!state.provider) return demoListEmails();
         const inp = input as { unread?: boolean; limit?: number; offset?: number; folder?: string };
-        const messages = await provider.listMessages({ unread: inp.unread, limit: inp.limit ?? 25, offset: inp.offset, folder: inp.folder ?? 'inbox' });
+        const messages = await state.provider.listMessages({ unread: inp.unread, limit: inp.limit ?? 25, offset: inp.offset, folder: inp.folder ?? 'inbox' });
         return {
           emails: (messages as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>).map(m => ({
             id: m.id,
@@ -296,17 +385,18 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
       output: z.object({ id: z.string(), subject: z.string(), from: z.string(), to: z.array(z.string()), body: z.string(), receivedAt: z.string() }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
+        await waitForInit(state);
         const inp = input as { id: string };
-        const msg = await provider.getMessage(inp.id) as { id: string; subject: string; from: { email: string; name?: string }; to: Array<{ email: string; name?: string }>; receivedAt: string; body?: string; bodyHtml?: string };
+        if (!state.provider) return demoReadEmail(inp.id);
+        const msg = await state.provider.getMessage(inp.id) as { id: string; subject: string; from: { email: string; name?: string }; to: Array<{ email: string; name?: string }>; receivedAt: string; body?: string; bodyHtml?: string };
 
-        // Transform HTML to markdown, or use plaintext body
         let emailBody = '';
         if (msg.bodyHtml) {
           try {
             const { htmlToMarkdown } = await import('@usejunior/email-core');
             emailBody = htmlToMarkdown(msg.bodyHtml);
           } catch {
-            emailBody = msg.bodyHtml; // fallback to raw HTML
+            emailBody = msg.bodyHtml;
           }
         } else if (msg.body) {
           emailBody = msg.body;
@@ -329,8 +419,10 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
       output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
+        await waitForInit(state);
+        if (!state.provider) return { emails: [] };
         const inp = input as { query: string; limit?: number; offset?: number };
-        const results = await provider.searchMessages(inp.query, undefined, inp.limit, inp.offset) as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>;
+        const results = await state.provider.searchMessages(inp.query, undefined, inp.limit, inp.offset) as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>;
         return {
           emails: results.map(m => ({
             id: m.id,
@@ -349,57 +441,35 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
       input: z.object({ mailbox: z.string().optional() }),
       output: z.object({ name: z.string(), provider: z.string(), status: z.string(), isDefault: z.boolean(), warnings: z.array(z.string()) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
+      // NON-BLOCKING — reports state directly without awaiting ensureProvider.
+      // This is how callers check whether the server is still warming up.
       run: async () => {
         const warnings: string[] = [];
-        const healthWarning = auth.getTokenHealthWarning();
-        if (healthWarning) warnings.push(healthWarning);
-        const currentAllowlist = getSendAllowlist();
-        if (!currentAllowlist || currentAllowlist.entries.length === 0) {
-          warnings.push('Send allowlist not configured — all outbound email is disabled. Run: email-agent-mcp configure');
+        switch (state.status) {
+          case 'pending':
+          case 'connecting':
+            return { name: 'pending', provider: 'pending', status: 'connecting', isDefault: false, warnings: ['Authenticating — provider is warming up'] };
+          case 'not_configured':
+            return { name: 'none', provider: 'none', status: 'not configured', isDefault: false, warnings: ['No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft'] };
+          case 'error':
+            return { name: 'none', provider: 'none', status: 'error', isDefault: false, warnings: [state.error ?? 'Provider init failed'] };
+          case 'connected': {
+            const healthWarning = state.auth?.getTokenHealthWarning();
+            if (healthWarning) warnings.push(healthWarning);
+            const currentAllowlist = getSendAllowlist();
+            if (!currentAllowlist || currentAllowlist.entries.length === 0) {
+              warnings.push('Send allowlist not configured — all outbound email is disabled. Run: email-agent-mcp configure');
+            }
+            return { name: state.connectedMailbox ?? 'default', provider: 'microsoft', status: 'connected', isDefault: true, warnings };
+          }
         }
-        return { name: 'default', provider: 'microsoft', status: 'connected', isDefault: true, warnings };
       },
     },
-    {
-      name: sendEmailAction.name,
-      description: sendEmailAction.description,
-      input: sendEmailAction.input,
-      output: sendEmailAction.output,
-      annotations: sendEmailAction.annotations,
-      run: async (_ctx, input) => sendEmailAction.run(actionCtx as never, input as never),
-    },
-    {
-      name: replyToEmailAction.name,
-      description: replyToEmailAction.description,
-      input: replyToEmailAction.input,
-      output: replyToEmailAction.output,
-      annotations: replyToEmailAction.annotations,
-      run: async (_ctx, input) => replyToEmailAction.run(actionCtx as never, input as never),
-    },
-    {
-      name: createDraftAction.name,
-      description: createDraftAction.description,
-      input: createDraftAction.input,
-      output: createDraftAction.output,
-      annotations: createDraftAction.annotations,
-      run: async (_ctx, input) => createDraftAction.run(actionCtx as never, input as never),
-    },
-    {
-      name: sendDraftAction.name,
-      description: sendDraftAction.description,
-      input: sendDraftAction.input,
-      output: sendDraftAction.output,
-      annotations: sendDraftAction.annotations,
-      run: async (_ctx, input) => sendDraftAction.run(actionCtx as never, input as never),
-    },
-    {
-      name: updateDraftAction.name,
-      description: updateDraftAction.description,
-      input: updateDraftAction.input,
-      output: updateDraftAction.output,
-      annotations: updateDraftAction.annotations,
-      run: async (_ctx, input) => updateDraftAction.run(actionCtx as never, input as never),
-    },
+    wrapAction(sendEmailAction),
+    wrapAction(replyToEmailAction),
+    wrapAction(createDraftAction),
+    wrapAction(sendDraftAction),
+    wrapAction(updateDraftAction),
     wrapAction(getThreadAction),
     wrapAction(labelEmailAction),
     wrapAction(flagEmailAction),
@@ -409,91 +479,62 @@ async function buildRealActions(provider: EmailProvider, auth: { getTokenHealthW
   ];
 }
 
-async function buildDemoActions(): Promise<EmailActionDef[]> {
-  const { z } = await import('zod');
-  const {
-    sendEmailAction,
-    replyToEmailAction,
-    createDraftAction,
-    sendDraftAction,
-    updateDraftAction,
-    getThreadAction,
-    labelEmailAction,
-    flagEmailAction,
-    markReadAction,
-    moveToFolderAction,
-    deleteEmailAction,
-  } = await import('@usejunior/email-core');
-  const demoError = {
-    success: false,
-    error: {
-      code: 'DEMO_MODE',
-      message: 'Demo mode — run email-agent-mcp configure to connect a mailbox',
-      recoverable: false,
-    },
-  };
-  const demoFailureAction = (action: EmailAction<any, any>): EmailActionDef => ({
-    name: action.name,
-    description: action.description,
-    input: action.input,
-    output: action.output,
-    annotations: action.annotations,
-    run: async () => demoError,
-  });
+/**
+ * Run the MCP server on stdio. Connects the transport immediately, then kicks
+ * off provider init in the background so the MCP handshake never waits on OAuth.
+ */
+export async function runServer(): Promise<void> {
+  const { Server } = await import('@modelcontextprotocol/sdk/server/index.js');
+  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
+  const { ListToolsRequestSchema, CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
 
-  return [
-    {
-      name: 'list_emails', description: 'List recent emails', input: z.object({ unread: z.boolean().optional(), limit: z.number().optional(), folder: z.string().optional() }), output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
-      annotations: { readOnlyHint: true, destructiveHint: false },
-      run: async () => ({ emails: [{ id: 'demo-1', subject: 'Demo mode — run email-agent-mcp configure to connect', from: 'system@email-agent-mcp.dev', receivedAt: new Date().toISOString(), isRead: false, hasAttachments: false }] }),
-    },
-    {
-      name: 'read_email', description: 'Read email by ID', input: z.object({ id: z.string() }), output: z.object({ id: z.string(), subject: z.string(), from: z.string(), to: z.array(z.string()), body: z.string(), receivedAt: z.string() }),
-      annotations: { readOnlyHint: true, destructiveHint: false },
-      run: async (_ctx, input) => ({ id: (input as {id:string}).id, subject: 'Demo mode', from: 'system@email-agent-mcp.dev', to: ['user@example.com'], body: 'No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft', receivedAt: new Date().toISOString() }),
-    },
-    {
-      name: 'search_emails', description: 'Search emails', input: z.object({ query: z.string() }), output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
-      annotations: { readOnlyHint: true, destructiveHint: false },
-      run: async () => ({ emails: [] }),
-    },
-    {
-      name: 'get_mailbox_status', description: 'Get mailbox status', input: z.object({ mailbox: z.string().optional() }), output: z.object({ name: z.string(), provider: z.string(), status: z.string(), isDefault: z.boolean(), warnings: z.array(z.string()) }),
-      annotations: { readOnlyHint: true, destructiveHint: false },
-      run: async () => ({ name: 'none', provider: 'none', status: 'not configured', isDefault: false, warnings: ['No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft'] }),
-    },
-    {
-      name: getThreadAction.name,
-      description: getThreadAction.description,
-      input: getThreadAction.input,
-      output: getThreadAction.output,
-      annotations: getThreadAction.annotations,
-      run: async () => ({
-        id: 'demo-thread-1',
-        subject: 'Demo mode',
-        messages: [{
-          id: 'demo-1',
-          subject: 'Demo mode',
-          from: 'system@email-agent-mcp.dev',
-          receivedAt: new Date().toISOString(),
-          body: 'No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft',
-          isRead: false,
-        }],
-        messageCount: 1,
-        isTruncated: false,
-      }),
-    },
-    demoFailureAction(sendEmailAction),
-    demoFailureAction(replyToEmailAction),
-    demoFailureAction(createDraftAction),
-    demoFailureAction(sendDraftAction),
-    demoFailureAction(updateDraftAction),
-    demoFailureAction(labelEmailAction),
-    demoFailureAction(flagEmailAction),
-    demoFailureAction(markReadAction),
-    demoFailureAction(moveToFolderAction),
-    demoFailureAction(deleteEmailAction),
-  ];
+  // Load send allowlist with hot-reload (convention: ~/.email-agent-mcp/send-allowlist.json)
+  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist } = await import('@usejunior/email-core');
+  const sendAllowlistPath = getSendAllowlistPath();
+  const sendAllowlistWatcher = new WatchedAllowlist(sendAllowlistPath, loadSendAllowlist);
+  await sendAllowlistWatcher.start();
+  const getSendAllowlist = () => sendAllowlistWatcher.config;
+  if (sendAllowlistWatcher.config && sendAllowlistWatcher.config.entries.length > 0) {
+    console.error(`[email-agent-mcp] Send allowlist loaded (watched): ${sendAllowlistWatcher.config.entries.length} entries from ${sendAllowlistPath}`);
+  } else {
+    console.error(`[email-agent-mcp] WARNING: Send allowlist empty or not found at ${sendAllowlistPath} — all outbound email is disabled`);
+  }
+
+  // Build tool registry with lazy provider state (no auth yet).
+  const state = createLazyProviderState();
+  const actions = await buildLazyActions(state, getSendAllowlist);
+
+  const server = new Server(
+    { name: 'email-agent-mcp', version: PACKAGE_VERSION },
+    { capabilities: { tools: {} } },
+  );
+
+  const tools = actionsToMcpTools(actions);
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.setRequestHandler(CallToolRequestSchema, (async (request: any) => {
+    const { name, arguments: args } = request.params;
+    try {
+      return await handleToolCall(actions, {}, name, (args ?? {}) as Record<string, unknown>);
+    } catch (err) {
+      return {
+        content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }) as never);
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`[email-agent-mcp] MCP server started on stdio (${tools.length} tools) — provider init deferred`);
+
+  // Fire-and-forget: warm up the provider in the background so most first tool
+  // calls hit a ready provider. initProvider is safe to call without awaiting
+  // because it never throws; .catch() is belt-and-suspenders.
+  void waitForInit(state).catch(() => {
+    /* initProvider records errors in state.error */
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

`runServer()` used to do OAuth token refresh (2-5s) **before** connecting the MCP transport, causing Claude Code to time out waiting for the handshake. The server now connects instantly and warms the provider in the background.

- Register all 15 tool schemas up-front — no auth needed to list tools
- Connect stdio transport immediately, then fire-and-forget `waitForInit(state)`
- First tool call that needs a provider awaits a single-flight init; subsequent calls hit the warm cache
- `get_mailbox_status` is **non-blocking** — reports `connecting` / `connected` / `not_configured` / `error` from state directly so callers can poll warm-up progress

## What changes

- New `LazyProviderState` + `createLazyProviderState`, `waitForInit`, `ensureProvider`, `initProvider` in `server.ts`
- `buildLazyActions(state, getSendAllowlist)` replaces `buildRealActions` + `buildDemoActions`. 4 custom tools fall back to demo responses when `state.isDemo`; 11 email-core wrappers return structured `{ code: 'PROVIDER_UNAVAILABLE' }` errors on init failure
- `initProvider` **never throws** — always records success/failure in `state`, so the fire-and-forget warm-up is safe
- `mcp-serve.ts` simplified from a 130-line demo stub to a 13-line delegate to `runServer()` now that `runServer()` is the instant-connect path

## What does NOT change

Same 15 tool names, same input/output schemas, same allowlist enforcement, same demo fallback behavior when unconfigured. Only the timing of auth changes: startup → first tool call.

## Test plan

- [x] `npx vitest run packages/email-mcp/` — 93 tests pass (8 new lazy-seam scenarios added)
- [x] `npm run test:run` across all workspaces — 368 tests pass
- [x] `npm run build` — clean
- [x] `node scripts/e2e-mcp-test.mjs` — full E2E passes against a real mailbox: handshake completes instantly, first `list_emails` triggers auth and returns 25 real unread emails, `get_mailbox_status` reports `connected`
- [x] Manual: `node packages/email-agent-mcp/bin/email-agent-mcp.js serve < /dev/null` logs `MCP server started on stdio (15 tools) — provider init deferred` before EOF kills it — confirms handshake no longer waits on OAuth

## New tests added (`server.test.ts`)

1. `buildLazyActions` returns 15 tool schemas without running any auth
2. `get_mailbox_status` is non-blocking during `pending` (does not trigger init)
3. Concurrent `ensureProvider` calls share a single `initPromise` (single-flight)
4. `ensureProvider` after failed init throws the stored error (fail-closed, session-sticky)
5. Email-core wrapped action returns structured `PROVIDER_UNAVAILABLE` error (not a throw) after init failure
6. Custom tools fall back to demo responses in `not_configured` mode
7. `get_mailbox_status` reports `error` state with stored error message
8. `waitForInit` is a no-op once a terminal state is reached