### PR TITLE
fix(email-mcp): coerce string scalars to declared Zod types at MCP boundary

### DIFF
--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -8,6 +8,7 @@ import {
   waitForInit,
   ensureProvider,
   buildLazyActions,
+  coerceArgsForZod,
   type EmailActionDef,
   type LazyProviderState,
 } from './server.js';
@@ -256,5 +257,145 @@ describe('mcp-transport/Lazy Provider State', () => {
     await waitForInit(state);
     spy.mockRestore();
     expect(state.status).toBe('not_configured');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scalar Coercion at MCP Boundary
+//
+// Claude Code's XML parameter encoder serializes boolean/number tool args as
+// strings on the wire (`"true"`, `"3"`). The email-core Zod schemas are
+// strict and reject strings. coerceArgsForZod walks the top-level shape and
+// converts matching fields so wire-format reality stops breaking tool calls,
+// without polluting the reusable email-core schemas.
+// ---------------------------------------------------------------------------
+
+describe('mcp-transport/Scalar Coercion at Boundary', () => {
+  it('Scenario: boolean "true"/"false" → true/false; other strings pass through', () => {
+    const schema = z.object({ flag: z.boolean().optional() });
+    expect(coerceArgsForZod(schema, { flag: 'true' })).toEqual({ flag: true });
+    expect(coerceArgsForZod(schema, { flag: 'false' })).toEqual({ flag: false });
+    // Unknown strings are left alone — Zod will produce its normal error.
+    expect(coerceArgsForZod(schema, { flag: 'yes' })).toEqual({ flag: 'yes' });
+    // Already-typed values are untouched.
+    expect(coerceArgsForZod(schema, { flag: true })).toEqual({ flag: true });
+    expect(coerceArgsForZod(schema, { flag: false })).toEqual({ flag: false });
+  });
+
+  it('Scenario: numeric strings → numbers; invalid strings pass through', () => {
+    const schema = z.object({ limit: z.number().optional() });
+    expect(coerceArgsForZod(schema, { limit: '3' })).toEqual({ limit: 3 });
+    expect(coerceArgsForZod(schema, { limit: '3.14' })).toEqual({ limit: 3.14 });
+    expect(coerceArgsForZod(schema, { limit: '0' })).toEqual({ limit: 0 });
+    // Non-numeric strings left alone — Zod will reject with its normal error.
+    expect(coerceArgsForZod(schema, { limit: 'abc' })).toEqual({ limit: 'abc' });
+    expect(coerceArgsForZod(schema, { limit: '' })).toEqual({ limit: '' });
+    // Already-typed numbers are untouched.
+    expect(coerceArgsForZod(schema, { limit: 42 })).toEqual({ limit: 42 });
+  });
+
+  it('Scenario: wrapped types (optional/default/nullable) still get coerced', () => {
+    const schema = z.object({
+      a: z.boolean().optional(),
+      b: z.boolean().optional().default(true),
+      c: z.number().nullable(),
+      d: z.number().default(25),
+    });
+    expect(coerceArgsForZod(schema, { a: 'false', b: 'true', c: '7', d: '100' })).toEqual({
+      a: false,
+      b: true,
+      c: 7,
+      d: 100,
+    });
+  });
+
+  it('Scenario: non-object args are returned unchanged (defensive)', () => {
+    const schema = z.object({ flag: z.boolean() });
+    expect(coerceArgsForZod(schema, null)).toBe(null);
+    expect(coerceArgsForZod(schema, undefined)).toBe(undefined);
+    expect(coerceArgsForZod(schema, 'string')).toBe('string');
+    expect(coerceArgsForZod(schema, 42)).toBe(42);
+    expect(coerceArgsForZod(schema, ['a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('Scenario: nested object/array fields are NOT recursed into', () => {
+    // Intentional: only top-level scalars. If a future action nests a boolean
+    // inside an object, extend coerceArgsForZod then.
+    const schema = z.object({
+      filter: z.object({ unread: z.boolean() }),
+      tags: z.array(z.string()),
+    });
+    const out = coerceArgsForZod(schema, {
+      filter: { unread: 'true' },
+      tags: ['a'],
+    }) as { filter: { unread: unknown } };
+    expect(out.filter.unread).toBe('true'); // untouched
+  });
+
+  it('Scenario: unknown fields (not declared in the schema) are untouched', () => {
+    const schema = z.object({ flag: z.boolean().optional() });
+    expect(coerceArgsForZod(schema, { flag: 'true', extra: 'hello' })).toEqual({
+      flag: true,
+      extra: 'hello',
+    });
+  });
+
+  it('Scenario: handleToolCall coerces stringified scalars end-to-end', async () => {
+    const echoActions: EmailActionDef[] = [
+      {
+        name: 'echo',
+        description: 'Echo its coerced input',
+        input: z.object({ flag: z.boolean(), n: z.number() }),
+        output: z.object({ flag: z.boolean(), n: z.number() }),
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        run: async (_ctx, input) => input,
+      },
+    ];
+    const result = await handleToolCall(echoActions, {}, 'echo', { flag: 'true', n: '42' });
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ flag: true, n: 42 });
+  });
+
+  it('Scenario: SAFETY — user_explicitly_requested_deletion: "false" stays false', async () => {
+    // This is the reason we can't use z.coerce.boolean() — it turns 'false' into true
+    // because JS Boolean('false') === true. For delete_email, flipping false → true
+    // would silently enable destructive operations. Lock this behaviour in forever.
+    const deleteSchema = z.object({
+      id: z.string(),
+      user_explicitly_requested_deletion: z.boolean(),
+      hard_delete: z.boolean().optional().default(false),
+    });
+
+    const coerced = coerceArgsForZod(deleteSchema, {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: 'false',
+      hard_delete: 'false',
+    }) as { user_explicitly_requested_deletion: boolean; hard_delete: boolean };
+
+    expect(coerced.user_explicitly_requested_deletion).toBe(false);
+    expect(coerced.hard_delete).toBe(false);
+
+    // And end-to-end through handleToolCall: the run fn must receive false.
+    const seen: Array<{ user_explicitly_requested_deletion: boolean; hard_delete: boolean }> = [];
+    const deleteActions: EmailActionDef[] = [
+      {
+        name: 'delete_email',
+        description: 'delete',
+        input: deleteSchema,
+        output: z.object({ success: z.boolean() }),
+        annotations: { readOnlyHint: false, destructiveHint: true },
+        run: async (_ctx, input) => {
+          seen.push(input as never);
+          return { success: false };
+        },
+      },
+    ];
+    await handleToolCall(deleteActions, {}, 'delete_email', {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: 'false',
+      hard_delete: 'false',
+    });
+    expect(seen[0]!.user_explicitly_requested_deletion).toBe(false);
+    expect(seen[0]!.hard_delete).toBe(false);
   });
 });

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -77,6 +77,81 @@ export function actionsToMcpTools(actions: EmailActionDef[]): McpTool[] {
 }
 
 /**
+ * Unwrap Optional/Default/Nullable/Effects wrappers to reach the inner type.
+ * We only need to peek at the type discriminator, not fully resolve it.
+ */
+function unwrapZodType(schema: z.ZodType): z.ZodType {
+  let cur: z.ZodType = schema;
+  for (let i = 0; i < 10; i++) {
+    const def = (cur as unknown as { _def: { type?: string; typeName?: string; innerType?: z.ZodType } })._def;
+    const id = def.type ?? def.typeName ?? '';
+    if (
+      (id === 'optional' || id === 'ZodOptional' ||
+       id === 'default'  || id === 'ZodDefault'  ||
+       id === 'nullable' || id === 'ZodNullable' ||
+       id === 'effects'  || id === 'ZodEffects')
+      && def.innerType
+    ) {
+      cur = def.innerType;
+      continue;
+    }
+    return cur;
+  }
+  return cur;
+}
+
+function zodTypeId(schema: z.ZodType): string {
+  const def = (schema as unknown as { _def: { type?: string; typeName?: string } })._def;
+  return def.type ?? def.typeName ?? '';
+}
+
+/**
+ * Coerce string-typed scalar args to their Zod-declared types.
+ *
+ * Claude Code's XML parameter encoder sends scalars as strings when calling
+ * MCP tools (e.g. `<parameter name="limit">3</parameter>` arrives as `"3"`).
+ * This walks the top-level shape of an object schema and converts any
+ * string-valued arg whose declared type is number or boolean.
+ *
+ * Booleans use explicit `'true'`/`'false'` matching rather than
+ * `z.coerce.boolean` — the latter is unsafe because it uses JS `Boolean(v)`
+ * semantics where any non-empty string is truthy, so `'false'` would become
+ * `true` and silently corrupt delete/send intent.
+ *
+ * Only top-level properties are coerced. Nested objects/arrays are left
+ * untouched; the Zod parser handles them or rejects them as-is.
+ */
+export function coerceArgsForZod(schema: z.ZodType, args: unknown): unknown {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return args;
+  const shapeRoot = unwrapZodType(schema);
+  const rootId = zodTypeId(shapeRoot);
+  if (rootId !== 'object' && rootId !== 'ZodObject') return args;
+
+  const def = (shapeRoot as unknown as { _def: { shape?: Record<string, z.ZodType> | (() => Record<string, z.ZodType>) } })._def;
+  const shape = typeof def.shape === 'function' ? def.shape() : (def.shape ?? {});
+  const out: Record<string, unknown> = { ...(args as Record<string, unknown>) };
+
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    const v = out[key];
+    if (typeof v !== 'string') continue;
+    const inner = unwrapZodType(fieldSchema as z.ZodType);
+    const id = zodTypeId(inner);
+    if (id === 'boolean' || id === 'ZodBoolean') {
+      if (v === 'true') out[key] = true;
+      else if (v === 'false') out[key] = false;
+      // else leave as string — Zod will produce its normal error
+    } else if (id === 'number' || id === 'ZodNumber') {
+      if (v.trim() !== '') {
+        const n = Number(v);
+        if (Number.isFinite(n)) out[key] = n;
+        // else leave as string — Zod will reject
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Handle an MCP tool call by dispatching to the right action.
  */
 export async function handleToolCall(
@@ -90,7 +165,8 @@ export async function handleToolCall(
     throw new Error(`Unknown tool: ${toolName}`);
   }
 
-  const input = action.input.parse(args);
+  const coerced = coerceArgsForZod(action.input, args);
+  const input = action.input.parse(coerced);
   const result = await action.run(ctx, input);
 
   return {


### PR DESCRIPTION
## Summary

- Claude Code's XML parameter encoder sends scalar MCP tool args as strings on the wire (`"true"`, `"3"`). The strict `z.boolean()`/`z.number()` schemas in `email-core` reject them, so every MCP tool call with a scalar arg fails from inside a Claude Code session with `invalid_type: expected boolean, received string`.
- Fix at the adapter boundary: a new `coerceArgsForZod(schema, args)` helper in `packages/email-mcp/src/server.ts` walks the top-level shape of the action input schema and coerces `"true"`/`"false"` → booleans and numeric strings → numbers. Wired into `handleToolCall` before `action.input.parse(args)`. `email-core` is untouched — the workaround lives in the transport layer where the wire format lives.
- Booleans use explicit `'true'`/`'false'` matching, **not** `z.coerce.boolean`, because `Boolean('false') === true` under JS semantics would silently flip destructive flags like `user_explicitly_requested_deletion`.

## Reproduction

```js
// before this fix, via an MCP client:
await client.callTool({ name: 'list_emails', arguments: { unread: true,   limit: 3   } }); // OK
await client.callTool({ name: 'list_emails', arguments: { unread: 'true', limit: '3' } }); // FAIL
// error: "Invalid input: expected boolean, received string"
```

After: both calls succeed. Verified end-to-end through a real `StdioClientTransport` against the built server.

## Tests

Added `describe('mcp-transport/Scalar Coercion at Boundary', ...)` with 8 cases:

1. Boolean `"true"`/`"false"` → `true`/`false`; other strings pass through.
2. Numeric strings (`"3"`, `"3.14"`, `"0"`) → numbers; `"abc"` and `""` pass through; already-typed values untouched.
3. Wrapped types (`optional`, `default`, `nullable`) still get coerced through the inner type.
4. Non-object args returned unchanged (defensive).
5. Nested objects/arrays are NOT recursed into (intentional, top-level only).
6. Unknown fields (not declared in the schema) are left alone.
7. End-to-end through `handleToolCall` with an echo action.
8. **SAFETY regression**: `delete_email`-shaped schema with `user_explicitly_requested_deletion: 'false'` must stay `false` (locks in why we rejected `z.coerce.boolean`).

All pre-existing 93 tests still pass (376 total across the workspace). Lint clean. `scripts/e2e-mcp-test.mjs` still green.

## Verification

- [x] `npm run build` — clean across all four workspaces
- [x] `npx vitest run packages/email-mcp/` — 101/101 (was 93, +8)
- [x] `npx vitest run` — 376/376
- [x] `npm run lint` — clean
- [x] `node scripts/e2e-mcp-test.mjs` — passes
- [x] Manual MCP client probe: `{unread: true, limit: 3}` and `{unread: 'true', limit: '3'}` both succeed
- [x] Manual safety probe: `delete_email` with `user_explicitly_requested_deletion: 'false'` returns `DELETE_DISABLED`, not a silent execution

## Follow-up (not addressed here)

- **`send_email.to` JSON Schema emission**: the manual `generateJsonSchema` fallback in `server.ts` doesn't handle `z.union([z.string(), z.array(z.string())])` and emits `{}`. Worth a separate PR — either add a `ZodUnion → oneOf` case or confirm whether Zod v4's `z.toJsonSchema` primary path is actually hitting in this workspace's Zod version.

## Test plan

- [x] Unit tests for coercion helper
- [x] End-to-end via `handleToolCall` + `StdioClientTransport`
- [x] Safety regression test for destructive boolean flags