### PR TITLE
refactor(email-mcp): harden scalar coercer per peer review

### DIFF
--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
+import { deleteEmailAction } from '@usejunior/email-core';
 import {
   actionsToMcpTools,
   handleToolCall,
@@ -282,16 +283,50 @@ describe('mcp-transport/Scalar Coercion at Boundary', () => {
     expect(coerceArgsForZod(schema, { flag: false })).toEqual({ flag: false });
   });
 
-  it('Scenario: numeric strings → numbers; invalid strings pass through', () => {
+  it('Scenario: strict decimal/float strings → numbers; exotic shapes pass through', () => {
     const schema = z.object({ limit: z.number().optional() });
+    // Accepted: plain decimals, floats, zero, negatives.
     expect(coerceArgsForZod(schema, { limit: '3' })).toEqual({ limit: 3 });
     expect(coerceArgsForZod(schema, { limit: '3.14' })).toEqual({ limit: 3.14 });
     expect(coerceArgsForZod(schema, { limit: '0' })).toEqual({ limit: 0 });
-    // Non-numeric strings left alone — Zod will reject with its normal error.
+    expect(coerceArgsForZod(schema, { limit: '-5' })).toEqual({ limit: -5 });
+    expect(coerceArgsForZod(schema, { limit: '-3.14' })).toEqual({ limit: -3.14 });
+    // Rejected (passed through as-is): Zod will throw its own invalid_type.
+    // `Number()` would silently accept all of these, which is the footgun we
+    // are closing off.
     expect(coerceArgsForZod(schema, { limit: 'abc' })).toEqual({ limit: 'abc' });
     expect(coerceArgsForZod(schema, { limit: '' })).toEqual({ limit: '' });
+    expect(coerceArgsForZod(schema, { limit: '  3  ' })).toEqual({ limit: '  3  ' }); // whitespace
+    expect(coerceArgsForZod(schema, { limit: '0x10' })).toEqual({ limit: '0x10' });   // hex
+    expect(coerceArgsForZod(schema, { limit: '1e3' })).toEqual({ limit: '1e3' });     // scientific
+    expect(coerceArgsForZod(schema, { limit: 'Infinity' })).toEqual({ limit: 'Infinity' });
+    expect(coerceArgsForZod(schema, { limit: 'NaN' })).toEqual({ limit: 'NaN' });
+    expect(coerceArgsForZod(schema, { limit: '3.' })).toEqual({ limit: '3.' });       // trailing dot
+    expect(coerceArgsForZod(schema, { limit: '.5' })).toEqual({ limit: '.5' });       // leading dot
     // Already-typed numbers are untouched.
     expect(coerceArgsForZod(schema, { limit: 42 })).toEqual({ limit: 42 });
+  });
+
+  it('Scenario: .refine() wrappers preserve the inner type discriminator', () => {
+    // Zod v4 does not have ZodEffects — a refined number still reports
+    // type: 'number' so coercion works through .refine() without any extra
+    // unwrapping logic. Lock that in.
+    const schema = z.object({
+      n: z.number().refine(v => v > 0, 'must be positive'),
+      flag: z.boolean().refine(v => v === true, 'must be true'),
+    });
+    expect(coerceArgsForZod(schema, { n: '5', flag: 'true' })).toEqual({ n: 5, flag: true });
+  });
+
+  it('Scenario: .pipe()/.transform() fields are NOT descended into', () => {
+    // pipe/transform can change the accepted input type, so coercing through
+    // them would be ambiguous. Intentional non-goal — document by test.
+    const schema = z.object({
+      n: z.string().pipe(z.coerce.number()),
+    });
+    // 'n' is declared as `pipe`, not `number`, so we leave it alone and let
+    // the downstream parser handle it.
+    expect(coerceArgsForZod(schema, { n: '5' })).toEqual({ n: '5' });
   });
 
   it('Scenario: wrapped types (optional/default/nullable) still get coerced', () => {
@@ -356,46 +391,77 @@ describe('mcp-transport/Scalar Coercion at Boundary', () => {
     expect(parsed).toEqual({ flag: true, n: 42 });
   });
 
-  it('Scenario: SAFETY — user_explicitly_requested_deletion: "false" stays false', async () => {
-    // This is the reason we can't use z.coerce.boolean() — it turns 'false' into true
-    // because JS Boolean('false') === true. For delete_email, flipping false → true
-    // would silently enable destructive operations. Lock this behaviour in forever.
-    const deleteSchema = z.object({
-      id: z.string(),
-      user_explicitly_requested_deletion: z.boolean(),
-      hard_delete: z.boolean().optional().default(false),
-    });
+  it('Scenario: SAFETY — real deleteEmailAction rejects stringified "false"', async () => {
+    // The entire reason we do not use z.coerce.boolean() — it would turn
+    // 'false' into true because JS Boolean('false') === true, silently
+    // enabling destructive operations. This test wires the REAL
+    // deleteEmailAction from email-core through handleToolCall so a future
+    // refactor that bypasses coerceArgsForZod can't silently break the
+    // safety guarantee.
 
-    const coerced = coerceArgsForZod(deleteSchema, {
-      id: 'msg-1',
-      user_explicitly_requested_deletion: 'false',
-      hard_delete: 'false',
-    }) as { user_explicitly_requested_deletion: boolean; hard_delete: boolean };
+    const deleteMessage = vi.fn();
+    const fakeCtx = {
+      provider: { deleteMessage },
+      deleteEnabled: true, // bypass "deletion disabled" so we reach the auth check
+    };
 
-    expect(coerced.user_explicitly_requested_deletion).toBe(false);
-    expect(coerced.hard_delete).toBe(false);
-
-    // And end-to-end through handleToolCall: the run fn must receive false.
-    const seen: Array<{ user_explicitly_requested_deletion: boolean; hard_delete: boolean }> = [];
-    const deleteActions: EmailActionDef[] = [
+    // Wrap the real action as an EmailActionDef so handleToolCall can dispatch it.
+    const actions: EmailActionDef[] = [
       {
-        name: 'delete_email',
-        description: 'delete',
-        input: deleteSchema,
-        output: z.object({ success: z.boolean() }),
-        annotations: { readOnlyHint: false, destructiveHint: true },
-        run: async (_ctx, input) => {
-          seen.push(input as never);
-          return { success: false };
-        },
+        name: deleteEmailAction.name,
+        description: deleteEmailAction.description,
+        input: deleteEmailAction.input,
+        output: deleteEmailAction.output,
+        annotations: deleteEmailAction.annotations,
+        run: (_ctx, input) => deleteEmailAction.run(fakeCtx as never, input as never),
       },
     ];
-    await handleToolCall(deleteActions, {}, 'delete_email', {
+
+    const result = await handleToolCall(actions, {}, 'delete_email', {
       id: 'msg-1',
-      user_explicitly_requested_deletion: 'false',
+      user_explicitly_requested_deletion: 'false', // wire format — string
       hard_delete: 'false',
     });
-    expect(seen[0]!.user_explicitly_requested_deletion).toBe(false);
-    expect(seen[0]!.hard_delete).toBe(false);
+
+    // Provider must NOT have been called. If 'false' had been flipped to
+    // true, checkDeletePolicy would pass and deleteMessage would run.
+    expect(deleteMessage).not.toHaveBeenCalled();
+
+    // The action should return a policy error indicating the missing consent.
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.success).toBe(false);
+    expect(parsed.error.message).toMatch(/user_explicitly_requested_deletion must be true/);
+  });
+
+  it('Scenario: SAFETY — real deleteEmailAction executes when "true" is passed', async () => {
+    // Complement to the regression above: if the caller explicitly sends
+    // 'true' as a string, coercion must flip it to `true` so the legitimate
+    // delete path still works end-to-end.
+    const deleteMessage = vi.fn();
+    const fakeCtx = {
+      provider: { deleteMessage },
+      deleteEnabled: true,
+    };
+
+    const actions: EmailActionDef[] = [
+      {
+        name: deleteEmailAction.name,
+        description: deleteEmailAction.description,
+        input: deleteEmailAction.input,
+        output: deleteEmailAction.output,
+        annotations: deleteEmailAction.annotations,
+        run: (_ctx, input) => deleteEmailAction.run(fakeCtx as never, input as never),
+      },
+    ];
+
+    const result = await handleToolCall(actions, {}, 'delete_email', {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: 'true',
+      hard_delete: 'false',
+    });
+
+    expect(deleteMessage).toHaveBeenCalledWith('msg-1', false);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.success).toBe(true);
   });
 });

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -76,23 +76,42 @@ export function actionsToMcpTools(actions: EmailActionDef[]): McpTool[] {
   }));
 }
 
+// Strict decimal/float regex for coercing numeric strings. Rejects hex
+// (`0x10`), scientific notation (`1e3`), `Infinity`, whitespace, and other
+// shapes that `Number()` silently accepts but which are unlikely to be
+// intended when an LLM emits a tool-call arg.
+const NUMERIC_STRING = /^-?\d+(?:\.\d+)?$/;
+
 /**
- * Unwrap Optional/Default/Nullable/Effects wrappers to reach the inner type.
- * We only need to peek at the type discriminator, not fully resolve it.
+ * Read the Zod v4 public type discriminator for a schema.
+ *
+ * Uses `.type` / `.def.type`, which are part of the stable `zod@^4` surface
+ * (see `node_modules/zod/v4/classic/schemas.d.ts` — `_def` is explicitly
+ * `@deprecated Use .def instead.`). Falls back through both for safety.
+ */
+function zodTypeId(schema: z.ZodType): string {
+  const s = schema as unknown as { type?: string; def?: { type?: string } };
+  return s.type ?? s.def?.type ?? '';
+}
+
+/**
+ * Unwrap Optional/Default/Nullable wrappers to reach the inner scalar type.
+ *
+ * Zod v4 no longer has `ZodEffects`; `.refine()` preserves the underlying
+ * type discriminator (a refined number still reports `type: 'number'`), and
+ * `.transform()` / `.pipe()` produce a `pipe` wrapper that we deliberately
+ * do not descend into — transforms can change the accepted input type and
+ * coercing through them would be ambiguous. The cycle guard (max 10 hops)
+ * is belt-and-suspenders; real schemas nest at most 2-3 levels.
  */
 function unwrapZodType(schema: z.ZodType): z.ZodType {
   let cur: z.ZodType = schema;
   for (let i = 0; i < 10; i++) {
-    const def = (cur as unknown as { _def: { type?: string; typeName?: string; innerType?: z.ZodType } })._def;
-    const id = def.type ?? def.typeName ?? '';
-    if (
-      (id === 'optional' || id === 'ZodOptional' ||
-       id === 'default'  || id === 'ZodDefault'  ||
-       id === 'nullable' || id === 'ZodNullable' ||
-       id === 'effects'  || id === 'ZodEffects')
-      && def.innerType
-    ) {
-      cur = def.innerType;
+    const id = zodTypeId(cur);
+    if (id === 'optional' || id === 'default' || id === 'nullable') {
+      const inner = (cur as unknown as { def?: { innerType?: z.ZodType } }).def?.innerType;
+      if (!inner) return cur;
+      cur = inner;
       continue;
     }
     return cur;
@@ -100,52 +119,63 @@ function unwrapZodType(schema: z.ZodType): z.ZodType {
   return cur;
 }
 
-function zodTypeId(schema: z.ZodType): string {
-  const def = (schema as unknown as { _def: { type?: string; typeName?: string } })._def;
-  return def.type ?? def.typeName ?? '';
-}
-
 /**
- * Coerce string-typed scalar args to their Zod-declared types.
+ * Coerce string-typed scalar args to their Zod-declared types at the MCP
+ * adapter boundary.
  *
- * Claude Code's XML parameter encoder sends scalars as strings when calling
- * MCP tools (e.g. `<parameter name="limit">3</parameter>` arrives as `"3"`).
- * This walks the top-level shape of an object schema and converts any
- * string-valued arg whose declared type is number or boolean.
+ * **Why this exists.** Claude Code's XML parameter encoder serializes scalar
+ * MCP tool args as strings on the wire (`<parameter name="limit">3</parameter>`
+ * arrives as `"3"`, not `3`). The strict `z.boolean()` / `z.number()` schemas
+ * in `email-core` reject these with `invalid_type`, so every tool call with a
+ * scalar arg would fail from inside a Claude Code session. The MCP spec does
+ * not prescribe coercion — servers are expected to handle their own wire
+ * format. We fix it at the adapter boundary so the reusable `email-core`
+ * schemas stay strict for other consumers.
  *
- * Booleans use explicit `'true'`/`'false'` matching rather than
- * `z.coerce.boolean` — the latter is unsafe because it uses JS `Boolean(v)`
- * semantics where any non-empty string is truthy, so `'false'` would become
- * `true` and silently corrupt delete/send intent.
+ * **Scope.** Walks the top-level shape of an object schema only. Nested
+ * objects, arrays, unions, and discriminated unions are intentionally NOT
+ * recursed into:
+ * - no current action has a nested boolean/number field
+ * - union coercion is ambiguous (`"3"` could satisfy either branch of a
+ *   `string | number` union)
+ * - transforms/pipes can change the accepted input type
  *
- * Only top-level properties are coerced. Nested objects/arrays are left
- * untouched; the Zod parser handles them or rejects them as-is.
+ * If a future action introduces a nested scalar field, extend the walker
+ * then — don't speculatively add complexity.
+ *
+ * **Boolean safety.** Explicit `'true'`/`'false'` matching, NOT
+ * `z.coerce.boolean`. The latter uses JS `Boolean(v)` semantics where any
+ * non-empty string is truthy, so `z.coerce.boolean().parse('false') === true`
+ * — which would silently flip destructive flags like
+ * `delete_email.user_explicitly_requested_deletion`. This is enforced by the
+ * safety regression test in `server.test.ts`.
+ *
+ * **Number safety.** Uses a strict decimal/float regex (`NUMERIC_STRING`)
+ * instead of `Number(v) + isFinite`. The former rejects `"0x10"`, `"1e3"`,
+ * `"  3  "`, `"Infinity"`, and other shapes that `Number()` accepts but
+ * which are unlikely to be intended by an LLM emitting a tool arg.
  */
 export function coerceArgsForZod(schema: z.ZodType, args: unknown): unknown {
   if (!args || typeof args !== 'object' || Array.isArray(args)) return args;
   const shapeRoot = unwrapZodType(schema);
-  const rootId = zodTypeId(shapeRoot);
-  if (rootId !== 'object' && rootId !== 'ZodObject') return args;
+  if (zodTypeId(shapeRoot) !== 'object') return args;
 
-  const def = (shapeRoot as unknown as { _def: { shape?: Record<string, z.ZodType> | (() => Record<string, z.ZodType>) } })._def;
-  const shape = typeof def.shape === 'function' ? def.shape() : (def.shape ?? {});
+  // ZodObject exposes a public `.shape` accessor on the schema itself
+  // (plain object, not a function) in Zod v4.
+  const shape = (shapeRoot as unknown as { shape?: Record<string, z.ZodType> }).shape ?? {};
   const out: Record<string, unknown> = { ...(args as Record<string, unknown>) };
 
   for (const [key, fieldSchema] of Object.entries(shape)) {
     const v = out[key];
     if (typeof v !== 'string') continue;
-    const inner = unwrapZodType(fieldSchema as z.ZodType);
-    const id = zodTypeId(inner);
-    if (id === 'boolean' || id === 'ZodBoolean') {
+    const id = zodTypeId(unwrapZodType(fieldSchema));
+    if (id === 'boolean') {
       if (v === 'true') out[key] = true;
       else if (v === 'false') out[key] = false;
       // else leave as string — Zod will produce its normal error
-    } else if (id === 'number' || id === 'ZodNumber') {
-      if (v.trim() !== '') {
-        const n = Number(v);
-        if (Number.isFinite(n)) out[key] = n;
-        // else leave as string — Zod will reject
-      }
+    } else if (id === 'number') {
+      if (NUMERIC_STRING.test(v)) out[key] = Number(v);
+      // else leave as string — Zod will reject with its normal error
     }
   }
   return out;


### PR DESCRIPTION
## Summary

Follow-up to #19 applying convergent feedback from two peer reviews (Codex + Gemini). Two reviewers independently flagged the same five issues. This PR addresses all of them and locks the behaviour in with new tests. No behavioural regression for legitimate inputs.

## What changed

1. **Migrated off deprecated Zod internals.** `_def` is explicitly marked `@deprecated Use .def instead.` in `node_modules/zod/v4/classic/schemas.d.ts:6`. `unwrapZodType` and `zodTypeId` now read the public `.type` / `.def` / `.shape` accessors exclusively. Verified on the installed `zod@4.3.6` that all three are present on `ZodObject`, `ZodOptional`, `ZodDefault`, `ZodNullable`, `ZodBoolean`, `ZodNumber`.

2. **Dropped the `ZodEffects` unwrap branch.** Zod v4 removed `ZodEffects`. A quick probe confirmed the replacement behaviour:
   - `.refine()` preserves the underlying type discriminator (a refined `z.number()` still reports `type: 'number'`) — no unwrapping needed
   - `.transform()` / `.pipe()` produce a `pipe` wrapper whose declared input type can differ from the nominal field type, so we intentionally skip them
   Both are now locked in with explicit tests.

3. **Tightened numeric coercion.** Replaced `Number(v) + isFinite` with a strict `^-?\d+(?:\.\d+)?$` regex. The previous implementation silently accepted `"  3  "`, `"0x10"` (→ 16), `"1e3"` (→ 1000), `"Infinity"`, `"NaN"`, and other shapes that `Number()` accepts but an LLM emitting a tool-call arg is very unlikely to intend. Each rejected shape now has an explicit test asserting it passes through unchanged.

4. **Real `deleteEmailAction` in the safety test.** The previous safety regression used a local echo action, which meant a future refactor that bypassed `handleToolCall` could silently break the guarantee. The test now wires the actual `deleteEmailAction` from `@usejunior/email-core` through `handleToolCall` with a spy `provider.deleteMessage`:
   - Negative: passing `user_explicitly_requested_deletion: "false"` (string) must leave `deleteMessage` uncalled and return the real `user_explicitly_requested_deletion must be true` policy error from `checkDeletePolicy`
   - Positive: passing `"true"` (string) must coerce and call `deleteMessage('msg-1', false)` successfully
   If `z.coerce.boolean()` ever slipped back into the code path, the negative test would fail immediately (because `Boolean('false') === true` would let the delete through).

5. **Expanded `coerceArgsForZod` JSDoc** to document top-level-only scope, why unions/transforms/nested objects are intentionally skipped, and the safety reasoning behind strict boolean and numeric matching. Future maintainers should not have to re-derive the analysis.

## Tests

Before: 101 email-mcp tests, 376 workspace-wide.
After: 104 email-mcp tests, 379 workspace-wide. +3 net (−1 inline safety assertion replaced with two end-to-end tests through the real action, +1 refine test, +1 pipe test, +1 new numeric rejection block merged into the existing number test).

Full verification:
- [x] `npm run build` — clean across all four workspaces
- [x] `npx vitest run packages/email-mcp/` — 104/104
- [x] `npx vitest run` — 379/379
- [x] `npm run lint` — clean
- [x] `node scripts/e2e-mcp-test.mjs` — passes

## Follow-up (still open, not fixed here)

**`zodToJsonSchema()` has a casing typo that renders the primary path dead.** `packages/email-mcp/src/server.ts` checks `'toJsonSchema' in z`, but Zod v4 exports `z.toJSONSchema` (capital S). That's why `send_email.to` (a `z.union([z.string(), z.array(z.string())])`) emits `{}` in the live `tools/list` output — the code falls through to the hand-rolled manual generator, which doesn't handle `ZodUnion`. Verified by calling `z.toJSONSchema(schema, { io: 'input', unrepresentable: 'any' })` directly, which correctly emits `anyOf`. Keeping this as its own PR so the resulting schema diff across all 15 tools can be reviewed cleanly.

## Test plan

- [x] Unit tests for coercion helper (booleans, numbers, wrappers, unions, pipe/refine)
- [x] End-to-end safety regression through real `deleteEmailAction`
- [x] End-to-end positive path through real `deleteEmailAction`
- [x] Lint, full vitest, e2e script

## References

- Peer review findings from Codex and Gemini agreed on all five items in this PR; the single disagreement (Gemini thought `_def` was stable, Codex proved the deprecation) was resolved in favour of Codex after reading the typings file directly.