### PR TITLE
fix(email-mcp): emit real JSON Schema via z.toJSONSchema (fixes send_email.to)

### DIFF
--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -70,6 +70,66 @@ describe('mcp-transport/Zod Schema Constraints', () => {
       expect(tool.inputSchema.properties).toBeDefined();
     }
   });
+
+  it('Scenario: ZodUnion fields emit anyOf, not {}', () => {
+    // Regression lock for the `z.toJsonSchema` casing bug: previously the
+    // feature-detect fell through to a hand-rolled generator that returned
+    // `{}` for ZodUnion, so `send_email.to` (a string | string[] union)
+    // emitted an empty object in tools/list and some MCP clients couldn't
+    // validate calls. z.toJSONSchema handles unions natively.
+    const unionAction: EmailActionDef[] = [
+      {
+        name: 'send_like',
+        description: 'Schema shape mirrors send_email.to',
+        input: z.object({
+          to: z.string().or(z.array(z.string())).optional(),
+          subject: z.string().optional(),
+        }),
+        output: z.object({ success: z.boolean() }),
+        annotations: { readOnlyHint: false, destructiveHint: false },
+        run: async () => ({ success: true }),
+      },
+    ];
+    const [tool] = actionsToMcpTools(unionAction);
+    const props = (tool!.inputSchema.properties as Record<string, unknown>);
+    const toSchema = props.to as { anyOf?: Array<{ type: string }> };
+    expect(toSchema.anyOf).toBeDefined();
+    expect(toSchema.anyOf).toHaveLength(2);
+    expect(toSchema.anyOf?.[0]?.type).toBe('string');
+    expect(toSchema.anyOf?.[1]?.type).toBe('array');
+    // Explicitly NOT `{}` — this is the assertion that would have caught the bug.
+    expect(Object.keys(toSchema)).not.toEqual([]);
+  });
+
+  it('Scenario: defaults are exposed in tool input schema (io: input)', () => {
+    // z.toJSONSchema with io:'input' emits `default` so clients know what
+    // value they get if they omit the field. Backwards-compatible with the
+    // old hand-rolled generator (which dropped defaults entirely) — this
+    // test documents the intentional enrichment.
+    const action: EmailActionDef[] = [
+      {
+        name: 'test_defaults',
+        description: 'Exercises default exposure',
+        input: z.object({
+          flagged: z.boolean().default(true),
+          limit: z.number().default(25),
+        }),
+        output: z.object({}),
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        run: async () => ({}),
+      },
+    ];
+    const [tool] = actionsToMcpTools(action);
+    const props = (tool!.inputSchema.properties as Record<string, { default?: unknown; type?: string }>);
+    expect(props.flagged?.default).toBe(true);
+    expect(props.flagged?.type).toBe('boolean');
+    expect(props.limit?.default).toBe(25);
+    expect(props.limit?.type).toBe('number');
+    // Defaults make fields optional — not in required[].
+    const required = (tool!.inputSchema.required as string[] | undefined) ?? [];
+    expect(required).not.toContain('flagged');
+    expect(required).not.toContain('limit');
+  });
 });
 
 describe('mcp-transport/Tool Annotations', () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -205,78 +205,23 @@ export async function handleToolCall(
 }
 
 /**
- * Convert a Zod schema to JSON Schema (simplified).
- * Uses Zod v4's built-in JSON Schema generation when available.
+ * Convert a Zod schema to JSON Schema for MCP `tools/list`.
+ *
+ * Uses Zod v4's first-party `z.toJSONSchema` with `io: 'input'`. Input mode
+ * is the semantically correct one for tool input schemas: fields with
+ * defaults are not marked required (because the client may omit them), and
+ * the emitted shape describes what the client sends, not what the parser
+ * produces.
+ *
+ * Historical note: this used to feature-detect a misspelled `toJsonSchema`
+ * (lowercase `s`), which never existed in Zod v4. The primary path
+ * silently fell through to a hand-rolled generator that returned `{}` for
+ * `ZodUnion`, which is why `send_email.to` (a `string | string[]` union)
+ * previously emitted `{}` in `tools/list` and some MCP clients couldn't
+ * validate calls to it. Fixed by calling the real API directly.
  */
 function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
-  try {
-    // Try Zod v4 built-in toJsonSchema
-    if ('toJsonSchema' in z && typeof (z as unknown as { toJsonSchema: (s: z.ZodType) => Record<string, unknown> }).toJsonSchema === 'function') {
-      return (z as unknown as { toJsonSchema: (s: z.ZodType) => Record<string, unknown> }).toJsonSchema(schema);
-    }
-  } catch {
-    // Fall through to manual generation
-  }
-
-  // Manual JSON Schema generation for common patterns
-  return generateJsonSchema(schema);
-}
-
-function generateJsonSchema(schema: z.ZodType): Record<string, unknown> {
-  // Zod v4 uses `_def.type` as a string discriminator and `_def.shape` as a plain object
-  const def = schema._def as {
-    type?: string;
-    typeName?: string;
-    shape?: Record<string, z.ZodType> | (() => Record<string, z.ZodType>);
-    innerType?: z.ZodType;
-    defaultValue?: () => unknown;
-  };
-
-  const typeId = def.type ?? def.typeName ?? '';
-
-  switch (typeId) {
-    case 'string':
-    case 'ZodString':
-      return { type: 'string' };
-    case 'number':
-    case 'ZodNumber':
-      return { type: 'number' };
-    case 'boolean':
-    case 'ZodBoolean':
-      return { type: 'boolean' };
-    case 'array':
-    case 'ZodArray': {
-      const itemType = def.innerType ?? (def as { element?: z.ZodType }).element;
-      return { type: 'array', items: itemType ? generateJsonSchema(itemType) : {} };
-    }
-    case 'object':
-    case 'ZodObject': {
-      const shape = typeof def.shape === 'function' ? def.shape() : (def.shape ?? {});
-      const properties: Record<string, unknown> = {};
-      const required: string[] = [];
-      for (const [key, value] of Object.entries(shape)) {
-        const propDef = (value as z.ZodType)._def as { type?: string; typeName?: string };
-        const propType = propDef.type ?? propDef.typeName ?? '';
-        properties[key] = generateJsonSchema(value as z.ZodType);
-        if (propType !== 'optional' && propType !== 'ZodOptional' &&
-            propType !== 'default' && propType !== 'ZodDefault') {
-          required.push(key);
-        }
-      }
-      return { type: 'object', properties, ...(required.length > 0 ? { required } : {}) };
-    }
-    case 'optional':
-    case 'ZodOptional':
-      return def.innerType ? generateJsonSchema(def.innerType) : {};
-    case 'default':
-    case 'ZodDefault':
-      return def.innerType ? generateJsonSchema(def.innerType) : {};
-    case 'nullable':
-    case 'ZodNullable':
-      return def.innerType ? { ...generateJsonSchema(def.innerType), nullable: true } : {};
-    default:
-      return {};
-  }
+  return z.toJSONSchema(schema, { io: 'input' }) as Record<string, unknown>;
 }
 
 /**


### PR DESCRIPTION
## Summary

The `zodToJsonSchema()` helper in `packages/email-mcp/src/server.ts` checked `'toJsonSchema' in z` (lowercase `s`) and called `z.toJsonSchema(schema)`. Zod v4 has no such export — the actual API is `z.toJSONSchema` (capital `S`). The feature detect always evaluated false, so every call silently fell through to a hand-rolled generator that returned `{}` for any Zod type discriminator it did not explicitly handle.

**Most visible consequence:** `send_email.to`, `create_draft.to`, and `update_draft.to` — all declared as `z.string().or(z.array(z.string()))` — emitted `"to": {}` in `tools/list`. MCP clients that strictly validate tool arguments against the emitted input schema could not call these tools, and lenient clients got no help from the schema about whether to send a string or an array.

**Fix:** call the real API directly with `io: 'input'` (the semantically correct mode for tool-input schemas — fields with defaults are not marked required because the client may omit them). Delete the hand-rolled fallback generator entirely — it was 56 lines of dead code whose only function was to mask the typo in the primary path and corrupt the output when it did run.

## Schema diff

Captured by running an `StdioClientTransport` against the built server and diffing `tools/list` before vs after across all 15 tools.

**1. Union emission fixed (the bug):**
```diff
 "send_email": {
   "properties": {
-    "to": {},
+    "to": {
+      "anyOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
+    },
```
Same fix applies to `create_draft.to` and `update_draft.to`.

**2. `$schema` metadata added to every tool:**
```diff
     }
+    ,"$schema": "https://json-schema.org/draft/2020-12/schema"
   }
```
Standard JSON Schema metadata. Harmless to MCP clients, which either ignore unknown top-level properties or expect exactly this shape.

**3. Defaults now exposed on three tools:**
```diff
 "flag_email": {
   "properties": {
     "flagged": {
+      "default": true,
       "type": "boolean"
     }
```
Same for `mark_read.is_read: default true` and `delete_email.hard_delete: default false`. Backwards-compatible and useful — clients can now display "defaults to true/false" in tool-call UIs without reading the docs. **Defaults do NOT make these fields required** in input mode, matching the previous behavior.

**No other schema changes:** no required-array regressions, no missing fields, no renamed types. Verified by full unified diff of all 15 tools.

## Regression tests

Two new tests lock in the fix so this class of bug can't silently return:

1. **`ZodUnion fields emit anyOf, not {}`** — builds a schema mirroring `send_email.to` and asserts the exact `anyOf` shape. Would have caught the original bug. Also explicitly asserts the property is not `{}`.
2. **`defaults are exposed in tool input schema (io: input)`** — locks in the intentional enrichment so a future refactor that switches modes doesn't regress client UX.

## Verification

- [x] `npm run build` — clean across all four workspaces
- [x] `npx vitest run packages/email-mcp/` — 106/106 (was 104, +2 regression locks)
- [x] `npx vitest run` — 381/381
- [x] `npm run lint` — clean
- [x] `node scripts/e2e-mcp-test.mjs` — passes
- [x] Manual `StdioClientTransport` probe confirms `send_email` can be called with both `{to: "x@y.com"}` and `{to: ["a@b.com", "c@d.com"]}` (the union fix actually working end-to-end)
- [x] Full schema diff captured and inspected for all 15 tools

## Context

Completes the follow-up chain from the peer review of #19. The scalar-coercion PR (#19) surfaced this adjacent bug; the review-feedback PR (#21) addressed everything in the coercion helper itself. This PR closes the last outstanding item by fixing the tool-schema emission and deleting the dead manual fallback that was masking it.

## Test plan

- [x] Schema regression tests for ZodUnion and defaults
- [x] End-to-end probe via StdioClientTransport
- [x] Manual `send_email` call with string and array `to`