### PR TITLE
feat: publish 5 email management skills to skills/ directory

### DIFF
--- a/skills/email-cleanup/SKILL.md
+++ b/skills/email-cleanup/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: email-cleanup
+description: >-
+  Organize a cluttered Outlook inbox with folders, batch moves, and server-side
+  inbox rules via the Microsoft Graph API. Use when user says "clean up my inbox,"
+  "organize email," "create email folders," "inbox rules," "filter notifications,"
+  "unclutter inbox," "sort my email," "move GitHub notifications," "email
+  folders," or "auto-sort email." Covers one-time cleanup and ongoing automation.
+license: Apache-2.0
+homepage: https://github.com/UseJunior/email-agent-mcp
+compatibility: >-
+  Works with any agent or client that can call the Microsoft Graph API on
+  the user's behalf. Requires a Microsoft 365 OAuth delegated token with
+  Mail.ReadWrite (for folder and message management) and
+  MailboxSettings.ReadWrite (for inbox rule management). The reference
+  runtime (email-agent-mcp, open source, Apache-2.0) uses MSAL device code
+  flow, requires Node.js >=20, and persists tokens in the OS keychain.
+  This skill does NOT require Mail.Send — cleanup does not send email.
+requires:
+  credentials:
+    provider: microsoft-graph
+    auth: oauth2-delegated
+    reference_flow: oauth2-device-code (MSAL, via @azure/identity)
+    scopes_required:
+      - Mail.ReadWrite
+      - MailboxSettings.ReadWrite
+      - offline_access
+    scopes_sensitive: []
+    token_storage: >-
+      Reference runtime stores OAuth tokens in the OS keychain via MSAL
+      with @azure/identity-cache-persistence. No raw passwords, no plain
+      text token files.
+  environment_variables:
+    - name: AGENT_EMAIL_CLIENT_ID
+      required: false
+      description: Override the default Microsoft App ID used for auth
+    - name: EMAIL_AGENT_MCP_HOME
+      required: false
+      description: Override default config and token storage directory (~/.email-agent-mcp)
+  network:
+    runtime:
+      - graph.microsoft.com
+      - login.microsoftonline.com
+  enforcement:
+    blocked_rule_actions:
+      - forwardTo
+      - forwardAsAttachmentTo
+      - redirectTo
+      - delete
+      - permanentDelete
+metadata:
+  author: UseJunior
+  version: "0.1.3"
+---
+
+# Inbox Cleanup & Rules (Outlook)
+
+This skill covers both one-time inbox cleanup and ongoing rule automation for Microsoft 365 / Outlook. The workflow uses the Microsoft Graph API for folder management and server-side inbox rules.
+
+## When to Use This Skill
+
+Use when the user's inbox has become noisy — automated notifications drowning out human conversations, newsletters mixed with client emails, or hundreds of unread messages that make it hard to find what matters.
+
+**Real trigger example**: A user's partner email went unread for 9 days because it was buried under GitHub and npm notifications. This is the exact problem server-side rules solve.
+
+## Authentication & Required Scopes
+
+This skill operates against Microsoft Graph and requires an OAuth 2.0 delegated access token for a Microsoft 365 account.
+
+### Minimum scopes by use case
+
+| Use case | Scopes required |
+|----------|----------------|
+| Audit existing folders and inbox rules (read-only) | `Mail.Read`, `MailboxSettings.Read`, `offline_access` |
+| Create folders and move existing email | + `Mail.ReadWrite` |
+| Create and delete server-side inbox rules | + `MailboxSettings.ReadWrite` |
+
+This skill does **not** require `Mail.Send` — inbox cleanup never sends email.
+
+### Token storage
+
+The reference runtime stores OAuth tokens in the OS keychain (macOS Keychain / Windows Credential Manager / Linux libsecret) via MSAL with `@azure/identity-cache-persistence`. No raw passwords. No plain text token files. Refresh tokens are handled silently by MSAL.
+
+### Risk mapping — scopes to exfiltration risk
+
+| Scope | Enables | Risk if misused |
+|-------|---------|----------------|
+| `Mail.Read` | Read any message, folder, and attachment | Read-only; no exfiltration beyond the agent session |
+| `Mail.ReadWrite` | Create folders, move/copy messages | Low on its own — no outbound mail capability |
+| `MailboxSettings.ReadWrite` | Create and delete inbox rules | **HIGH** — malicious rules with `forwardTo`/`redirectTo` can exfiltrate mail silently even after the session ends |
+| `offline_access` | Refresh tokens without re-auth | Low on its own; extends the blast radius of any other scope if the token is stolen |
+
+`MailboxSettings.ReadWrite` is the only HIGH-risk scope this skill needs. It is mitigated by the reference runtime's hard block on dangerous rule actions (see "Rule Security Model" below).
+
+### Reference runtime guardrails
+
+This skill is instruction-only — it cannot enforce any guardrails by itself. The protections below are provided by the **runtime** that actually executes the Graph API calls, not by this skill.
+
+If you use [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp) as the runtime, it blocks dangerous inbox rule actions at the action handler level — `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete` — and rejects any rule creation attempt that includes them. Source: [`packages/email-core/src/actions/rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39).
+
+If you use a different runtime (raw Graph API client, custom MCP server), these protections are NOT automatically present. You should either layer NemoClaw network policy, restrict OAuth scopes, or use a runtime that provides equivalent guardrails.
+
+### Hardening recipes
+
+1. **Audit mode only** — grant `MailboxSettings.Read` (without `.ReadWrite`) if you want the agent to review existing rules without being able to create or modify them. The cleanup workflow below will still work for folder management.
+2. **Don't grant `MailboxSettings.ReadWrite`** if you don't need automated rule creation. Folder management and batch moves work with just `Mail.ReadWrite`.
+3. **Layer NemoClaw** — see the [NemoClaw Email Policy skill](https://clawhub.ai/skill/nemoclaw-email-policy) to block dangerous Graph endpoints at the network layer regardless of scope grants.
+
+## The Cleanup Workflow
+
+This workflow was battle-tested on a 2,500+ email cleanup. Follow the steps in order.
+
+### Step 1 — Scan Before Creating Folders
+
+Don't guess what folders to create. Let the data tell you.
+
+Fetch the last 200 inbox emails and count by sender address:
+
+```
+GET /me/messages?$top=200&$select=from,receivedDateTime&$orderby=receivedDateTime desc
+```
+
+Group by `from.emailAddress.address`, sort by count descending. The top automated senders are the ones to filter.
+
+**MCP**: Use `list_emails(max_results=200, fields=["fromAddress", "receivedDateTime"])` and count programmatically.
+
+### Step 2 — Categorize by Action Required
+
+Don't organize by sender type (that is arbitrary). Organize by what the user needs to do:
+
+| Category | Action | Examples |
+|----------|--------|----------|
+| **Glance, don't act** | Skim the subject line, archive | GitHub CI, Azure DevOps builds, npm advisories, DMARC reports |
+| **Read when time allows** | Set aside for a slow moment | Newsletters, marketing from known vendors |
+| **Archive for records** | Keep but don't read now | Receipts, invoices, payment confirmations |
+| **May need action** | Review and decide | Meeting bookings, compliance alerts, security notifications |
+| **Default: don't filter** | Leave in inbox | Human conversations (colleagues, clients, partners) |
+
+The last row is important: human conversations stay in inbox unless the user specifically requests otherwise. The goal is to remove noise, not to hide signal.
+
+### Step 3 — Create Folders
+
+Keep it to 5-9 folders. More than that and the user stops checking them. The right test: "Would I check this folder at least weekly?" If no, it should be a subfolder or merged into a broader category.
+
+**REST API**:
+```
+POST /me/mailFolders
+{"displayName": "Dev Notifications"}
+```
+
+**MCP**: `create_folder("Dev Notifications")`
+
+### Step 4 — Batch-Move Existing Email
+
+Rules only apply to future mail. After creating folders, move all existing matching emails.
+
+**REST API**:
+```
+GET /me/messages?$filter=from/emailAddress/address eq 'notifications@github.com'&$top=50
+```
+Then for each message:
+```
+POST /me/messages/{id}/move
+{"destinationId": "<folder-id>"}
+```
+
+Paginate with `@odata.nextLink` — some senders will have hundreds of messages. Process 50 at a time.
+
+**MCP**: `move_to_folder(email_id, "Dev Notifications")` handles ID resolution. Loop through search results.
+
+### Step 5 — Create Server-Side Rules
+
+Server-side rules run on Microsoft's servers — they work 24/7, even when no agent is running.
+
+**REST API**:
+```
+POST /me/mailFolders/inbox/messageRules
+{
+  "displayName": "GitHub to Dev Notifications",
+  "sequence": 1,
+  "isEnabled": true,
+  "conditions": {
+    "fromAddresses": [
+      {"emailAddress": {"address": "notifications@github.com"}}
+    ]
+  },
+  "actions": {
+    "moveToFolder": "<folder-id>",
+    "stopProcessingRules": true
+  }
+}
+```
+
+**MCP**: `create_inbox_rule({displayName: "GitHub to Dev Notifications", conditions: {fromAddresses: [{email: "notifications@github.com"}]}, actions: {moveToFolder: "<folder-id>", markAsRead: true}})`
+
+### Step 6 — Re-Sweep After Rule Creation
+
+Rules and email arrival can race. After creating rules, wait a few minutes, then re-run the batch move from Step 4 to catch any emails that arrived between rule creation and activation.
+
+## Rule Ordering
+
+The `sequence` field controls which rules fire first. Lower sequence = higher priority.
+
+**This matters because**: A generic "any `noreply@` sender goes to Newsletters" rule will swallow meeting booking notifications from `noreply@notifications.hubspot.com` if it fires first.
+
+**Fix**: Create specific rules with lower sequence numbers before broad rules.
+
+```
+sequence 1: HubSpot meeting bookings → Meetings folder
+sequence 2: noreply@ senders → Newsletters folder
+```
+
+Always set `stopProcessingRules: true` on each rule to prevent cascade.
+
+## Rule Security Model
+
+Not all rule actions are safe. Agents should never create rules with the actions listed below. This skill is instruction-only — it cannot enforce these restrictions itself. The agent's runtime is what actually makes (or blocks) the API calls.
+
+If your runtime is [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), it rejects rule creation attempts that include any of these actions and returns a `BLOCKED_ACTION` error. Source: [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39). If you use a different runtime, you should verify it provides equivalent enforcement, or layer network-level controls (e.g. NemoClaw).
+
+**Block these actions:**
+
+| Action | Risk |
+|--------|------|
+| `forwardTo` | Could exfiltrate email to external addresses |
+| `forwardAsAttachmentTo` | Same risk |
+| `redirectTo` | Same risk |
+| `delete` | Data loss |
+| `permanentDelete` | Irreversible data loss |
+
+**These actions are safe:**
+
+| Action | Effect |
+|--------|--------|
+| `moveToFolder` | Move to a folder ID |
+| `copyToFolder` | Copy to a folder ID |
+| `markAsRead` | Mark as read |
+| `markImportance` | Set importance level (low/normal/high) |
+| `stopProcessingRules` | Prevent later rules from firing |
+
+If the user asks for a forwarding rule, ask them to confirm the destination address explicitly before creating it.
+
+## Common Conditions
+
+| Condition | Use |
+|-----------|-----|
+| `fromAddresses` | Exact sender match: `[{emailAddress: {address: "..."}}]` |
+| `subjectContains` | Words in subject: `["[npm]", "advisory"]` |
+| `senderContains` | Partial sender match: `["github.com"]` |
+| `headerContains` | Match email headers |
+
+## Graph API Gotchas
+
+These are production-discovered issues — not theoretical:
+
+1. **`$select` on PATCH = 400** — `$select` does not work on PATCH requests. Returns "OData request not supported." Only use `$select` on GET.
+
+2. **Move is POST, not PATCH** — `POST /me/messages/{id}/move` with `{"destinationId": "<id>"}`.
+
+3. **`$filter` with sender address** — `$filter=from/emailAddress/address eq '...'` works reliably. URL-encode the filter value.
+
+4. **Uppercase in storage** — Outlook uppercases `senderContains` values (e.g., `NOTIFICATIONS@GITHUB.COM`). This is cosmetic — matching is case-insensitive.
+
+5. **Root-only folder listing** — `GET /me/mailFolders?$top=100` returns only root-level folders. Child folders require `/mailFolders/{id}/childFolders`.
+
+6. **Pagination** — Large mailboxes can have hundreds of folders. Always check for and follow `@odata.nextLink`.
+
+## Verification
+
+After creating rules:
+
+1. `GET /me/mailFolders/inbox/messageRules` — verify the rule exists and is enabled
+2. Check `hasError` field — if `true`, the rule has a configuration issue
+3. Send a test email matching the rule conditions and verify it lands in the correct folder
+
+## Feedback
+
+If this skill helped, star us on GitHub: https://github.com/UseJunior/email-agent-mcp
+On ClawHub: `clawhub star stevenobiajulu/inbox-cleanup-outlook`

--- a/skills/email-drafting/SKILL.md
+++ b/skills/email-drafting/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: email-drafting
+description: >-
+  Draft email replies with tone matching, proper threading, and formatting that
+  survives email clients. Use when user says "draft a reply," "respond to this
+  email," "write an email," "compose a response," "email reply," "tone match,"
+  "professional email," "follow-up email," or "thank you email." Covers voice
+  calibration, formatting gotchas, and the draft-first safety pattern.
+license: Apache-2.0
+compatibility: >-
+  Works with any agent. No runtime dependencies — instruction-only skill.
+  Optionally enhanced by email-agent-mcp (Node.js >=20) for draft saving
+  and thread detection.
+metadata:
+  author: UseJunior
+  version: "0.1.0"
+---
+
+# Email Response Drafting
+
+This skill covers drafting email replies that sound human, thread correctly, and render properly across email clients. It is scoped to response drafting — not marketing campaigns or mass outreach.
+
+## Draft-First: The Non-Negotiable Rule
+
+Never send an email without the user's explicit approval. The workflow:
+
+1. **Compose** the draft (in markdown, in the agent's chat, or in a file)
+2. **Present** recipients, subject, and body to the user for review
+3. **Save as draft** to Outlook (or the user's email client) if available
+4. **Wait** for the user to say "send," "send now," "reply now," or equivalent
+5. **Send** only after explicit approval
+
+If intent is ambiguous ("looks good" could mean "I approve the draft" or "I'll send it myself"), ask for one-line confirmation before sending.
+
+## Voice and Tone Matching
+
+The cardinal rule: match the sender's register.
+
+| Relationship | Tone | Example opener |
+|-------------|------|----------------|
+| Internal team / contractors | Short, direct, no filler | "Sent the updated file. Let me know if anything looks off." |
+| Existing clients (high trust) | Warm but efficient | "Quick update — the document is ready for your review." |
+| New contacts / cold replies | Professional, value-first | Lead with what is relevant to them, not your credentials |
+| Formal threads | Match their formality | If they write "Dear Steven," reply with "Dear [Name]," not "Hey!" |
+
+### Calibration signals
+
+Read the sender's email for cues:
+- **Length** — if they wrote 2 sentences, don't reply with 5 paragraphs
+- **Greeting style** — mirror their "Hi" / "Hello" / "Dear" / no greeting
+- **Closing** — mirror their "Best" / "Thanks" / "Regards" / no closing
+- **Emoji/exclamation use** — match their energy level, don't exceed it
+
+### What to avoid
+
+- **Over-explaining process** — state the outcome, not the journey. "The agreement is ready" beats "I reviewed the agreement, made several updates to sections 3 and 7, cross-referenced with our template library, and..."
+- **Filler phrases** — "I hope this email finds you well" is noise. Start with the point.
+- **Quoting others on your own product** — never attribute your product description to someone else
+- **Singling out one insight from a rich conversation** — if you had a long call, reference the breadth of the discussion, don't cherry-pick
+
+## Threading: Get It Right
+
+Broken threading looks unprofessional. Before creating a reply draft:
+
+1. **Check the subject** — if it has "Re:" or "RE:", this is a reply to an existing thread
+2. **Find the original message** — search by sender + subject keywords
+3. **Get the message ID** — use it as the `in_reply_to` or `reply_to` parameter
+4. **Create a threaded reply** — not a standalone new message
+
+If the original message cannot be found, tell the user rather than silently creating a standalone draft that will break the thread in the recipient's inbox.
+
+**REST API**: Use `POST /me/messages/{id}/createReply` to maintain threading. This preserves conversation ID and In-Reply-To headers.
+
+**MCP**: `reply_to_email` handles threading automatically.
+
+## Structure: One Ask Per Email
+
+Every email should have exactly one clear action item. If you need multiple things, either:
+
+- Pick the most important one and save the rest for a follow-up
+- Use a numbered list where the first item is the ask and the rest are context
+
+**Structure template for action-needed replies:**
+
+```
+[1-2 sentence context/update]
+
+[The ask — what you need from them, by when]
+
+[Optional: supporting detail they might need to act]
+```
+
+**Structure template for informational replies:**
+
+```
+[The news — what happened or what's ready]
+
+[Optional: what they should do next, or "no action needed"]
+```
+
+## Formatting That Survives Email Clients
+
+Email rendering is a minefield. Markdown that looks perfect in a text editor can break in Outlook, Gmail, or Apple Mail.
+
+### Gotchas
+
+| Issue | What breaks | Fix |
+|-------|------------|-----|
+| **Cuddled lists** | No blank line before first `- item` | Always add a blank line before the first list item |
+| **Raw markdown in HTML** | `**bold**` renders as literal asterisks in HTML email | Convert markdown to HTML before sending |
+| **Missing plain-text body** | HTML-only emails get flagged by spam filters | Always include both HTML and plain-text versions |
+| **Signature placement** | Signature appears before the quoted thread | Put signature after reply body, before the quoted thread |
+| **Long URLs** | URLs wrap mid-word and break clickability | Use hyperlink text `[click here](url)` in markdown; convert to `<a>` in HTML |
+| **Tables** | Many email clients don't render markdown tables | Use HTML `<table>` with inline styles for email |
+
+### Character encoding
+
+- Curly quotes (`\u201c\u201d`) and straight quotes (`"`) should both be handled
+- Em dashes (`\u2014`) render fine in modern clients but may break in plain-text
+- Non-ASCII characters in subject lines need proper encoding (most APIs handle this)
+
+## Draft File Format
+
+When saving drafts to files (for MCP or manual review), use YAML frontmatter:
+
+```yaml
+---
+to: recipient@example.com
+subject: Re: Project update
+in_reply_to: <message-id-from-original>
+---
+
+Body of the email in markdown.
+
+The MCP or send script converts this to HTML + plain text automatically.
+```
+
+Do not pre-populate `draft_id` or `draft_link` — these are auto-appended by the MCP after saving to Outlook.
+
+## Tone Calibration by Context
+
+### Delivering good news
+Lead with the news. "The document is signed and filed" — then details if needed.
+
+### Delivering bad news
+Lead with empathy, then the fact, then the path forward. "I understand the timeline is tight. The review is taking longer than expected — we should have it by Thursday. I will send it as soon as it is ready."
+
+### Following up (no response yet)
+Soft-remind the agreed action, don't re-ask. "Circling back on the agreement — let me know if you need anything to move forward." Not: "Did you get my last email?"
+
+### Declining or redirecting
+Be direct and offer an alternative. "I'm not the right person for this, but [Name] at [Company] specializes in exactly this."
+
+## Feedback
+
+If this skill helped, star us on GitHub: https://github.com/UseJunior/email-agent-mcp
+On ClawHub: `clawhub star stevenobiajulu/email-response-drafting`

--- a/skills/email-triage/SKILL.md
+++ b/skills/email-triage/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: email-triage
+description: >-
+  Zero-trust email triage — prioritize inbox by sender trust tier, not arrival
+  order. Surfaces paying customers immediately, batches newsletters, and applies
+  an exception lane for unknown senders with objective evidence. Use when user
+  says "triage my inbox," "prioritize email," "what's important," "check for
+  urgent email," "email priority," "sender trust," "inbox zero," or "which
+  emails matter." Works with any email client or Graph API tool.
+license: Apache-2.0
+homepage: https://github.com/UseJunior/email-agent-mcp
+compatibility: >-
+  Instruction-only skill — no runtime dependencies. Provides prioritization
+  logic that works with whatever email data the agent's runtime already
+  exposes. Does not require the skill to declare or request any credentials.
+  This skill does not instruct the agent to fetch additional data sources
+  it doesn't already have access to.
+metadata:
+  author: UseJunior
+  version: "0.1.2"
+---
+
+# Zero-Trust Email Triage
+
+AI is fast enough that if it sees an email, it can respond quickly. The failure mode is not slow response — it is surfacing noise that drowns out real signal. This skill teaches agents to classify email by sender trust, not by arrival order or self-claimed urgency.
+
+## The Problem
+
+Most email agents treat all unread email as equally important. This creates two failure modes:
+
+1. **Noise escalation** — a marketing email from an unknown sender with "URGENT" in the subject gets surfaced alongside a client asking for help
+2. **Buried signal** — a partner reply sits unread for days because it arrived between 50 GitHub notifications
+
+Both failures damage trust. The fix is sender-based prioritization.
+
+## Primary Classifier: Sender Trust Tiers
+
+Classify every email by who sent it, not what it says:
+
+### Tier 1 — Paying Customers and Active Clients
+Surface immediately. These are relationships where a missed email damages trust and revenue.
+
+**Examples**: Client asking for a document review, customer reporting a bug, partner requesting a meeting.
+
+**Action**: Summarize and surface to the user right away. If the email requires a response, flag it as action-needed.
+
+### Tier 2 — Engaged Contacts
+Surface promptly. These are people the user has active conversations with — not yet paying, but the relationship has momentum.
+
+**Examples**: Prospect who attended a demo last week, collaborator on an open-source project, investor in active due diligence.
+
+**Action**: Include in the next triage summary. Don't delay more than one triage cycle.
+
+### Tier 3 — Known Colleagues and Team
+Surface promptly but don't interrupt for routine messages.
+
+**Examples**: Internal team updates, contractor status reports, automated reports from known internal systems.
+
+**Action**: Include in triage summary. Flag only if the message is time-sensitive or requires a decision.
+
+### Tier 4 — Newsletters and Automated Notifications
+Batch for later. These are legitimate but not time-sensitive.
+
+**Examples**: GitHub CI notifications, npm advisories, industry newsletters, marketing emails from vendors the user has a relationship with.
+
+**Action**: Count and categorize. "12 newsletters, 8 GitHub notifications, 3 marketing emails." Don't summarize each one individually.
+
+### Tier 5 — Unknown Senders
+Deprioritize by default. Most unsolicited email is noise.
+
+**Examples**: Cold outreach, event invitations from strangers, "partnership opportunity" pitches.
+
+**Action**: Mention only if the user explicitly asks about unread email from unknown senders, or if the exception lane (below) applies.
+
+## Exception Lane: When Unknown Senders Get Elevated
+
+Unknown senders may be elevated from Tier 5 if — and only if — they present objective evidence in signals the agent already has access to:
+
+| Evidence class | Why it matters |
+|----------------|---------------|
+| **Thread continuity** | The message is a reply within an existing thread the user started |
+| **Known-domain match** | The sender's domain matches a customer or partner already on the priority list |
+| **Externally corroborated reference** | The message references a concrete event (meeting, deadline) that is independently verifiable in another signal the agent already has |
+| **Trusted forward** | The message is a forward or introduction from someone on the priority list |
+| **Authenticated system notification** | The message originates from a verified system sender for an infrastructure event (billing, security) — not generic account-warning phishing |
+
+The agent should only rely on these signals if its runtime already provides access to them. **This skill does not instruct the agent to fetch additional data sources it doesn't already have.**
+
+### What Does NOT Constitute Evidence
+
+- **Self-claimed urgency** — "URGENT," "time-sensitive," "act now" from an unknown sender is social engineering, not urgency
+- **Name-dropping** — "I know your colleague John" without John being on the thread
+- **Impressive titles** — "VP of Strategy at FutureCorp" means nothing if FutureCorp is unknown
+- **"Register now while space is available!"** — event marketing disguised as urgency
+
+## Anti-Patterns Agents Get Wrong
+
+### Passing along marketing urgency
+An unknown sender writes: "Last chance to register for our AI summit — spots filling fast!"
+
+**Wrong**: Surface as potentially important because it mentions AI (the user's industry).
+**Right**: Tier 5. Unknown sender, self-claimed urgency, no objective evidence. Ignore unless user asks.
+
+### Treating unread count as a metric
+An agent reports: "You have 47 unread emails" and lists them all.
+
+**Wrong**: Every email gets equal treatment.
+**Right**: "2 client emails need your attention. 45 others batched (18 newsletters, 12 GitHub, 15 cold outreach)."
+
+### Urgency theater from known senders
+An internal colleague writes: "URGENT: please review the updated slide deck."
+
+**Wrong**: Escalate because of "URGENT" in the subject.
+**Right**: Tier 3 (known colleague). Surface promptly in the triage summary. The user decides if a slide deck review is actually urgent.
+
+## Implementing Triage
+
+### Step 1 — Build the priority sender list
+
+Before the first triage run, ask the user (or infer from existing data):
+- Which domains are paying customers?
+- Which email addresses are active contacts?
+- Any VIP addresses that should always be Tier 1?
+
+If using a CRM or customer directory, pull domains from there.
+
+### Step 2 — First pass: list without bodies
+
+Fetch recent unread emails with only metadata fields (sender, subject, date, read status). Don't fetch bodies yet — this keeps the first pass fast and token-efficient.
+
+### Step 3 — Classify by tier
+
+Match each email's sender against the priority list. Apply the tier classification.
+
+### Step 4 — Second pass: preview priority emails
+
+For Tier 1-2 emails only, fetch a body preview (first ~500 chars). Summarize the key point and any action needed.
+
+### Step 5 — Report by tier
+
+Present results grouped by tier, not chronologically:
+
+```
+## Priority emails (2)
+- [Client] Sarah at AcmeCorp: "Can you send the updated agreement?" → needs reply
+- [Partner] Dave at PartnerFirm: "Confirming Thursday meeting" → informational
+
+## Batched (37)
+- 12 GitHub notifications
+- 8 newsletters  
+- 17 cold outreach / unknown
+```
+
+## Feedback
+
+If this skill helped, star us on GitHub: https://github.com/UseJunior/email-agent-mcp
+On ClawHub: `clawhub star stevenobiajulu/zero-trust-email-triage`

--- a/skills/nemoclaw-email-policy/SKILL.md
+++ b/skills/nemoclaw-email-policy/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: nemoclaw-email-policy
+description: >-
+  Enforce email safety policies at the network level with NemoClaw. Use when user
+  says "email policy," "send guardrail," "prevent accidental send," "email
+  allowlist," "NemoClaw email," "outlook policy," "agent email security,"
+  "email sandbox," or "enterprise email safety." Covers NemoClaw setup, the
+  Outlook preset, and policy enforcement for production email agents.
+license: Apache-2.0
+compatibility: >-
+  Requires NemoClaw (macOS). Works with any MCP-based email agent
+  including email-agent-mcp and direct Graph API clients.
+metadata:
+  author: UseJunior
+  version: "0.1.0"
+---
+
+# NemoClaw Email Policy
+
+NemoClaw enforces network-level policies for AI agents. For email workflows, this means controlling which endpoints agents can reach — and which actions they cannot take — regardless of what the agent itself tries to do.
+
+This is defense in depth: even if an email MCP server has a bug, or an agent hallucinates a send command, the network policy blocks the request before it reaches Microsoft's servers.
+
+## Why Policy Enforcement Matters
+
+Email agents have access to sensitive data (inbox contents, contacts, calendars) and can take impactful actions (send email, create calendar events, modify inbox rules). In production, "the agent is well-behaved" is not a sufficient security model.
+
+**Failure modes without policy enforcement:**
+- Agent sends an email to an unintended recipient because of a hallucinated address
+- A prompt injection in an email body tricks the agent into forwarding the message
+- Agent creates an inbox rule that forwards all email to an external address
+- A bug in the MCP server sends a draft that was not approved
+
+NemoClaw prevents these by controlling the network layer — the agent process cannot reach endpoints that are not explicitly allowed.
+
+## Prerequisites
+
+- **macOS** (NemoClaw uses the macOS sandbox)
+- **NemoClaw installed**: `npm install -g nemoclaw` or clone from GitHub
+- **Email MCP server configured**: e.g., `email-agent-mcp` with Microsoft 365 OAuth completed
+
+## Setting Up the Outlook Preset
+
+NemoClaw ships with a curated Outlook preset that allows the minimum necessary endpoints for Microsoft 365 email.
+
+### Apply for the current session
+
+```bash
+openshell policy set nemoclaw-blueprint/policies/presets/outlook.yaml
+```
+
+This enables access to:
+- `graph.microsoft.com` — Microsoft Graph API (GET, POST, PATCH)
+- `login.microsoftonline.com` — OAuth token refresh
+- `outlook.office365.com` — Outlook backend
+- `outlook.office.com` — Outlook web (for draft links)
+
+All connections require TLS. The preset blocks all other outbound network access.
+
+### Make it permanent
+
+To include the Outlook preset in your baseline policy:
+
+1. Merge the preset entries into your `nemoclaw-blueprint/policies/openclaw-sandbox.yaml`
+2. Re-run the onboard wizard:
+   ```bash
+   nemoclaw onboard
+   ```
+
+The preset is one of NemoClaw's 9 built-in presets (discord, docker, huggingface, jira, npm, outlook, pypi, slack, telegram).
+
+## What the Policy Enforces
+
+### Allowed: Read and Draft Operations
+
+| Operation | Endpoint | Method |
+|-----------|----------|--------|
+| List/search emails | `graph.microsoft.com/v1.0/me/messages` | GET |
+| Read email body | `graph.microsoft.com/v1.0/me/messages/{id}` | GET |
+| Create draft | `graph.microsoft.com/v1.0/me/messages` | POST |
+| Update draft | `graph.microsoft.com/v1.0/me/messages/{id}` | PATCH |
+| List folders | `graph.microsoft.com/v1.0/me/mailFolders` | GET |
+| Create folder | `graph.microsoft.com/v1.0/me/mailFolders` | POST |
+| Move email | `graph.microsoft.com/v1.0/me/messages/{id}/move` | POST |
+| List events | `graph.microsoft.com/v1.0/me/events` | GET |
+| OAuth refresh | `login.microsoftonline.com/*/oauth2/v2.0/token` | POST |
+
+### Controlled: Send Operations
+
+The Outlook preset allows POST to Graph API endpoints, which includes the send endpoint (`/me/sendMail`). To restrict sending further:
+
+1. **email-agent-mcp send allowlist** — configure which recipients the MCP server allows (empty by default — blocks all sends)
+2. **Custom NemoClaw policy** — create a custom policy that blocks the send endpoint entirely:
+   ```yaml
+   - host: graph.microsoft.com
+     port: 443
+     tls: true
+     methods: [GET, PATCH]  # POST removed — blocks send, create draft, move
+   ```
+
+For most deployments, the MCP allowlist is sufficient. The custom policy is for high-security environments where you want belt-and-suspenders.
+
+### Blocked: Everything Else
+
+Any endpoint not in the preset is blocked. This prevents:
+- Data exfiltration to unknown servers
+- Communication with unauthorized APIs
+- Prompt injection attacks that try to redirect requests
+
+## Layered Security Model
+
+Production email agents should use multiple layers:
+
+| Layer | What it controls | Tool |
+|-------|-----------------|------|
+| **Network policy** | Which endpoints the agent process can reach | NemoClaw |
+| **Send allowlist** | Which recipients the agent can email | email-agent-mcp config |
+| **Draft-first workflow** | User approves before any send | Agent skill / MCP design |
+| **Inbox rules security** | Block dangerous rule actions (forward, delete) | Agent skill / MCP validation |
+
+Each layer catches a different class of failure. No single layer is sufficient alone.
+
+## Verifying the Policy
+
+After applying the preset, verify it is active:
+
+```bash
+openshell policy list
+```
+
+Test that blocked endpoints are actually blocked:
+
+```bash
+# This should succeed (allowed endpoint)
+curl -s -o /dev/null -w "%{http_code}" https://graph.microsoft.com/v1.0/me
+
+# This should fail (blocked endpoint)
+curl -s -o /dev/null -w "%{http_code}" https://api.example.com/exfiltrate
+```
+
+## Troubleshooting
+
+### "Network request blocked" errors in the email MCP
+
+The policy is working correctly. Check which endpoint was blocked in the NemoClaw logs. Common causes:
+- The email MCP is trying to reach an endpoint not in the preset (e.g., a new Microsoft endpoint)
+- A third-party dependency is making an unexpected outbound call
+
+### OAuth token refresh fails
+
+Verify `login.microsoftonline.com` is in the allowed hosts. If using a custom policy instead of the preset, ensure both GET and POST are allowed for the login endpoint.
+
+### Calendar or Teams tools fail
+
+The Outlook preset covers core email and calendar endpoints. For Teams, add the Teams preset separately or merge the required endpoints into your policy.
+
+## Feedback
+
+If this skill helped, star us on GitHub: https://github.com/UseJunior/email-agent-mcp
+On ClawHub: `clawhub star stevenobiajulu/nemoclaw-email-policy`

--- a/skills/outlook-email/SKILL.md
+++ b/skills/outlook-email/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: outlook-email
+description: >-
+  Manage Outlook and Microsoft 365 email with AI agents — triage inbox by sender
+  trust, draft replies with tone matching, organize folders, create inbox rules,
+  and monitor for priority messages. Use when user says "check my email," "triage
+  inbox," "organize email," "email cleanup," "outlook folders," "inbox rules,"
+  "draft a reply," "email summary," "unread messages," "email heartbeat," or
+  "monitor my mailbox." Works with any Graph API client; optionally enhanced by
+  the open-source email-agent-mcp server.
+license: Apache-2.0
+homepage: https://github.com/UseJunior/email-agent-mcp
+compatibility: >-
+  Works with any agent or client that can call the Microsoft Graph API on
+  the user's behalf. Requires a Microsoft 365 OAuth delegated token with
+  the scopes listed below. The reference runtime (email-agent-mcp, open
+  source, Apache-2.0) uses MSAL device code flow, requires Node.js >=20,
+  and persists tokens in the OS keychain.
+requires:
+  credentials:
+    provider: microsoft-graph
+    auth: oauth2-delegated
+    reference_flow: oauth2-device-code (MSAL, via @azure/identity)
+    scopes_read_minimum:
+      - Mail.Read
+      - offline_access
+    scopes_write:
+      - Mail.ReadWrite
+      - MailboxSettings.ReadWrite
+    scopes_sensitive:
+      - Mail.Send
+    reference_runtime_scope_set:
+      - Mail.Read
+      - Mail.ReadWrite
+      - Mail.Send
+      - MailboxSettings.ReadWrite
+      - User.Read
+      - offline_access
+    token_storage: >-
+      Reference runtime (email-agent-mcp) stores OAuth tokens in the OS
+      keychain via MSAL with @azure/identity-cache-persistence. No raw
+      passwords, no plain text token files. Other clients should use their
+      platform's secure storage.
+  environment_variables:
+    - name: AGENT_EMAIL_CLIENT_ID
+      required: false
+      description: Override the default Microsoft App ID used for auth
+    - name: AGENT_EMAIL_SEND_ALLOWLIST
+      required: false
+      description: Path to JSON file listing recipients allowed for send_email (empty by default — blocks all sends)
+    - name: EMAIL_AGENT_MCP_HOME
+      required: false
+      description: Override default config and token storage directory (~/.email-agent-mcp)
+  network:
+    runtime:
+      - graph.microsoft.com
+      - login.microsoftonline.com
+  filesystem:
+    - draft markdown files (optional, client-dependent)
+  enforcement:
+    draft_first: layered
+  out_of_scope:
+    - calendar_integration
+metadata:
+  author: UseJunior
+  version: "0.1.6"
+---
+
+# Outlook Email Management
+
+> 使用 AI 代理管理 Outlook 邮件
+
+Patterns for AI agents working with Microsoft 365 / Outlook email. These patterns work with any Graph API client. For a turnkey MCP server with safety guardrails, see [email-agent-mcp](https://github.com/UseJunior/email-agent-mcp) (open source, Apache-2.0).
+
+## Safety Model
+> 安全模型
+
+**Draft-first is the recommended default for enterprise email.** Agents should never send email without explicit user approval.
+
+The workflow:
+
+1. **Compose** — create the email as a draft
+2. **Present** — show recipients, subject, and body to the user
+3. **Wait for approval** — only send when the user says "send," "send now," or equivalent
+4. **Clean up** — after confirming a send, archive stale duplicate drafts
+
+Why this matters: a single wrong send — wrong recipient, wrong attachment, confidential content to the wrong thread — can cause real damage. Drafts are free. Mistakes are expensive.
+
+**email-agent-mcp** enforces this via concrete runtime guardrails:
+
+- **Empty send allowlist by default** — agents cannot send email until the user explicitly configures allowed recipients
+- **Action-level blocks** on dangerous inbox rule actions: `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete` ([rules.ts:39](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39))
+- **`delete_email` disabled by default** unless the caller explicitly opts in with `user_explicitly_requested_deletion: true` ([label.ts](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts))
+
+**NemoClaw** can enforce it at the network policy level — see the [NemoClaw Email Policy skill](#related-skills).
+
+## Authentication & Required Scopes
+> 身份验证与所需权限
+
+This skill operates against Microsoft Graph and requires an OAuth 2.0 delegated access token for a Microsoft 365 account.
+
+### Minimum scopes by use case
+
+| Use case | Scopes required |
+|----------|----------------|
+| Read-only triage and summarization | `Mail.Read`, `offline_access` |
+| Create drafts and move email | + `Mail.ReadWrite` |
+| Create and delete inbox rules | + `MailboxSettings.ReadWrite` |
+| Send email directly (not draft-first) | + `Mail.Send` — **sensitive, see below** |
+
+`MailboxSettings.Read` alone is insufficient for rule management; Microsoft requires `MailboxSettings.ReadWrite` in practice to read some rule state. The reference runtime requests `MailboxSettings.ReadWrite` directly.
+
+### Reference runtime scope set (email-agent-mcp)
+
+The open-source reference runtime [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp) requests all six of the following scopes up front via MSAL device code flow:
+
+```
+Mail.Read
+Mail.ReadWrite
+Mail.Send
+MailboxSettings.ReadWrite
+User.Read
+offline_access
+```
+
+`User.Read` is requested by the reference runtime only — it is used by the CLI to fetch `/me` and persist the authenticated mailbox address to config. A generic Graph client does not need `User.Read` unless it performs the same profile lookup.
+
+Source: [`packages/provider-microsoft/src/auth.ts:14`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/provider-microsoft/src/auth.ts#L14)
+
+### Token storage
+
+The reference runtime stores OAuth tokens in the OS keychain (macOS Keychain / Windows Credential Manager / Linux libsecret) via MSAL with `@azure/identity-cache-persistence`. No raw passwords. No plain text token files. Refresh tokens are handled silently by MSAL.
+
+If using a different client, use your platform's secure secret storage. Do not store Graph tokens in `.env` files committed to repos.
+
+### Risk mapping — scopes to exfiltration risk
+
+| Scope | Enables | Risk if misused |
+|-------|---------|----------------|
+| `Mail.Read` | Read any message, attachment, and header | Read-only; no exfiltration beyond what the agent session can already see |
+| `Mail.ReadWrite` | Create drafts, move/copy messages, mark read | Low on its own; combined with `Mail.Send` enables outbound |
+| `MailboxSettings.ReadWrite` | Create and delete inbox rules | **HIGH** — malicious rules with `forwardTo`/`redirectTo` can exfiltrate mail silently even after the session ends |
+| `Mail.Send` | Send email from the user's account | **HIGH** — unauthorized outbound mail, impersonation risk |
+| `User.Read` | Read user profile basics (email, display name) | Low; metadata only |
+| `offline_access` | Refresh tokens without re-auth | Low on its own; extends the blast radius of any other scope if the token is stolen |
+
+The reference runtime mitigates the two HIGH-risk scopes with concrete controls — see the enforcement layers below.
+
+### Draft-first: layered enforcement
+
+Draft-first is the recommended workflow for all runtimes. Enforcement is layered — this skill describes the policy, and the runtime enforces it:
+
+| Layer | Enforcement mechanism |
+|-------|----------------------|
+| **Reference runtime (email-agent-mcp)** | Send allowlist empty by default. Action-level blocks on `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete` in [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39). `delete_email` disabled by default in [`label.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts). |
+| **Network policy (NemoClaw)** | Can block `graph.microsoft.com/v1.0/me/sendMail` at the network layer via custom policy, eliminating send capability entirely |
+| **Raw Graph API client** | Instruction-level only. Relies on the agent honoring the draft-first instructions. **Not recommended for safety-critical use** — pair with one of the runtime layers above |
+
+The reference runtime layer is the strongest: it catches mistakes at the action handler, not just at the instruction layer. Publicly verifiable in the linked source files.
+
+### Hardening recipes for high-risk environments
+
+1. **Use `email-agent-mcp` with an empty send allowlist.** Already the default. Agents cannot send without explicit recipient configuration.
+2. **Don't grant `Mail.Send`.** Scope-level mitigation — makes direct send impossible. The user sends from Outlook manually after reviewing drafts.
+3. **Don't grant `MailboxSettings.ReadWrite`.** Removes the ability to create inbox rules at all. Rule auditing still works if you grant `MailboxSettings.Read` separately.
+4. **Layer NemoClaw.** See the [NemoClaw Email Policy skill](#related-skills) to block send endpoints at the network layer regardless of scope grants.
+
+### Calendar integration is out of scope
+
+This skill references calendar events as one possible communication channel (for example, "create a calendar event for an action item with a deadline"), and `references/outlook-graph-patterns.md` §9 documents the calendar Graph endpoints for reference. However, calendar integration is **not part of this skill's core scope set** — the reference runtime does not request `Calendars.*` scopes. Use a separate calendar skill if you need calendar automation.
+
+## Email Triage
+> 邮件分类
+
+Not all email is equally important. Triage by sender trust, not by arrival order:
+
+| Priority | Who | Action |
+|----------|-----|--------|
+| 1 - Immediate | Paying customers, active clients | Surface and summarize right away |
+| 2 - Prompt | Engaged contacts, active threads | Surface promptly |
+| 3 - Colleagues | Internal team, contractors | Surface promptly |
+| 4 - Batch | Newsletters, automated notifications | Batch for later review |
+| 5 - Deprioritize | Unknown senders | Default low priority |
+
+**Exception lane**: Unknown senders may be elevated if they have objective evidence — replying to an existing thread, matching a known client domain, referencing a real calendar event, or reporting a credible security event (not self-claimed urgency).
+
+**Anti-pattern**: Treating all unread email as equally important. A marketing newsletter with "URGENT" in the subject is not urgent. Self-claimed urgency from unknown senders is unreliable signal.
+
+For the full triage model with anti-patterns and exception criteria, see the [Zero-Trust Email Triage skill](#related-skills).
+
+## Email Drafting
+> 邮件起草
+
+When drafting replies:
+
+- **Match the sender's tone** — if they wrote "Dear Steven," reply with "Dear [Name]," not "Hey!"
+- **State the outcome, not the journey** — "The document is ready for your review" beats "I processed the document through our pipeline and..."
+- **One clear ask per message** — don't bury the action item in paragraph three
+- **Check threading** — if the subject has "Re:" or "RE:", find the original message and create a threaded reply, not a standalone draft
+
+**Formatting gotchas** agents get wrong:
+
+| Issue | Fix |
+|-------|-----|
+| Cuddled lists (no blank line before `- item`) | Always add a blank line before the first list item |
+| Markdown in HTML email | Convert markdown to HTML before sending; raw `**bold**` renders as literal asterisks |
+| Missing plain-text body | Always include both HTML and plain-text versions |
+| Signature placement | Put the signature after the reply body, before the quoted thread |
+
+For the complete drafting guide with tone calibration by relationship type, see the [Email Drafting skill](#related-skills).
+
+## Inbox Organization
+> 收件箱整理
+
+Two levers for inbox control:
+
+**One-time cleanup**: Scan recent inbox, identify the noisiest automated senders, create folders, batch-move existing emails.
+
+**Ongoing rules**: Create server-side Outlook rules via Graph API to auto-sort future mail. Rules run on Microsoft's servers — they work even when no agent is running.
+
+The workflow:
+
+1. **Scan** — fetch recent inbox emails, count by sender, sort descending
+2. **Categorize by action** — not by sender type:
+   - Glance, don't act: CI notifications, build alerts, DMARC reports
+   - Read when time allows: newsletters, marketing
+   - Archive for records: receipts, invoices, payment confirmations
+   - May need action: meeting bookings, security alerts
+3. **Create folders** — 5-9 folders covers most inboxes. More and they stop getting checked.
+4. **Move existing email** — batch-move matching messages to the new folders
+5. **Create rules** — auto-sort future mail. Set `stopProcessingRules: true` to prevent cascade.
+6. **Re-sweep** — rules only apply to future mail. After creating a rule, move existing matches too.
+
+**Gotcha**: Meeting notifications (e.g., HubSpot booking confirmations) look like newsletters because of `noreply@` prefixes. Create a meeting-specific rule with a lower sequence number, or the generic newsletter rule will swallow them.
+
+For the full cleanup workflow with Graph API gotchas and battle-tested patterns, see the [Inbox Cleanup skill](#related-skills).
+
+## Email Heartbeat
+> 邮件心跳检查
+
+Three tiers of mailbox monitoring:
+
+| Tier | Frequency | What to check |
+|------|-----------|---------------|
+| **Light** | Every 15-30 min | Unread count from priority senders only |
+| **Deep** | Every 2-4 hours | Full triage pass — new unread from all senders, summarize by priority tier |
+| **Digest** | Daily | End-of-day summary — what came in, what was handled, what needs follow-up |
+
+**Light check pattern**:
+1. List unread emails from priority sender domains
+2. If any found, surface a one-line summary per email
+3. If none, stay silent — no "no new email" noise
+
+**Deep check pattern**:
+1. List all unread emails
+2. Classify by sender trust tier
+3. Summarize Tier 1-2 emails individually
+4. Batch Tier 3-5 into a count ("12 newsletters, 3 GitHub notifications")
+
+**Digest pattern**:
+1. List all emails received today
+2. Group by: handled (replied/read), needs follow-up, informational
+3. Highlight any Tier 1-2 emails that haven't been responded to
+
+## Communicating Results to the User
+
+Different users prefer different channels for email updates:
+
+| Channel | When to use |
+|---------|------------|
+| **Chat interface** | Default. Summarize inline in the conversation. |
+| **Text message** | If the user prefers distilled updates via messaging. Provide copy-paste text with phone number if no SMS tool is available. |
+| **Calendar event** | For action items with deadlines — create an event instead of a reminder email. |
+| **Summary email** | Only if explicitly requested. Be aware this adds to inbox clutter. |
+
+Ask on first use — don't assume the user wants email summaries delivered by email.
+
+## Gotchas That Will Bite You
+> 常见陷阱
+
+**Graph API `$search` cannot combine `from:` + `to:` KQL prefixes** — you get a 400 Syntax error. Use `$filter` instead when combining sender and recipient filters.
+
+**`$select` does not work on PATCH requests** — returns 400 "OData request not supported." Only use `$select` on GET.
+
+**Move is a POST, not a PATCH** — `POST /me/messages/{id}/move` with `{"destinationId": "<folder-id>"}`.
+
+**Self-sent emails** are best found by listing `sentitems`, not searching inbox.
+
+**Root-only folder listing** — `GET /me/mailFolders` returns only root-level folders. Child folders require recursive traversal via `/mailFolders/{id}/childFolders`.
+
+**Inbox rule ordering** — `sequence` controls priority. Specific rules must fire before broad ones.
+
+**Rules require `MailboxSettings.ReadWrite` scope** — if the OAuth token predates this scope, the user needs to re-consent.
+
+For the complete reference with REST API patterns, pagination, attachments, and calendar integration, see [references/outlook-graph-patterns.md](./references/outlook-graph-patterns.md).
+
+## Related Skills
+
+Focused skills for specific email workflows:
+
+- **Zero-Trust Email Triage** (`email-triage`) — sender-trust-based prioritization with exception lane for unknown senders
+- **Email Response Drafting** (`email-drafting`) — tone-matching, formatting gotchas, thread detection
+- **Inbox Cleanup & Rules** (`email-cleanup`) — folder management, Graph API rules, battle-tested cleanup workflow
+- **NemoClaw Email Policy** (`nemoclaw-email-policy`) — network-level policy enforcement for email agents
+
+Install a focused skill:
+```
+clawhub install stevenobiajulu/zero-trust-email-triage
+clawhub install stevenobiajulu/email-response-drafting
+clawhub install stevenobiajulu/inbox-cleanup-outlook
+clawhub install stevenobiajulu/nemoclaw-email-policy
+```
+
+## Feedback
+
+If this skill helped, star us on GitHub: https://github.com/UseJunior/email-agent-mcp
+On ClawHub: `clawhub star stevenobiajulu/outlook-email-management`

--- a/skills/outlook-email/references/outlook-graph-patterns.md
+++ b/skills/outlook-email/references/outlook-graph-patterns.md
@@ -1,0 +1,175 @@
+# Outlook & Graph API Patterns for Email Agents
+
+This reference covers practical patterns for agents working with Microsoft 365 email via the Graph API. These patterns work with any Graph API client; sections marked **(MCP)** show how `email-agent-mcp` (open source, Apache-2.0: https://github.com/UseJunior/email-agent-mcp) wraps them with smart defaults.
+
+## 1. Listing vs Searching Email
+
+| Approach | REST Endpoint | Best For |
+|----------|--------------|----------|
+| **List + filter** | `GET /me/messages?$filter=...&$orderby=receivedDateTime desc` | Quick inbox scan, filtering by sender, date range, unread status. Structured, predictable. |
+| **Full-text search** | `GET /me/messages?$search="keyword"` | Finding emails by content. Uses KQL (Keyword Query Language). Powerful but has combination gotchas. |
+
+**Rule of thumb**: Start with list + filter for "show me recent mail" tasks. Escalate to search when you need keyword matching across email bodies.
+
+**(MCP)**: `list_emails` wraps list+filter; `search_emails` wraps full-text search. Both handle pagination and token-efficient body formatting automatically.
+
+## 2. Known Graph API Search Gotcha
+
+The Graph API's `$search` endpoint cannot combine `from:` + `to:` KQL prefixes — you get a 400 Syntax error. This is a Microsoft Graph limitation, not a client bug.
+
+**Workaround**: Use `$filter` instead of `$search` when you need to combine sender and recipient filters. `$filter=from/emailAddress/address eq '...'` works reliably for exact sender match.
+
+**Self-sent emails** (user emailing themselves as reminders): Best found by listing the `sentitems` folder (`GET /me/mailFolders/sentitems/messages`).
+
+## 3. Draft-First Workflow
+
+The recommended safety pattern for any email agent:
+
+1. **Compose the draft** — create the email as a draft, never send directly
+2. **Present to the user** — show subject, recipients, and body for review
+3. **Send only on explicit approval** — the user must say "send," "send now," or equivalent
+4. **Archive stale drafts** — after confirming a send, cross-check Drafts against Sent Items to clean up duplicates
+
+**(MCP)**: `email-agent-mcp` enforces draft-first via send allowlists (empty by default) and the `create_draft` → `send_draft` two-step flow.
+
+### Reply Thread Detection
+
+Before creating any draft with "Re:" or "RE:" in the subject:
+
+1. Search inbox for the original message (by sender + subject keywords)
+2. Get the original message ID
+3. Create the draft as a reply to that message ID
+
+A standalone draft that should be a reply breaks conversation threading in the recipient's inbox. If the original message cannot be found, flag it to the user rather than silently creating a standalone draft.
+
+**(MCP)**: `reply_to_email` handles threading automatically via RFC message-ID headers.
+
+## 4. Token Efficiency
+
+Email bodies can be enormous (HTML newsletters, forwarded chains). Control token consumption:
+
+| Lever | Effect |
+|-------|--------|
+| Request markdown format | Converts HTML to markdown, dramatically reducing tokens vs raw HTML |
+| Request only needed fields | e.g., subject, sender, date for triage — skip body entirely |
+| Cap body length | Limit to ~4000 chars for initial reads |
+| Use preview mode | Lightweight body fetch; escalate to full only when needed |
+
+**Triage pattern**: First pass — list emails without bodies. Second pass — preview bodies on the important ones. Full read only when needed.
+
+**(MCP)**: `list_emails` supports a `fields` parameter; `read_email` supports `body_format: "markdown"` and `body_max_chars`.
+
+## 5. Pagination
+
+Both listing and searching return paginated results. When processing large inboxes:
+
+- Use the cursor/nextLink from each response to get the next page
+- Process in batches to stay within context limits — don't fetch all pages upfront
+- For large-scale operations (cleanup, migration), paginate with a page size of 50
+
+**(MCP)**: `list_emails` returns a `cursor` field for continuation. `search_emails` handles `@odata.nextLink` internally.
+
+## 6. Folder Awareness
+
+Common Outlook folders:
+
+| Folder | Well-known name | Use |
+|--------|----------------|-----|
+| Inbox | `inbox` | Default for listing/searching |
+| Sent Items | `sentitems` | Check what was already sent, find self-emails |
+| Drafts | `drafts` | Manage draft lifecycle |
+| Archive | `archive` | Archived mail |
+| Junk Email | `junkemail` | Spam review |
+
+Custom folders require name-to-ID resolution. Use `$filter=displayName eq '{name}'` on `/me/mailFolders` to resolve.
+
+**Gotcha**: `GET /me/mailFolders?$top=100` returns only root-level folders. Child folders require recursive traversal via `/mailFolders/{id}/childFolders`.
+
+## 7. Folder Management
+
+| Operation | REST API | Notes |
+|-----------|----------|-------|
+| List folders | `GET /me/mailFolders?$top=100` | Root only; recurse childFolders for nested |
+| Create folder | `POST /me/mailFolders` with `{"displayName": "..."}` | Optionally under a parent: `POST /me/mailFolders/{parentId}/childFolders` |
+| Move email | `POST /me/messages/{id}/move` with `{"destinationId": "<folder-id>"}` | POST, not PATCH |
+| Delete folder | `DELETE /me/mailFolders/{id}` | Rejects system folders (inbox, sentitems, etc.) |
+
+**Gotchas**:
+- `$select` does NOT work on PATCH requests — returns 400. Only use `$select` on GET.
+- The `move` endpoint is a POST, not a PATCH.
+- Outlook uppercases `senderContains` values in storage — this is cosmetic, matching is case-insensitive.
+
+**(MCP)**: `list_folders`, `create_folder`, `move_to_folder`, and `delete_folder` tools handle ID resolution and pagination automatically.
+
+## 8. Inbox Rules
+
+Server-side rules that run on Microsoft's servers (not client-side):
+
+| Operation | REST API |
+|-----------|----------|
+| List rules | `GET /me/mailFolders/inbox/messageRules` |
+| Create rule | `POST /me/mailFolders/inbox/messageRules` |
+| Delete rule | `DELETE /me/mailFolders/inbox/messageRules/{id}` |
+
+### Rule Security Model
+
+**High-risk actions (block or gate):**
+- `forwardTo`, `forwardAsAttachmentTo`, `redirectTo` — could exfiltrate email
+- `delete`, `permanentDelete` — data loss
+
+**Safe actions:**
+- `moveToFolder` — move to a folder ID
+- `copyToFolder` — copy to a folder ID
+- `markAsRead` — mark as read
+- `markImportance` — set importance level
+- `stopProcessingRules` — prevent cascade to later rules
+
+### Common Conditions
+
+- `fromAddresses` — match by sender email
+- `subjectContains` — match words in subject
+- `senderContains` — partial sender match
+- `headerContains` — match email headers
+
+### Rule Ordering
+
+The `sequence` field controls priority. Specific rules (e.g., meeting booking notifications) must fire before broad rules (e.g., any `noreply@` sender). Always set `stopProcessingRules: true` to prevent cascade.
+
+**Auth scope**: Rules require `MailboxSettings.ReadWrite`. If the OAuth token was issued before this scope was added, the user needs to re-consent.
+
+**(MCP)**: `list_inbox_rules`, `create_inbox_rule`, and `delete_inbox_rule` tools validate conditions and block dangerous actions.
+
+## 9. Calendar Integration
+
+When an email requires scheduling a meeting:
+
+| Operation | REST API |
+|-----------|----------|
+| Find free time | `POST /me/calendar/getSchedule` |
+| Create event | `POST /me/events` |
+
+Default timezone to `America/New_York` unless the user specifies otherwise. Common recurrence patterns: `weekly`, `daily`, `monthly on day 15`, `every 2 weeks`.
+
+**(MCP)**: `find_free_time` and `add_calendar_event` tools wrap these endpoints.
+
+## 10. Attachments
+
+- **Reading**: `GET /me/messages/{id}/attachments` returns attachment metadata and content
+- **Drafting with attachments**: Include file paths in the draft; the MCP or API call handles upload
+- **Size limits**: Graph API accepts up to 4MB inline; larger files require an upload session
+
+## 11. Composing Drafts via REST
+
+`POST /me/messages` creates a draft. Include `toRecipients`, `subject`, `body` (with `contentType: "HTML"` or `"Text"`), and optionally `attachments`.
+
+For replies, use `POST /me/messages/{id}/createReply` to maintain threading. This preserves the conversation ID and In-Reply-To headers.
+
+Whether using REST or MCP, always create a draft first and let the user review before sending.
+
+## 12. Frontmatter Auto-Enrichment
+
+When using file-based draft workflows, the MCP auto-appends `draft_id` and `draft_link` to the file's YAML frontmatter after saving to Outlook. Agents should:
+
+- NOT pre-populate `draft_id` or `draft_link` — these are write-back fields
+- Expect the file to be mutated after the save call
+- Use `draft_link` to give the user a clickable URL to review in Outlook web


### PR DESCRIPTION
## Summary
- Adds 5 SKILL.md-based skills to the `skills/` directory: email-cleanup, email-drafting, email-triage, nemoclaw-email-policy, and outlook-email
- Enables `skills.sh` to auto-discover these skills from GitHub (they exist in the repo so the discovery script can find them)
- Skills are already live on ClawHub and Smithery (published via CLI upload from this same local directory), but were not yet committed to GitHub

## Why
`skills.sh` discovers skills by scanning GitHub repositories for `skills/*/SKILL.md` files. Without these files committed, the 5 email skills we've published elsewhere (ClawHub, Smithery) are invisible to that discovery path. This PR closes that gap.

## What's included
- `skills/email-cleanup/SKILL.md` — inbox organization, folders, batch moves, inbox rules
- `skills/email-drafting/SKILL.md` — compose and save drafts
- `skills/email-triage/SKILL.md` — prioritize and classify incoming mail
- `skills/nemoclaw-email-policy/SKILL.md` — policy guardrails for email handling
- `skills/outlook-email/SKILL.md` + `references/outlook-graph-patterns.md` — Microsoft Graph patterns

Each SKILL.md has proper YAML frontmatter (name, description, license, compatibility, requires) so downstream loaders can parse them.

## Test plan
- [ ] Verify `skills.sh` discovers all 5 skills from the GitHub repo after merge
- [ ] Confirm SKILL.md frontmatter parses cleanly in downstream tools
- [ ] Spot-check that the committed content matches what's already live on ClawHub / Smithery