### PR TITLE
feat(email): attachments, reply_all, frontmatter back-link + fix reply-all allowlist bypass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,109 @@ Use `@/openspec/AGENTS.md` to learn:
 - Zod v4 schemas as single source of truth for tool input validation
 - Tests: Vitest with spec traceability
 - Logging: ALWAYS to stderr, NEVER stdout (corrupts MCP stdio transport)
+
+## Draft & Reply Tools — extended flags
+
+`create_draft` and `reply_to_email` support three extra behaviors beyond
+simple body+recipients. These are driven by parameters on the MCP tool
+call (and, for `create_draft`, also by YAML frontmatter in a `body_file`).
+
+### `attachments` — outbound file attachments
+
+Pass an array of file paths. Paths are resolved against the directory
+pointed to by the environment variable `EMAIL_AGENT_MCP_ATTACHMENT_DIR`,
+which **must be set, absolute, and refer to an existing directory**.
+Paths outside that sandbox — including sibling-prefix attacks like
+`/allowed-evil/x.pdf` when the base is `/allowed`, and symlink escapes —
+are rejected via realpath-based `path.relative()` checks.
+
+- **Size cap:** 3 MiB per file. Zero-byte files are allowed.
+- **Dedupe:** multiple paths that resolve to the same realpath (via
+  symlinks or relative/absolute duplication) become a single attachment.
+- **Filename collisions:** if two different files share a basename, the
+  second gets `(2)` inserted before the extension (`report.pdf` →
+  `report (2).pdf`), matching native-client behavior.
+- **`body_file` frontmatter:** if `body_file` lists `attachments:` in
+  its frontmatter, those paths are unioned with the parameter list
+  (dedup by realpath). Attachments are the one field where frontmatter
+  and parameter values are additive rather than frontmatter-wins.
+- **Rollback:** on Microsoft, attachments are uploaded via follow-up
+  `POST /messages/{id}/attachments`. If any upload fails, the draft is
+  `DELETE`d so there's no half-attached draft in the user's mailbox.
+  If the cleanup DELETE also fails, the orphaned draftId is logged to
+  stderr.
+- **Gmail:** outbound attachments return `NOT_SUPPORTED` — Gmail's
+  `buildRawMessage` doesn't yet emit `multipart/mixed`. Documented
+  follow-up.
+
+### `reply_all` — sender-only vs reply-all
+
+Default `true` (reply to all original recipients, matching the historical
+behavior of Microsoft's `createReplyAll`). Set to `false` to narrow to
+the original sender only.
+
+- **Microsoft:** switches between `POST /messages/{id}/createReplyAll`
+  and `POST /messages/{id}/createReply` endpoints.
+- **Gmail:** when `replyAll=false`, skips the `mergeAddressLists(to, cc)`
+  auto-population; when `replyAll=true`, includes original `to + cc` in
+  the outgoing `Cc` header.
+- **Reply-all send path goes through a draft.** `reply_to_email` (send
+  mode) creates a draft server-side, fetches the populated recipients,
+  allowlist-checks them, and only then calls `sendDraft`. This closes
+  a bypass where the old code only checked `from.email` while Graph's
+  `createReplyAll` silently cc'd every original recipient.
+- **`create_draft(reply_to=...)` validation:** `to` and `subject` are
+  NOT required when creating a reply draft — the provider auto-
+  populates them from the original thread. They are still required
+  when `reply_all=false` (you must explicitly name the narrowed
+  recipient).
+
+### `update_source_frontmatter` — back-link the draft into your .md file
+
+Opt-in flag (default `false`) on `create_draft`. When `true` AND
+`body_file` is set AND draft creation succeeds, the tool patches the
+source Markdown file's frontmatter with:
+
+- `draft_id: <id>` and `draft_link: <outlook-deep-link>` for standard
+  drafts
+- `draft_reply_id: <id>` and `draft_reply_link: <outlook-deep-link>`
+  for reply drafts (matches `save_draft_to_outlook.py` convention)
+
+The Outlook deep link is
+`https://outlook.office.com/mail/deeplink/compose?ItemID=<urlencoded-draftId>`.
+
+This is **silent-fail**: if the write fails (read-only file, unsupported
+multiline YAML, missing closing `---`), the helper logs to stderr and
+returns — the draft was already created, and the back-link is a
+convenience metadata patch, not a delivery guarantee.
+
+### Worked example
+
+```yaml
+# weekly-status.md
+---
+reply_to: AAMkAGI2TG93AAA=
+reply_all: false
+attachments: q1-report.pdf
+---
+
+Here's the quarterly rollup — let me know if anything looks off.
+```
+
+```json
+// MCP tool call
+{
+  "tool": "create_draft",
+  "arguments": {
+    "body_file": "weekly-status.md",
+    "attachments": ["q2-addendum.pdf"],
+    "update_source_frontmatter": true
+  }
+}
+```
+
+This creates a reply draft to the sender of message `AAMkAGI2TG93AAA=`
+only (no cc), with both `q1-report.pdf` and `q2-addendum.pdf` attached
+(merged from frontmatter + parameter), then writes `draft_reply_id`
+and `draft_reply_link` back into `weekly-status.md` so you can reopen
+the draft in Outlook from the source file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -817,6 +817,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.5.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -4100,10 +4107,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "^18.0.0",
+        "mime-types": "^3.0.1",
         "node-html-markdown": "^2.0.0",
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@types/mime-types": "^3.0.0",
         "@types/node": "^25.5.0",
         "@vitest/coverage-v8": "^4.0.0",
         "typescript": "^5.4.0",

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -20,10 +20,12 @@
   },
   "dependencies": {
     "marked": "^18.0.0",
+    "mime-types": "^3.0.1",
     "node-html-markdown": "^2.0.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@types/mime-types": "^3.0.0",
     "@types/node": "^25.5.0",
     "@vitest/coverage-v8": "^4.0.0",
     "typescript": "^5.4.0",

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -39,6 +39,13 @@ export interface ComposeFields {
   draft?: boolean;
   format?: BodyFormat;
   forceBlack?: boolean;
+  /**
+   * Merged attachments list: frontmatter values followed by parameter values,
+   * preserving order. Dedup by resolved realpath happens later in
+   * resolveAttachments.
+   */
+  attachments?: string[];
+  replyAll?: boolean;
   error?: ActionError;
 }
 
@@ -46,6 +53,12 @@ export interface ComposeFields {
  * Resolve body content from body/body_file and merge frontmatter.
  * Stays narrow: body resolution + frontmatter merge only.
  * Does NOT do required-field validation or mode branching.
+ *
+ * Precedence: frontmatter is authoritative for all scalar fields. The one
+ * exception is `attachments`, which is ADDITIVE — frontmatter attachments
+ * plus parameter attachments are unioned (dedup happens later in
+ * attachment-loader). This lets users set defaults in the body_file and
+ * still add one-off attachments from the tool call.
  *
  * For update_draft where body is optional, pass `bodyOptional: true`.
  */
@@ -60,6 +73,8 @@ export async function resolveComposeFields(
     draft?: boolean;
     format?: BodyFormat;
     force_black?: boolean;
+    attachments?: string[];
+    reply_all?: boolean;
   },
   safeDir?: string,
   opts?: { bodyOptional?: boolean },
@@ -72,6 +87,8 @@ export async function resolveComposeFields(
   let draft = input.draft;
   let format = input.format;
   let forceBlack = input.force_black;
+  let replyAll = input.reply_all;
+  const attachmentPaths: string[] = [];
 
   if (input.body_file) {
     const bodyResult = await resolveBodyFile(input.body_file, safeDir);
@@ -80,7 +97,7 @@ export async function resolveComposeFields(
     }
     body = bodyResult.content!;
 
-    // Frontmatter is authoritative
+    // Frontmatter is authoritative for scalars; attachments union below.
     if (bodyResult.frontmatter) {
       const fm = bodyResult.frontmatter;
       if (fm.to !== undefined) to = fm.to;
@@ -90,6 +107,8 @@ export async function resolveComposeFields(
       if (fm.draft !== undefined) draft = fm.draft;
       if (fm.format !== undefined) format = fm.format;
       if (fm.force_black !== undefined) forceBlack = fm.force_black;
+      if (fm.reply_all !== undefined) replyAll = fm.reply_all;
+      if (fm.attachments) attachmentPaths.push(...fm.attachments);
     }
   } else if (input.body) {
     body = input.body;
@@ -100,7 +119,22 @@ export async function resolveComposeFields(
     };
   }
 
-  return { body: body ?? '', to, cc, subject, replyTo, draft, format, forceBlack };
+  if (input.attachments?.length) {
+    attachmentPaths.push(...input.attachments);
+  }
+
+  return {
+    body: body ?? '',
+    to,
+    cc,
+    subject,
+    replyTo,
+    draft,
+    format,
+    forceBlack,
+    attachments: attachmentPaths.length > 0 ? attachmentPaths : undefined,
+    replyAll,
+  };
 }
 
 // --- validateRequiredFields ---

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -141,6 +141,61 @@ Body from file.`);
     expect(result.success).toBe(false);
     expect(result.error!.code).toBe('MAILBOX_REQUIRED');
   });
+
+  it('Scenario: reply_to with no to/subject succeeds (relaxed validation)', async () => {
+    provider.addMessage({
+      id: 'orig-no-fields',
+      subject: 'Original thread',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'orig-no-fields',
+      body: 'Just the body',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.draftId).toBeDefined();
+  });
+
+  it('Scenario: reply_to with reply_all=false and no to fails with MISSING_FIELD', async () => {
+    provider.addMessage({
+      id: 'orig-narrow',
+      subject: 'Narrow me',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'orig-narrow',
+      reply_all: false,
+      body: 'Private',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('MISSING_FIELD');
+    expect(result.error!.message).toContain('reply_all=false');
+  });
+
+  it('Scenario: createDraft preserves cc (regression for dropped cc bug)', async () => {
+    const result = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      cc: ['bob@allowed.com', 'carol@allowed.com'],
+      subject: 'With CC',
+      body: 'Body',
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.cc?.map(a => a.email)).toEqual(['bob@allowed.com', 'carol@allowed.com']);
+  });
 });
 
 describe('email-write/Send Draft', () => {

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { writeFile, mkdir } from 'node:fs/promises';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFile, mkdir, rm, mkdtemp } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { createDraftAction, sendDraftAction, updateDraftAction } from './draft.js';
+import { ATTACHMENT_DIR_ENV } from '../content/attachment-loader.js';
 import type { ActionContext } from './registry.js';
 
 let provider: MockEmailProvider;
@@ -366,5 +367,134 @@ describe('email-write/Body Rendering', () => {
     const draft = [...provider.getDrafts().values()][0]!;
     expect(draft.body).toBe('### Not a header');
     expect(draft.bodyHtml).toBeUndefined();
+  });
+});
+
+describe('email-write/Create Draft — attachments (plan §2.1)', () => {
+  let attachDir: string;
+  const savedEnv = process.env[ATTACHMENT_DIR_ENV];
+
+  beforeEach(async () => {
+    attachDir = await mkdtemp(join(tmpdir(), 'draft-attach-test-'));
+    process.env[ATTACHMENT_DIR_ENV] = attachDir;
+  });
+
+  afterEach(async () => {
+    if (savedEnv === undefined) {
+      delete process.env[ATTACHMENT_DIR_ENV];
+    } else {
+      process.env[ATTACHMENT_DIR_ENV] = savedEnv;
+    }
+    await rm(attachDir, { recursive: true, force: true });
+  });
+
+  it('Scenario: create_draft with one attachment stores it on the mock draft', async () => {
+    await writeFile(join(attachDir, 'report.pdf'), 'pdf bytes');
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'With attachment',
+      body: 'See attached',
+      attachments: ['report.pdf'],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.attachments).toHaveLength(1);
+    expect(draft.attachments![0]!.filename).toBe('report.pdf');
+    expect(draft.attachments![0]!.content.toString('utf-8')).toBe('pdf bytes');
+  });
+
+  it('Scenario: create_draft with oversized attachment fails', async () => {
+    await writeFile(join(attachDir, 'big.bin'), Buffer.alloc(3 * 1024 * 1024 + 1, 0x41));
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Too big',
+      body: 'nope',
+      attachments: ['big.bin'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ATTACHMENT_TOO_LARGE');
+    expect(provider.getDrafts().size).toBe(0);
+  });
+
+  it('Scenario: create_draft with attachment but env var unset fails', async () => {
+    delete process.env[ATTACHMENT_DIR_ENV];
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'No dir',
+      body: 'nope',
+      attachments: ['report.pdf'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ATTACHMENT_DIR_NOT_CONFIGURED');
+  });
+
+  it('Scenario: create_draft with frontmatter + param attachments merges both', async () => {
+    await writeFile(join(attachDir, 'from-fm.txt'), 'fm');
+    await writeFile(join(attachDir, 'from-param.txt'), 'param');
+    // Frontmatter attachments are a comma-separated list
+    await writeFile(join(testDir, 'draft.md'), `---
+to: alice@allowed.com
+subject: Merged
+attachments: from-fm.txt
+---
+Body`);
+
+    const result = await createDraftAction.run(ctx, {
+      body_file: 'draft.md',
+      attachments: ['from-param.txt'],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.attachments).toHaveLength(2);
+    expect(draft.attachments!.map(a => a.filename)).toEqual(['from-fm.txt', 'from-param.txt']);
+  });
+
+  it('Scenario: two same-basename attachments get disambiguated filenames', async () => {
+    await mkdir(join(attachDir, 'a'));
+    await mkdir(join(attachDir, 'b'));
+    await writeFile(join(attachDir, 'a', 'report.pdf'), 'first');
+    await writeFile(join(attachDir, 'b', 'report.pdf'), 'second');
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Two reports',
+      body: 'See attached',
+      attachments: ['a/report.pdf', 'b/report.pdf'],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.attachments!.map(a => a.filename)).toEqual(['report.pdf', 'report (2).pdf']);
+  });
+
+  it('Scenario: reply draft attachments flow through to mock (via opts.attachments)', async () => {
+    provider.addMessage({
+      id: 'thread-att',
+      subject: 'Thread',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+    await writeFile(join(attachDir, 'doc.pdf'), 'bytes');
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'thread-att',
+      body: 'Response',
+      attachments: ['doc.pdf'],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.attachments).toHaveLength(1);
+    expect(draft.attachments![0]!.filename).toBe('doc.pdf');
   });
 });

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -163,6 +163,35 @@ Body from file.`);
     expect(result.draftId).toBeDefined();
   });
 
+  it('Scenario: frontmatter reply_all=false overrides default', async () => {
+    provider.addMessage({
+      id: 'orig-fm-replyall',
+      subject: 'Original',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      cc: [{ email: 'other@allowed.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+    await writeFile(join(testDir, 'fm-reply.md'), `---
+reply_to: orig-fm-replyall
+reply_all: false
+to: partner@allowed.com
+---
+Private response`);
+
+    const result = await createDraftAction.run(ctx, {
+      body_file: 'fm-reply.md',
+    });
+
+    expect(result.success).toBe(true);
+    // Mock's createReplyDraft gets replyAll=false and should NOT populate
+    // cc from original.to + original.cc
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.cc ?? []).toHaveLength(0);
+  });
+
   it('Scenario: reply_to with reply_all=false and no to fails with MISSING_FIELD', async () => {
     provider.addMessage({
       id: 'orig-narrow',
@@ -496,5 +525,101 @@ Body`);
     const draft = [...provider.getDrafts().values()][0]!;
     expect(draft.attachments).toHaveLength(1);
     expect(draft.attachments![0]!.filename).toBe('doc.pdf');
+  });
+});
+
+describe('email-write/Create Draft — update_source_frontmatter (plan §2.3)', () => {
+  it('Scenario: standard draft with update_source_frontmatter=true writes draft_id + draft_link', async () => {
+    const src = join(testDir, 'source.md');
+    await writeFile(src, `---
+to: alice@allowed.com
+subject: Write back
+---
+Body`);
+
+    const result = await createDraftAction.run(ctx, {
+      body_file: 'source.md',
+      update_source_frontmatter: true,
+    });
+
+    expect(result.success).toBe(true);
+    const updated = await import('node:fs/promises').then(m => m.readFile(src, 'utf-8'));
+    expect(updated).toContain(`draft_id: ${result.draftId}`);
+    expect(updated).toContain(`draft_link: https://outlook.office.com/mail/deeplink/compose?ItemID=${encodeURIComponent(result.draftId!)}`);
+    // Existing keys preserved
+    expect(updated).toContain('to: alice@allowed.com');
+    expect(updated).toContain('Body');
+  });
+
+  it('Scenario: reply draft writes draft_reply_id + draft_reply_link (reply-specific keys)', async () => {
+    provider.addMessage({
+      id: 'thread-writeback',
+      subject: 'Original',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const src = join(testDir, 'reply.md');
+    await writeFile(src, `---
+reply_to: thread-writeback
+---
+Reply body`);
+
+    const result = await createDraftAction.run(ctx, {
+      body_file: 'reply.md',
+      update_source_frontmatter: true,
+    });
+
+    expect(result.success).toBe(true);
+    const updated = await import('node:fs/promises').then(m => m.readFile(src, 'utf-8'));
+    expect(updated).toContain(`draft_reply_id: ${result.draftId}`);
+    expect(updated).toContain('draft_reply_link: https://outlook.office.com');
+    expect(updated).not.toContain('draft_id:');
+  });
+
+  it('Scenario: default (update_source_frontmatter=false) leaves source byte-exact', async () => {
+    const src = join(testDir, 'unchanged.md');
+    const original = `---
+to: alice@allowed.com
+subject: Leave me alone
+---
+Body here
+`;
+    await writeFile(src, original);
+
+    const result = await createDraftAction.run(ctx, {
+      body_file: 'unchanged.md',
+    });
+
+    expect(result.success).toBe(true);
+    const { readFile: rf } = await import('node:fs/promises');
+    const after = await rf(src, 'utf-8');
+    expect(after).toBe(original);
+  });
+
+  it('Scenario: write failure does not abort the draft (silent fail)', async () => {
+    const src = join(testDir, 'readonly.md');
+    await writeFile(src, `---
+to: alice@allowed.com
+subject: Silent fail
+---
+Body`);
+    const { chmod } = await import('node:fs/promises');
+    await chmod(src, 0o444);
+
+    try {
+      const result = await createDraftAction.run(ctx, {
+        body_file: 'readonly.md',
+        update_source_frontmatter: true,
+      });
+      // Draft still succeeds even though the frontmatter patch failed
+      expect(result.success).toBe(true);
+      expect(result.draftId).toBeDefined();
+    } finally {
+      await chmod(src, 0o644).catch(() => {});
+    }
   });
 });

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -7,6 +7,8 @@ import { withRetry } from '../providers/provider.js';
 import { truncateBody, BODY_SIZE_LIMIT } from '../content/body-loader.js';
 import { renderEmailBody } from '../content/body-renderer.js';
 import { resolveAttachments } from '../content/attachment-loader.js';
+import { patchFrontmatter } from '../content/frontmatter-writer.js';
+import { resolve as resolvePath } from 'node:path';
 import {
   checkMailboxRequired,
   resolveComposeFields,
@@ -40,6 +42,8 @@ const CreateDraftInput = z.object({
     .describe('For reply drafts (reply_to set): reply to all original recipients (default) or only the sender. Ignored for non-reply drafts.'),
   attachments: z.array(z.string()).optional()
     .describe('File paths to attach. Paths are resolved against EMAIL_AGENT_MCP_ATTACHMENT_DIR (must be set). 3 MiB max per file. Merged additively with any attachments listed in body_file frontmatter.'),
+  update_source_frontmatter: z.boolean().optional().default(false)
+    .describe('When true AND body_file is set AND draft creation succeeds, patch the source .md file frontmatter with draft_id + draft_link (or draft_reply_id + draft_reply_link for reply drafts). Silent-fail: does not abort the draft if the write fails.'),
   mailbox: z.string().optional(),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
@@ -149,6 +153,9 @@ export const createDraftAction: EmailAction<
           replyAll: effectiveReplyAll,
           attachments: resolvedAttachments,
         });
+        if (result.success && result.draftId && input.update_source_frontmatter && input.body_file) {
+          await writeDraftBackLink(input.body_file, result.draftId, true, ctx.safeDir);
+        }
         return {
           success: result.success,
           draftId: result.draftId,
@@ -169,6 +176,9 @@ export const createDraftAction: EmailAction<
         bodyHtml: outBodyHtml,
         attachments: resolvedAttachments,
       });
+      if (result.success && result.draftId && input.update_source_frontmatter && input.body_file) {
+        await writeDraftBackLink(input.body_file, result.draftId, false, ctx.safeDir);
+      }
       return {
         success: result.success,
         draftId: result.draftId,
@@ -179,6 +189,33 @@ export const createDraftAction: EmailAction<
     }
   },
 };
+
+/**
+ * Patch the source body_file with draft_id + draft_link (or draft_reply_*)
+ * so the human author can navigate from their markdown back to the created
+ * draft in Outlook. Silent-fails: on any error, logs to stderr and returns.
+ * Never throws — the draft was already created successfully.
+ */
+async function writeDraftBackLink(
+  bodyFile: string,
+  draftId: string,
+  isReply: boolean,
+  safeDir: string | undefined,
+): Promise<void> {
+  const baseDir = safeDir ?? process.cwd();
+  const absolute = resolvePath(baseDir, bodyFile);
+  const outlookLink = `https://outlook.office.com/mail/deeplink/compose?ItemID=${encodeURIComponent(draftId)}`;
+  const updates: Record<string, string> = isReply
+    ? { draft_reply_id: draftId, draft_reply_link: outlookLink }
+    : { draft_id: draftId, draft_link: outlookLink };
+
+  const result = await patchFrontmatter(absolute, updates);
+  if (!result.ok) {
+    process.stderr.write(
+      `[email-agent-mcp] create_draft: update_source_frontmatter failed for ${bodyFile}: ${result.reason ?? 'unknown'}\n`,
+    );
+  }
+}
 
 // --- send_draft ---
 

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -35,6 +35,8 @@ const CreateDraftInput = z.object({
   body: z.string().optional(),
   body_file: z.string().optional(),
   reply_to: z.string().optional(),
+  reply_all: z.boolean().optional().default(true)
+    .describe('For reply drafts (reply_to set): reply to all original recipients (default) or only the sender. Ignored for non-reply drafts.'),
   mailbox: z.string().optional(),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
@@ -67,20 +69,39 @@ export const createDraftAction: EmailAction<
     const { to, cc, subject, replyTo, format, forceBlack } = fields;
     let { body } = fields;
 
-    // Validate required fields
-    const requiredError = validateRequiredFields(to, subject);
-    if (requiredError) {
-      return { success: false, error: requiredError };
+    // Validate required fields.
+    //
+    // Reply drafts are special: when reply_to is set, the provider auto-populates
+    // `to` (and `cc` if reply_all) from the original thread, so we don't require
+    // `to` or `subject` up front — matching foam-email-calendar's behavior. The
+    // exception is reply_all=false + no `to`, which is a real mistake (you'd
+    // want the narrowed recipient to be explicit).
+    if (!replyTo) {
+      const requiredError = validateRequiredFields(to, subject);
+      if (requiredError) {
+        return { success: false, error: requiredError };
+      }
+    } else if (input.reply_all === false && !to) {
+      return {
+        success: false,
+        error: {
+          code: 'MISSING_FIELD',
+          message: 'to is required when reply_all=false (reply narrows to a single recipient that must be explicit)',
+          recoverable: false,
+        },
+      };
     }
 
-    const recipients = Array.isArray(to) ? to : [to!];
+    const recipients = to ? (Array.isArray(to) ? to : [to]) : [];
 
     // Drafts bypass allowlist — enforcement happens at send_draft time
 
-    // Re: threading guardrail
-    const threadingError = checkReplyThreading(subject!, replyTo);
-    if (threadingError) {
-      return { success: false, error: threadingError };
+    // Re: threading guardrail (only when we have a subject to check)
+    if (subject) {
+      const threadingError = checkReplyThreading(subject, replyTo);
+      if (threadingError) {
+        return { success: false, error: threadingError };
+      }
     }
 
     // Render body: markdown → HTML by default
@@ -108,6 +129,7 @@ export const createDraftAction: EmailAction<
         const result = await ctx.provider.createReplyDraft(replyTo, body, {
           cc: cc?.map(email => ({ email })),
           bodyHtml: outBodyHtml,
+          replyAll: input.reply_all,
         });
         return {
           success: result.success,

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -56,7 +56,7 @@ export const createDraftAction: EmailAction<
   z.infer<typeof DraftOutput>
 > = {
   name: 'create_draft',
-  description: 'Create an email draft. Supports body_file with YAML frontmatter. Use reply_to for threaded reply drafts.',
+  description: 'Create an email draft. Supports body_file with YAML frontmatter, attachments (in EMAIL_AGENT_MCP_ATTACHMENT_DIR, 3MB max), reply_to for threaded reply drafts with reply_all toggle, and update_source_frontmatter to write draft_id/draft_link back to the source .md.',
   input: CreateDraftInput,
   output: DraftOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -6,6 +6,7 @@ import { checkReplyThreading } from '../security/reply-validation.js';
 import { withRetry } from '../providers/provider.js';
 import { truncateBody, BODY_SIZE_LIMIT } from '../content/body-loader.js';
 import { renderEmailBody } from '../content/body-renderer.js';
+import { resolveAttachments } from '../content/attachment-loader.js';
 import {
   checkMailboxRequired,
   resolveComposeFields,
@@ -37,6 +38,8 @@ const CreateDraftInput = z.object({
   reply_to: z.string().optional(),
   reply_all: z.boolean().optional().default(true)
     .describe('For reply drafts (reply_to set): reply to all original recipients (default) or only the sender. Ignored for non-reply drafts.'),
+  attachments: z.array(z.string()).optional()
+    .describe('File paths to attach. Paths are resolved against EMAIL_AGENT_MCP_ATTACHMENT_DIR (must be set). 3 MiB max per file. Merged additively with any attachments listed in body_file frontmatter.'),
   mailbox: z.string().optional(),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
@@ -66,8 +69,10 @@ export const createDraftAction: EmailAction<
       return { success: false, error: fields.error };
     }
 
-    const { to, cc, subject, replyTo, format, forceBlack } = fields;
+    const { to, cc, subject, replyTo, format, forceBlack, attachments: attachmentPaths, replyAll: fmReplyAll } = fields;
     let { body } = fields;
+    // Frontmatter-sourced reply_all overrides the param (matches "frontmatter wins" convention)
+    const effectiveReplyAll = fmReplyAll !== undefined ? fmReplyAll : input.reply_all;
 
     // Validate required fields.
     //
@@ -81,7 +86,7 @@ export const createDraftAction: EmailAction<
       if (requiredError) {
         return { success: false, error: requiredError };
       }
-    } else if (input.reply_all === false && !to) {
+    } else if (effectiveReplyAll === false && !to) {
       return {
         success: false,
         error: {
@@ -102,6 +107,18 @@ export const createDraftAction: EmailAction<
       if (threadingError) {
         return { success: false, error: threadingError };
       }
+    }
+
+    // Resolve attachments (frontmatter + param, unioned, dedup by realpath).
+    // Fail closed if the env var is misconfigured or any file is invalid —
+    // we never want to create a partial draft.
+    let resolvedAttachments;
+    if (attachmentPaths?.length) {
+      const res = await resolveAttachments(attachmentPaths);
+      if (res.error) {
+        return { success: false, error: res.error };
+      }
+      resolvedAttachments = res.attachments;
     }
 
     // Render body: markdown → HTML by default
@@ -129,7 +146,8 @@ export const createDraftAction: EmailAction<
         const result = await ctx.provider.createReplyDraft(replyTo, body, {
           cc: cc?.map(email => ({ email })),
           bodyHtml: outBodyHtml,
-          replyAll: input.reply_all,
+          replyAll: effectiveReplyAll,
+          attachments: resolvedAttachments,
         });
         return {
           success: result.success,
@@ -149,6 +167,7 @@ export const createDraftAction: EmailAction<
         subject: subject!,
         body,
         bodyHtml: outBodyHtml,
+        attachments: resolvedAttachments,
       });
       return {
         success: result.success,

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -56,7 +56,8 @@ describe('email-write/Reply to Email', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error!.message).toContain('Recipient not in send allowlist');
+    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(result.error!.message).toContain('reply recipients not in send allowlist');
   });
 
   it('Scenario: Mailbox required with multiple accounts', async () => {
@@ -126,6 +127,67 @@ describe('email-write/Reply Draft', () => {
 
     expect(result.success).toBe(false);
     expect(result.error!.code).toBe('NOT_SUPPORTED');
+  });
+});
+
+describe('email-write/Reply Allowlist — P0 regression (plan §2.0)', () => {
+  it('Scenario: reply_all=true blocks on non-allowlisted auto-populated cc recipient', async () => {
+    // Original thread: allowed sender + allowed recipient, but cc'd a non-allowlisted
+    // outsider. Replying reply-all auto-populates all three into the reply draft.
+    // The old code only checked original.from.email, letting this silently leak.
+    const threadId = 'thread_with_evil_cc_123456';
+    provider.addMessage({
+      id: threadId,
+      subject: 'Project update',
+      from: { email: 'partner@lawfirm.com' },
+      to: [{ email: 'me@company.com' }],
+      cc: [{ email: 'outsider@evil.com' }],
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: threadId,
+      body: 'I agree!',
+      // reply_all defaults to true
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    // The draft must have been created (provider populated recipients) and
+    // then deleted by our send-path guard.
+    expect(provider.getDrafts().size).toBe(0);
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
+  it('Scenario: reply_all=false skips auto-populated cc and succeeds for sender-only', async () => {
+    // Same thread as above — non-allowlisted outsider in cc — but reply_all=false
+    // narrows to sender only, which IS allowlisted.
+    const threadId = 'thread_with_evil_cc_222222';
+    provider.addMessage({
+      id: threadId,
+      subject: 'Project update',
+      from: { email: 'partner@lawfirm.com' },
+      to: [{ email: 'me@company.com' }],
+      cc: [{ email: 'outsider@evil.com' }],
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: threadId,
+      body: 'Private response',
+      reply_all: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(provider.getSentMessages()).toHaveLength(1);
+    const sent = provider.getSentMessages()[0];
+    expect(sent.to.map(a => a.email)).toEqual(['partner@lawfirm.com']);
+    // No cc should have been auto-populated
+    expect(sent.cc ?? []).toHaveLength(0);
   });
 });
 

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -1,9 +1,14 @@
-// reply_to_email action — reply within existing thread, gated by send allowlist
+// reply_to_email action — reply within existing thread, gated by send allowlist.
+//
+// Send-path design: we create a reply draft via the provider, fetch the draft
+// to see exactly which recipients Graph/Gmail auto-populated, allowlist-check
+// *those* recipients, and only then send. This closes the window where a
+// reply-all could send to a recipient that was never checked against the
+// allowlist (see CVE-style note in plan §2.0 / P0 fix).
 import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { isPlausibleMessageId } from '../security/reply-validation.js';
-import { withRetry } from '../providers/provider.js';
 import { renderEmailBody } from '../content/body-renderer.js';
 import {
   checkMailboxRequired,
@@ -17,6 +22,8 @@ const ReplyToEmailInput = z.object({
   mailbox: z.string().optional(),
   cc: z.array(z.string()).optional(),
   draft: z.boolean().optional(),
+  reply_all: z.boolean().optional().default(true)
+    .describe('Reply to all recipients (to + cc) when true (default), or only the sender when false.'),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
@@ -67,22 +74,27 @@ export const replyToEmailAction: EmailAction<
     const bodyPlain = rendered.body;
     const bodyHtml = rendered.bodyHtml;
 
-    // Draft branch — create reply draft, bypass allowlist
+    // Every code path below goes through createReplyDraft — draft and send.
+    // This keeps the allowlist gate on the *actual* populated recipients and
+    // lets attachment upload share one code path with create_draft.
+    if (!ctx.provider.createReplyDraft) {
+      return {
+        success: false,
+        error: {
+          code: 'NOT_SUPPORTED',
+          message: 'Reply drafts are not supported by this email provider',
+          recoverable: false,
+        },
+      };
+    }
+
+    // Draft branch — create reply draft, bypass allowlist (enforced at send time)
     if (input.draft) {
-      if (!ctx.provider.createReplyDraft) {
-        return {
-          success: false,
-          error: {
-            code: 'NOT_SUPPORTED',
-            message: 'Reply drafts are not supported by this email provider',
-            recoverable: false,
-          },
-        };
-      }
       try {
         const draftResult = await ctx.provider.createReplyDraft(input.message_id, bodyPlain, {
           cc: input.cc?.map(email => ({ email })),
           bodyHtml,
+          replyAll: input.reply_all,
         });
         return {
           success: draftResult.success,
@@ -98,20 +110,70 @@ export const replyToEmailAction: EmailAction<
       }
     }
 
-    // Send path — get the original message to check the recipient against allowlist
-    const originalMessage = await ctx.provider.getMessage(input.message_id);
-    const replyRecipient = originalMessage.from.email;
+    // Send path — create reply draft, then allowlist-check the actual recipients
+    // the provider populated (to + cc), then sendDraft. This closes the reply-all
+    // allowlist bypass: the old code only checked original.from.email, but Graph's
+    // createReplyAll auto-populates every original recipient.
+    let draftId: string | undefined;
+    try {
+      const draftResult = await ctx.provider.createReplyDraft(input.message_id, bodyPlain, {
+        cc: input.cc?.map(email => ({ email })),
+        bodyHtml,
+        replyAll: input.reply_all,
+      });
+      if (!draftResult.success || !draftResult.draftId) {
+        return {
+          success: false,
+          error: draftResult.error
+            ? { code: draftResult.error.code, message: draftResult.error.message, recoverable: draftResult.error.recoverable }
+            : { code: 'DRAFT_FAILED', message: 'createReplyDraft returned no draftId', recoverable: false },
+        };
+      }
+      draftId = draftResult.draftId;
+    } catch (err) {
+      return handleProviderError(err, 'DRAFT_FAILED');
+    }
 
-    // Check send allowlist — reply recipients must also be allowed
-    const allowlistError = checkSendAllowlist([replyRecipient], ctx.sendAllowlist);
+    // Fetch the draft to see the actual recipients the provider populated
+    let populatedRecipients: string[];
+    try {
+      const draftMessage = await ctx.provider.getMessage(draftId);
+      populatedRecipients = [
+        ...(draftMessage.to?.map(a => a.email) ?? []),
+        ...(draftMessage.cc?.map(a => a.email) ?? []),
+      ];
+    } catch (err) {
+      // If we can't verify recipients, fail closed and try to clean up the draft.
+      await safeDeleteDraft(ctx.provider, draftId);
+      return {
+        success: false,
+        error: {
+          code: 'DRAFT_LOOKUP_FAILED',
+          message: `Cannot verify reply recipients before sending: ${err instanceof Error ? err.message : String(err)}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    if (populatedRecipients.length === 0) {
+      await safeDeleteDraft(ctx.provider, draftId);
+      return {
+        success: false,
+        error: { code: 'NO_RECIPIENTS', message: 'Reply draft has no recipients', recoverable: false },
+      };
+    }
+
+    // Allowlist-check the populated recipients
+    const allowlistError = checkSendAllowlist(populatedRecipients, ctx.sendAllowlist);
     if (allowlistError) {
+      await safeDeleteDraft(ctx.provider, draftId);
       return {
         success: false,
         error: {
           code: 'ALLOWLIST_BLOCKED',
           message: allowlistError.includes('not configured')
             ? allowlistError
-            : `Recipient not in send allowlist`,
+            : `One or more reply recipients not in send allowlist`,
           recoverable: false,
         },
       };
@@ -120,22 +182,15 @@ export const replyToEmailAction: EmailAction<
     // Check rate limit
     const rateLimitError = checkRateLimit(ctx.rateLimiter, 'reply_to_email');
     if (rateLimitError) {
+      await safeDeleteDraft(ctx.provider, draftId);
       return rateLimitError;
     }
 
     try {
-      const result = await withRetry(
-        () => ctx.provider.replyToMessage(input.message_id, bodyPlain, {
-          cc: input.cc?.map(email => ({ email })),
-          bodyHtml,
-        }),
-        { maxRetries: 3, baseDelay: 1000 },
-      );
-
+      const result = await ctx.provider.sendDraft(draftId);
       if (ctx.rateLimiter) {
         ctx.rateLimiter.recordUsage('reply_to_email');
       }
-
       return {
         success: result.success,
         messageId: result.messageId,
@@ -150,3 +205,19 @@ export const replyToEmailAction: EmailAction<
     }
   },
 };
+
+// Delete a draft, swallowing errors. Used on failure paths where the caller
+// already has a fatal error to return and just wants to clean up.
+async function safeDeleteDraft(
+  provider: { deleteMessage?: (id: string, hard?: boolean) => Promise<string | void> },
+  draftId: string,
+): Promise<void> {
+  if (!provider.deleteMessage) return;
+  try {
+    await provider.deleteMessage(draftId, true);
+  } catch (err) {
+    process.stderr.write(
+      `[email-agent-mcp] WARNING: failed to clean up reply draft ${draftId}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -49,7 +49,7 @@ export const replyToEmailAction: EmailAction<
   z.infer<typeof ReplyToEmailOutput>
 > = {
   name: 'reply_to_email',
-  description: 'Reply to an email within an existing thread. Send path gated by send allowlist; draft path bypasses.',
+  description: 'Reply within an existing thread. reply_all (default true) chooses sender-only vs all recipients; attachments require EMAIL_AGENT_MCP_ATTACHMENT_DIR. Send path creates a draft, allowlist-checks populated recipients, then sends.',
   input: ReplyToEmailInput,
   output: ReplyToEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -10,6 +10,7 @@ import type { EmailAction } from './registry.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { isPlausibleMessageId } from '../security/reply-validation.js';
 import { renderEmailBody } from '../content/body-renderer.js';
+import { resolveAttachments } from '../content/attachment-loader.js';
 import {
   checkMailboxRequired,
   checkRateLimit,
@@ -24,6 +25,8 @@ const ReplyToEmailInput = z.object({
   draft: z.boolean().optional(),
   reply_all: z.boolean().optional().default(true)
     .describe('Reply to all recipients (to + cc) when true (default), or only the sender when false.'),
+  attachments: z.array(z.string()).optional()
+    .describe('File paths to attach. Paths are resolved against EMAIL_AGENT_MCP_ATTACHMENT_DIR (must be set). 3 MiB max per file.'),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
@@ -74,6 +77,17 @@ export const replyToEmailAction: EmailAction<
     const bodyPlain = rendered.body;
     const bodyHtml = rendered.bodyHtml;
 
+    // Resolve attachments. reply_to_email doesn't parse frontmatter (no
+    // body_file input), so attachments come from the param only.
+    let resolvedAttachments;
+    if (input.attachments?.length) {
+      const res = await resolveAttachments(input.attachments);
+      if (res.error) {
+        return { success: false, error: res.error };
+      }
+      resolvedAttachments = res.attachments;
+    }
+
     // Every code path below goes through createReplyDraft — draft and send.
     // This keeps the allowlist gate on the *actual* populated recipients and
     // lets attachment upload share one code path with create_draft.
@@ -95,6 +109,7 @@ export const replyToEmailAction: EmailAction<
           cc: input.cc?.map(email => ({ email })),
           bodyHtml,
           replyAll: input.reply_all,
+          attachments: resolvedAttachments,
         });
         return {
           success: draftResult.success,
@@ -120,6 +135,7 @@ export const replyToEmailAction: EmailAction<
         cc: input.cc?.map(email => ({ email })),
         bodyHtml,
         replyAll: input.reply_all,
+        attachments: resolvedAttachments,
       });
       if (!draftResult.success || !draftResult.draftId) {
         return {

--- a/packages/email-core/src/content/attachment-loader.test.ts
+++ b/packages/email-core/src/content/attachment-loader.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  resolveAttachments,
+  ATTACHMENT_DIR_ENV,
+  ATTACHMENT_MAX_SIZE,
+} from './attachment-loader.js';
+
+let baseDir: string;
+const savedEnv = process.env[ATTACHMENT_DIR_ENV];
+
+beforeEach(async () => {
+  baseDir = await mkdtemp(join(tmpdir(), 'attachment-loader-test-'));
+  process.env[ATTACHMENT_DIR_ENV] = baseDir;
+});
+
+afterEach(async () => {
+  if (savedEnv === undefined) {
+    delete process.env[ATTACHMENT_DIR_ENV];
+  } else {
+    process.env[ATTACHMENT_DIR_ENV] = savedEnv;
+  }
+  await rm(baseDir, { recursive: true, force: true });
+});
+
+describe('content/attachment-loader — happy path', () => {
+  it('loads a single small attachment', async () => {
+    const path = join(baseDir, 'hello.txt');
+    await writeFile(path, 'hello world');
+
+    const res = await resolveAttachments(['hello.txt']);
+    expect(res.error).toBeUndefined();
+    expect(res.attachments).toHaveLength(1);
+    expect(res.attachments![0]!.filename).toBe('hello.txt');
+    expect(res.attachments![0]!.content.toString('utf-8')).toBe('hello world');
+    expect(res.attachments![0]!.mimeType).toBe('text/plain');
+  });
+
+  it('loads a zero-byte attachment', async () => {
+    const path = join(baseDir, 'empty.pdf');
+    await writeFile(path, '');
+
+    const res = await resolveAttachments(['empty.pdf']);
+    expect(res.error).toBeUndefined();
+    expect(res.attachments).toHaveLength(1);
+    expect(res.attachments![0]!.content.length).toBe(0);
+    expect(res.attachments![0]!.mimeType).toBe('application/pdf');
+  });
+
+  it('loads an attachment exactly at the 3 MiB size cap', async () => {
+    const path = join(baseDir, 'big.bin');
+    await writeFile(path, Buffer.alloc(ATTACHMENT_MAX_SIZE, 0x41));
+
+    const res = await resolveAttachments(['big.bin']);
+    expect(res.error).toBeUndefined();
+    expect(res.attachments).toHaveLength(1);
+    expect(res.attachments![0]!.content.length).toBe(ATTACHMENT_MAX_SIZE);
+  });
+
+  it('rejects an attachment one byte over the cap', async () => {
+    const path = join(baseDir, 'toobig.bin');
+    await writeFile(path, Buffer.alloc(ATTACHMENT_MAX_SIZE + 1, 0x41));
+
+    const res = await resolveAttachments(['toobig.bin']);
+    expect(res.attachments).toBeUndefined();
+    expect(res.error?.code).toBe('ATTACHMENT_TOO_LARGE');
+    expect(res.error?.message).toContain(String(ATTACHMENT_MAX_SIZE + 1));
+  });
+
+  it('detects mime types for common extensions', async () => {
+    await writeFile(join(baseDir, 'doc.pdf'), 'x');
+    await writeFile(join(baseDir, 'sheet.xlsx'), 'x');
+    await writeFile(join(baseDir, 'img.png'), 'x');
+    await writeFile(join(baseDir, 'unknown.xyz123'), 'x');
+
+    const res = await resolveAttachments(['doc.pdf', 'sheet.xlsx', 'img.png', 'unknown.xyz123']);
+    expect(res.attachments).toHaveLength(4);
+    expect(res.attachments![0]!.mimeType).toBe('application/pdf');
+    expect(res.attachments![1]!.mimeType).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    expect(res.attachments![2]!.mimeType).toBe('image/png');
+    expect(res.attachments![3]!.mimeType).toBe('application/octet-stream');
+  });
+
+  it('returns [] when paths is empty (does not require env var)', async () => {
+    delete process.env[ATTACHMENT_DIR_ENV];
+
+    const res = await resolveAttachments([]);
+    expect(res.error).toBeUndefined();
+    expect(res.attachments).toEqual([]);
+  });
+});
+
+describe('content/attachment-loader — env var validation', () => {
+  it('rejects when env var is unset', async () => {
+    delete process.env[ATTACHMENT_DIR_ENV];
+
+    const res = await resolveAttachments(['x.txt']);
+    expect(res.error?.code).toBe('ATTACHMENT_DIR_NOT_CONFIGURED');
+  });
+
+  it('rejects when env var is relative', async () => {
+    process.env[ATTACHMENT_DIR_ENV] = 'relative/path';
+
+    const res = await resolveAttachments(['x.txt']);
+    expect(res.error?.code).toBe('ATTACHMENT_DIR_NOT_ABSOLUTE');
+  });
+
+  it('rejects when env var points to a nonexistent directory', async () => {
+    process.env[ATTACHMENT_DIR_ENV] = '/tmp/definitely-does-not-exist-123456789';
+
+    const res = await resolveAttachments(['x.txt']);
+    expect(res.error?.code).toBe('ATTACHMENT_DIR_NOT_FOUND');
+  });
+
+  it('rejects when env var points to a file instead of a directory', async () => {
+    const filePath = join(baseDir, 'not-a-dir');
+    await writeFile(filePath, 'x');
+    process.env[ATTACHMENT_DIR_ENV] = filePath;
+
+    const res = await resolveAttachments(['x.txt']);
+    expect(res.error?.code).toBe('ATTACHMENT_DIR_NOT_FOUND');
+  });
+});
+
+describe('content/attachment-loader — path traversal', () => {
+  it('rejects ../../../etc/passwd style traversal', async () => {
+    const res = await resolveAttachments(['../../../etc/passwd']);
+    // Realpath may succeed on /etc/passwd, but isPathInsideDir should reject
+    expect(res.error?.code).toMatch(/^ATTACHMENT_(NOT_ALLOWED|NOT_FOUND)$/);
+  });
+
+  it('rejects sibling-prefix attack (baseDir is /tmp/allowed, candidate in /tmp/allowed-evil)', async () => {
+    // Use OS tmp dir to create baseDir and a sibling "<baseDir>-evil"
+    const evilDir = `${baseDir}-evil`;
+    await mkdir(evilDir, { recursive: true });
+    const evilFile = join(evilDir, 'stolen.txt');
+    await writeFile(evilFile, 'secret');
+
+    try {
+      const res = await resolveAttachments([evilFile]);
+      expect(res.attachments).toBeUndefined();
+      expect(res.error?.code).toBe('ATTACHMENT_NOT_ALLOWED');
+    } finally {
+      await rm(evilDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects symlink escape (symlink inside baseDir points outside)', async () => {
+    // Create the target file outside baseDir, and a symlink to it inside
+    const outsideDir = `${baseDir}-outside`;
+    await mkdir(outsideDir, { recursive: true });
+    const outsideFile = join(outsideDir, 'secret.txt');
+    await writeFile(outsideFile, 'secret');
+
+    const link = join(baseDir, 'link.txt');
+    try {
+      await symlink(outsideFile, link);
+      const res = await resolveAttachments(['link.txt']);
+      expect(res.error?.code).toBe('ATTACHMENT_NOT_ALLOWED');
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it('allows symlink inside baseDir that points to another file inside baseDir', async () => {
+    await writeFile(join(baseDir, 'target.txt'), 'inside');
+    await symlink(join(baseDir, 'target.txt'), join(baseDir, 'alias.txt'));
+
+    const res = await resolveAttachments(['alias.txt']);
+    expect(res.error).toBeUndefined();
+    expect(res.attachments).toHaveLength(1);
+  });
+
+  it('rejects a path that does not exist', async () => {
+    const res = await resolveAttachments(['ghost.txt']);
+    expect(res.error?.code).toBe('ATTACHMENT_NOT_FOUND');
+  });
+});
+
+describe('content/attachment-loader — dedupe and disambiguation', () => {
+  it('dedupes identical paths', async () => {
+    await writeFile(join(baseDir, 'one.txt'), 'hello');
+
+    const res = await resolveAttachments(['one.txt', 'one.txt']);
+    expect(res.attachments).toHaveLength(1);
+  });
+
+  it('dedupes absolute path and relative path pointing to the same file', async () => {
+    await writeFile(join(baseDir, 'one.txt'), 'hello');
+
+    const res = await resolveAttachments(['one.txt', join(baseDir, 'one.txt')]);
+    expect(res.attachments).toHaveLength(1);
+  });
+
+  it('dedupes symlink alias pointing to the same realpath', async () => {
+    await writeFile(join(baseDir, 'target.txt'), 'hello');
+    await symlink(join(baseDir, 'target.txt'), join(baseDir, 'alias.txt'));
+
+    const res = await resolveAttachments(['target.txt', 'alias.txt']);
+    expect(res.attachments).toHaveLength(1);
+  });
+
+  it('disambiguates two different files that share a basename', async () => {
+    await mkdir(join(baseDir, 'sub1'));
+    await mkdir(join(baseDir, 'sub2'));
+    await writeFile(join(baseDir, 'sub1', 'report.pdf'), 'first');
+    await writeFile(join(baseDir, 'sub2', 'report.pdf'), 'second');
+
+    const res = await resolveAttachments(['sub1/report.pdf', 'sub2/report.pdf']);
+    expect(res.attachments).toHaveLength(2);
+    expect(res.attachments![0]!.filename).toBe('report.pdf');
+    expect(res.attachments![1]!.filename).toBe('report (2).pdf');
+    expect(res.attachments![0]!.content.toString('utf-8')).toBe('first');
+    expect(res.attachments![1]!.content.toString('utf-8')).toBe('second');
+  });
+
+  it('disambiguates three same-named files with (2), (3) suffixes', async () => {
+    await mkdir(join(baseDir, 'a'));
+    await mkdir(join(baseDir, 'b'));
+    await mkdir(join(baseDir, 'c'));
+    await writeFile(join(baseDir, 'a', 'x.txt'), '1');
+    await writeFile(join(baseDir, 'b', 'x.txt'), '2');
+    await writeFile(join(baseDir, 'c', 'x.txt'), '3');
+
+    const res = await resolveAttachments(['a/x.txt', 'b/x.txt', 'c/x.txt']);
+    expect(res.attachments).toHaveLength(3);
+    expect(res.attachments!.map(a => a.filename)).toEqual(['x.txt', 'x (2).txt', 'x (3).txt']);
+  });
+});

--- a/packages/email-core/src/content/attachment-loader.ts
+++ b/packages/email-core/src/content/attachment-loader.ts
@@ -1,0 +1,195 @@
+// Attachment resolution — safe file loading for outbound email attachments.
+//
+// Security model:
+// - Files must live inside EMAIL_AGENT_MCP_ATTACHMENT_DIR (env var).
+// - The env var must be set, absolute, and point to an existing directory —
+//   fail closed with a distinct error code for each failure mode.
+// - Paths are resolved through `fs.realpath` on both the base dir and the
+//   candidate, then compared via `path.relative()` to catch sibling-prefix
+//   attacks (e.g. `/allowed-evil/x` vs base `/allowed`).
+// - Per-file size cap is 3 MiB. Zero-byte files are allowed.
+// - When two different paths resolve to the same realpath (duplicate or
+//   symlink alias), only the first occurrence is kept.
+// - When two different realpaths share the same basename, later ones are
+//   disambiguated with ` (2)`, ` (3)` suffixes before the extension.
+import { readFile, realpath, stat } from 'node:fs/promises';
+import { basename, extname, isAbsolute, resolve } from 'node:path';
+import { lookup as lookupMime } from 'mime-types';
+import type { OutboundAttachment } from '../types.js';
+import { isPathInsideDir } from './safe-path.js';
+
+export const ATTACHMENT_MAX_SIZE = 3 * 1024 * 1024; // 3 MiB
+export const ATTACHMENT_DIR_ENV = 'EMAIL_AGENT_MCP_ATTACHMENT_DIR';
+
+export interface AttachmentLoaderError {
+  code:
+    | 'ATTACHMENT_DIR_NOT_CONFIGURED'
+    | 'ATTACHMENT_DIR_NOT_ABSOLUTE'
+    | 'ATTACHMENT_DIR_NOT_FOUND'
+    | 'ATTACHMENT_NOT_FOUND'
+    | 'ATTACHMENT_NOT_ALLOWED'
+    | 'ATTACHMENT_TOO_LARGE';
+  message: string;
+  recoverable: false;
+}
+
+export interface AttachmentLoaderResult {
+  attachments?: OutboundAttachment[];
+  error?: AttachmentLoaderError;
+}
+
+/**
+ * Resolve and load a list of attachment paths. Returns either
+ * `{ attachments }` on success or `{ error }` on the first failure — this is
+ * an all-or-nothing operation (we don't want to half-attach a draft).
+ *
+ * An empty input list returns `{ attachments: [] }` without consulting the
+ * env var — the caller may not have attachments at all, in which case we
+ * shouldn't demand the dir be configured.
+ */
+export async function resolveAttachments(paths: readonly string[]): Promise<AttachmentLoaderResult> {
+  if (paths.length === 0) {
+    return { attachments: [] };
+  }
+
+  const configured = process.env[ATTACHMENT_DIR_ENV];
+  if (!configured) {
+    return {
+      error: {
+        code: 'ATTACHMENT_DIR_NOT_CONFIGURED',
+        message: `${ATTACHMENT_DIR_ENV} must be set to an absolute directory path to use outbound attachments`,
+        recoverable: false,
+      },
+    };
+  }
+  if (!isAbsolute(configured)) {
+    return {
+      error: {
+        code: 'ATTACHMENT_DIR_NOT_ABSOLUTE',
+        message: `${ATTACHMENT_DIR_ENV} must be an absolute path, got: ${configured}`,
+        recoverable: false,
+      },
+    };
+  }
+
+  let baseReal: string;
+  try {
+    const st = await stat(configured);
+    if (!st.isDirectory()) {
+      return {
+        error: {
+          code: 'ATTACHMENT_DIR_NOT_FOUND',
+          message: `${ATTACHMENT_DIR_ENV} is not a directory: ${configured}`,
+          recoverable: false,
+        },
+      };
+    }
+    baseReal = await realpath(configured);
+  } catch {
+    return {
+      error: {
+        code: 'ATTACHMENT_DIR_NOT_FOUND',
+        message: `${ATTACHMENT_DIR_ENV} directory does not exist: ${configured}`,
+        recoverable: false,
+      },
+    };
+  }
+
+  // Map realpath → index in the output array, for dedupe.
+  const realToIndex = new Map<string, number>();
+  const out: OutboundAttachment[] = [];
+  // Track used filenames so collisions across different realpaths get a
+  // " (2)", " (3)" suffix — matches how native clients handle same-named
+  // attachments.
+  const usedFilenames = new Map<string, number>();
+
+  for (const p of paths) {
+    // Resolve against the attachment dir (treats relative paths as
+    // attachment-dir-relative; absolute paths are kept as-is).
+    const resolved = resolve(baseReal, p);
+
+    let candidateReal: string;
+    try {
+      candidateReal = await realpath(resolved);
+    } catch {
+      return {
+        error: {
+          code: 'ATTACHMENT_NOT_FOUND',
+          message: `Attachment file not found: ${p}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    if (!isPathInsideDir(candidateReal, baseReal)) {
+      return {
+        error: {
+          code: 'ATTACHMENT_NOT_ALLOWED',
+          message: `Attachment path is outside ${ATTACHMENT_DIR_ENV}: ${p}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    // Dedupe: if we've already loaded this realpath, skip.
+    if (realToIndex.has(candidateReal)) {
+      continue;
+    }
+
+    let fileStat;
+    try {
+      fileStat = await stat(candidateReal);
+    } catch {
+      return {
+        error: {
+          code: 'ATTACHMENT_NOT_FOUND',
+          message: `Attachment file not found: ${p}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    if (fileStat.size > ATTACHMENT_MAX_SIZE) {
+      return {
+        error: {
+          code: 'ATTACHMENT_TOO_LARGE',
+          message: `Attachment ${basename(p)} is ${fileStat.size} bytes — exceeds ${ATTACHMENT_MAX_SIZE} byte limit`,
+          recoverable: false,
+        },
+      };
+    }
+
+    const content = await readFile(candidateReal);
+    const rawName = basename(candidateReal);
+    const filename = disambiguateFilename(rawName, usedFilenames);
+    const mimeType = lookupMime(rawName) || 'application/octet-stream';
+
+    realToIndex.set(candidateReal, out.length);
+    out.push({ filename, content, mimeType });
+  }
+
+  return { attachments: out };
+}
+
+/**
+ * If `raw` has already been used, return `raw` with a ` (2)`, ` (3)` suffix
+ * inserted before the extension. Mutates `used` so subsequent calls see the
+ * updated counts.
+ */
+function disambiguateFilename(raw: string, used: Map<string, number>): string {
+  const existing = used.get(raw);
+  if (existing === undefined) {
+    used.set(raw, 1);
+    return raw;
+  }
+  const next = existing + 1;
+  used.set(raw, next);
+  const ext = extname(raw);
+  const stem = ext ? raw.slice(0, -ext.length) : raw;
+  const candidate = `${stem} (${next})${ext}`;
+  // If the candidate is itself already used, keep bumping.
+  // Register the candidate too so the same input with the same count twice
+  // doesn't produce a collision.
+  used.set(candidate, 1);
+  return candidate;
+}

--- a/packages/email-core/src/content/body-loader.ts
+++ b/packages/email-core/src/content/body-loader.ts
@@ -2,6 +2,7 @@
 import { readFile, realpath, lstat } from 'node:fs/promises';
 import { resolve, relative, isAbsolute, extname } from 'node:path';
 import { parseFrontmatter, type FrontmatterFields } from './frontmatter.js';
+import { isPathInsideDir } from './safe-path.js';
 
 export const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 export const TEXT_EXTENSIONS = new Set(['.md', '.html', '.htm', '.txt', '.text']);
@@ -47,7 +48,8 @@ export async function resolveBodyFile(
     const stat = await lstat(resolved);
     if (stat.isSymbolicLink()) {
       const realPath = await realpath(resolved);
-      if (!realPath.startsWith(baseDir)) {
+      const realBase = await realpath(baseDir);
+      if (!isPathInsideDir(realPath, realBase)) {
         return {
           error: {
             code: 'SYMLINK_ESCAPE',

--- a/packages/email-core/src/content/frontmatter-writer.test.ts
+++ b/packages/email-core/src/content/frontmatter-writer.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtemp, readFile, writeFile, rm, chmod } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { patchFrontmatter } from './frontmatter-writer.js';
+import { parseFrontmatter } from './frontmatter.js';
+
+let workDir: string;
+let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'fm-writer-test-'));
+  // Silence stderr writes inside tests so the test reporter stays clean.
+  stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(async () => {
+  stderrSpy.mockRestore();
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe('content/frontmatter-writer — no existing frontmatter', () => {
+  it('prepends a new frontmatter block when file has none', async () => {
+    const filePath = join(workDir, 'plain.md');
+    await writeFile(filePath, 'Just a body\nSecond line\n');
+
+    const res = await patchFrontmatter(filePath, { draft_id: 'abc123' });
+    expect(res.ok).toBe(true);
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated.startsWith('---\n')).toBe(true);
+    expect(updated).toContain('draft_id: abc123');
+    expect(updated).toContain('Just a body\nSecond line\n');
+  });
+});
+
+describe('content/frontmatter-writer — patch existing frontmatter', () => {
+  it('appends a new key when not present', async () => {
+    const filePath = join(workDir, 'reply.md');
+    await writeFile(filePath, `---
+to: alice@example.com
+subject: Hello
+---
+Body content`);
+
+    const res = await patchFrontmatter(filePath, {
+      draft_reply_id: 'xyz789',
+      draft_reply_link: 'https://outlook.office.com/mail/deeplink/compose?ItemID=xyz789',
+    });
+    expect(res.ok).toBe(true);
+
+    const updated = await readFile(filePath, 'utf-8');
+    const parsed = parseFrontmatter(updated);
+    expect(parsed.body).toBe('Body content');
+    // draft_reply_id is not a known frontmatter key so it'll be in the raw text but not in parsed.frontmatter
+    expect(updated).toContain('draft_reply_id: xyz789');
+    expect(updated).toContain('draft_reply_link: https://outlook.office.com/mail/deeplink/compose?ItemID=xyz789');
+    // Existing keys preserved
+    expect(parsed.frontmatter?.to).toBe('alice@example.com');
+    expect(parsed.frontmatter?.subject).toBe('Hello');
+  });
+
+  it('replaces an existing key in place', async () => {
+    const filePath = join(workDir, 'update.md');
+    await writeFile(filePath, `---
+to: alice@example.com
+draft_id: old-id
+---
+Body`);
+
+    const res = await patchFrontmatter(filePath, { draft_id: 'new-id' });
+    expect(res.ok).toBe(true);
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated).toContain('draft_id: new-id');
+    expect(updated).not.toContain('old-id');
+  });
+
+  it('preserves body bytes exactly (including trailing newlines)', async () => {
+    const filePath = join(workDir, 'preserve.md');
+    const body = '# Heading\n\n- bullet\n- another\n\n  indented code\n\nfinal line\n';
+    await writeFile(filePath, `---
+subject: Test
+---
+${body}`);
+
+    await patchFrontmatter(filePath, { draft_id: 'xxx' });
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated.endsWith(body)).toBe(true);
+  });
+
+  it('only patches the first occurrence of a duplicate key', async () => {
+    const filePath = join(workDir, 'dup.md');
+    await writeFile(filePath, `---
+draft_id: first
+other: value
+draft_id: second
+---
+Body`);
+
+    const res = await patchFrontmatter(filePath, { draft_id: 'patched' });
+    expect(res.ok).toBe(true);
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated).toContain('draft_id: patched');
+    expect(updated).toContain('draft_id: second');
+    expect(updated).not.toContain('draft_id: first');
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('duplicate keys'));
+  });
+
+  it('refuses to patch when frontmatter contains multiline YAML scalar', async () => {
+    const filePath = join(workDir, 'multiline.md');
+    const original = `---
+subject: |
+  line one
+  line two
+---
+Body`;
+    await writeFile(filePath, original);
+
+    const res = await patchFrontmatter(filePath, { draft_id: 'abc' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('multiline');
+
+    const unchanged = await readFile(filePath, 'utf-8');
+    expect(unchanged).toBe(original);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining('multiline scalar'));
+  });
+
+  it('refuses to patch when frontmatter block is unclosed', async () => {
+    const filePath = join(workDir, 'unclosed.md');
+    const original = `---
+subject: Test
+(no closing marker)
+Body`;
+    await writeFile(filePath, original);
+
+    const res = await patchFrontmatter(filePath, { draft_id: 'abc' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('unclosed');
+  });
+});
+
+describe('content/frontmatter-writer — CRLF handling', () => {
+  it('preserves CRLF line endings', async () => {
+    const filePath = join(workDir, 'crlf.md');
+    const crlfContent = '---\r\nsubject: Hi\r\n---\r\nBody\r\nline 2\r\n';
+    await writeFile(filePath, crlfContent);
+
+    const res = await patchFrontmatter(filePath, { draft_id: 'abc' });
+    expect(res.ok).toBe(true);
+
+    const updated = await readFile(filePath, 'utf-8');
+    expect(updated).toContain('\r\n');
+    expect(updated).not.toMatch(/[^\r]\n/); // no bare LF
+    expect(updated).toContain('subject: Hi');
+    expect(updated).toContain('draft_id: abc');
+    expect(updated).toContain('Body\r\nline 2\r\n');
+  });
+});
+
+describe('content/frontmatter-writer — validation', () => {
+  it('rejects invalid key names', async () => {
+    const filePath = join(workDir, 'ok.md');
+    await writeFile(filePath, 'body');
+
+    const res = await patchFrontmatter(filePath, { 'bad key!': 'v' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('invalid key');
+  });
+
+  it('rejects values containing newlines', async () => {
+    const filePath = join(workDir, 'ok.md');
+    await writeFile(filePath, 'body');
+
+    const res = await patchFrontmatter(filePath, { ok: 'line1\nline2' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('single-line');
+  });
+
+  it('returns ok: false (no throw) when file is missing', async () => {
+    const res = await patchFrontmatter(join(workDir, 'ghost.md'), { x: 'y' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('read failed');
+  });
+
+  it('returns ok: false (no throw) when file is read-only', async () => {
+    const filePath = join(workDir, 'readonly.md');
+    await writeFile(filePath, '---\nsubject: x\n---\nbody');
+    await chmod(filePath, 0o444);
+
+    try {
+      const res = await patchFrontmatter(filePath, { draft_id: 'abc' });
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain('write failed');
+    } finally {
+      await chmod(filePath, 0o644).catch(() => {});
+    }
+  });
+});

--- a/packages/email-core/src/content/frontmatter-writer.ts
+++ b/packages/email-core/src/content/frontmatter-writer.ts
@@ -1,0 +1,151 @@
+// Frontmatter writer — patches simple key: value pairs into a Markdown file's
+// YAML-ish frontmatter block. Mirrors the (intentionally narrow) parser in
+// frontmatter.ts: flat scalar fields only, no nesting, no multiline values.
+//
+// Used by create_draft's update_source_frontmatter flag to write back
+// draft_id / draft_link (or draft_reply_id / draft_reply_link) so the
+// human author can open the resulting draft from their source file.
+//
+// Design choices:
+// - Patch in place: read file → split into frontmatter + body → update keys
+//   → re-serialize. Body bytes are preserved byte-exact.
+// - If the file has no frontmatter block, prepend one.
+// - Existing keys: replace the FIRST occurrence; any additional occurrences
+//   are left alone and a warning is written to stderr (the parser behaviour
+//   reads the last value, but rewriting them all risks mangling structured
+//   lists the user wrote by hand).
+// - Multiline YAML scalars (`key: |` or `key: >`) are refused — we log a
+//   warning and return `{ ok: false }` without modifying the file.
+// - Silent-fail policy: this helper is called from a success-path branch
+//   (draft already created). The caller should not abort the draft on
+//   write failure; it should log and continue.
+import { readFile, writeFile } from 'node:fs/promises';
+
+export interface PatchResult {
+  ok: boolean;
+  reason?: string;
+}
+
+/**
+ * Patch the given keys into the frontmatter of `filePath`.
+ *
+ * Values are written as plain unquoted scalars. Keys/values containing
+ * characters that would confuse the hand-rolled parser (colons, newlines,
+ * leading/trailing whitespace) are rejected with `{ ok: false }`.
+ */
+export async function patchFrontmatter(
+  filePath: string,
+  updates: Record<string, string>,
+): Promise<PatchResult> {
+  // Validate values up front — we refuse to write anything that would break
+  // the read-side parser or introduce ambiguity.
+  for (const [k, v] of Object.entries(updates)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(k)) {
+      return { ok: false, reason: `invalid key: ${JSON.stringify(k)}` };
+    }
+    if (typeof v !== 'string' || v.includes('\n') || v.includes('\r')) {
+      return { ok: false, reason: `value for ${k} must be a single-line string` };
+    }
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch (err) {
+    return { ok: false, reason: `read failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const hadCrlf = raw !== normalized;
+
+  let newContent: string;
+  if (!normalized.startsWith('---\n')) {
+    // No frontmatter block — prepend a new one followed by the original body.
+    const fm = ['---', ...Object.entries(updates).map(([k, v]) => `${k}: ${v}`), '---', ''].join('\n');
+    newContent = fm + raw;
+  } else {
+    const closingIdx = normalized.indexOf('\n---\n', 4);
+    if (closingIdx === -1) {
+      return { ok: false, reason: 'frontmatter block is unclosed — refusing to rewrite' };
+    }
+
+    const fmBlock = normalized.substring(4, closingIdx);
+    // Body includes the trailing '\n---\n' marker length (5 chars)
+    const bodyStart = closingIdx + 5;
+    const body = normalized.substring(bodyStart);
+
+    // Check for multiline scalar syntax — we can't safely rewrite those.
+    for (const line of fmBlock.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx === -1) continue;
+      const value = trimmed.substring(colonIdx + 1).trim();
+      if (value === '|' || value === '>' || value === '|-' || value === '>-') {
+        process.stderr.write(
+          `[email-agent-mcp] frontmatter-writer: refusing to patch ${filePath} — contains multiline scalar ("${value}")\n`,
+        );
+        return { ok: false, reason: 'multiline YAML scalars are not supported' };
+      }
+    }
+
+    // Patch existing keys in place (first occurrence); append new ones.
+    const fmLines = fmBlock.split('\n');
+    const remainingUpdates = new Map(Object.entries(updates));
+    const duplicateWarnings: string[] = [];
+    const seenKeys = new Set<string>();
+    // Track which keys we actually patched so we can warn on duplicates even
+    // after the update has been consumed from remainingUpdates.
+    const patchedKeys = new Set<string>();
+
+    for (let i = 0; i < fmLines.length; i++) {
+      const line = fmLines[i]!;
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx === -1) continue;
+      const key = trimmed.substring(0, colonIdx).trim();
+
+      if (seenKeys.has(key)) {
+        // Duplicate key in the original frontmatter — warn if we patched the
+        // first occurrence (the duplicate may now disagree with the patched
+        // value).
+        if (patchedKeys.has(key)) {
+          duplicateWarnings.push(key);
+        }
+        continue;
+      }
+      seenKeys.add(key);
+
+      if (remainingUpdates.has(key)) {
+        fmLines[i] = `${key}: ${remainingUpdates.get(key)}`;
+        remainingUpdates.delete(key);
+        patchedKeys.add(key);
+      }
+    }
+
+    // Append any updates whose keys weren't found
+    const appendLines = [...remainingUpdates.entries()].map(([k, v]) => `${k}: ${v}`);
+
+    if (duplicateWarnings.length > 0) {
+      process.stderr.write(
+        `[email-agent-mcp] frontmatter-writer: ${filePath} has duplicate keys ${duplicateWarnings.join(', ')} — only the first occurrence was patched\n`,
+      );
+    }
+
+    const newFm = [...fmLines, ...appendLines].join('\n');
+    newContent = `---\n${newFm}\n---\n${body}`;
+  }
+
+  // Restore CRLF line endings if the original file used them.
+  if (hadCrlf) {
+    newContent = newContent.replace(/\n/g, '\r\n');
+  }
+
+  try {
+    await writeFile(filePath, newContent, 'utf-8');
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, reason: `write failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}

--- a/packages/email-core/src/content/frontmatter.ts
+++ b/packages/email-core/src/content/frontmatter.ts
@@ -11,9 +11,21 @@ export interface FrontmatterFields {
   draft?: boolean;
   format?: BodyFormat;
   force_black?: boolean;
+  attachments?: string[];
+  reply_all?: boolean;
 }
 
-const KNOWN_KEYS = new Set(['to', 'cc', 'subject', 'reply_to', 'draft', 'format', 'force_black']);
+const KNOWN_KEYS = new Set([
+  'to',
+  'cc',
+  'subject',
+  'reply_to',
+  'draft',
+  'format',
+  'force_black',
+  'attachments',
+  'reply_all',
+]);
 
 export function parseFrontmatter(
   content: string,
@@ -73,6 +85,11 @@ export function parseFrontmatter(
       // unknown values silently ignored — action layer falls back to default
     } else if (key === 'force_black') {
       fields.force_black = value.toLowerCase() === 'true';
+    } else if (key === 'attachments') {
+      // Always a list (even single value)
+      fields.attachments = value.split(',').map(s => s.trim()).filter(Boolean);
+    } else if (key === 'reply_all') {
+      fields.reply_all = value.toLowerCase() === 'true';
     }
   }
 

--- a/packages/email-core/src/content/safe-path.ts
+++ b/packages/email-core/src/content/safe-path.ts
@@ -1,0 +1,27 @@
+// Shared safe-path check used by body-loader and attachment-loader.
+//
+// The naive approach — `candidate.startsWith(baseDir)` — has a sibling-prefix
+// bug: given `baseDir=/allowed`, `candidate=/allowed-evil/foo` would pass,
+// because the string "/allowed-evil/foo" literally starts with "/allowed".
+// This caller uses `path.relative()` + rejection of `..`-prefixes or absolute
+// results, which correctly distinguishes subdirectories from prefix-siblings.
+//
+// Callers should pass REALPATHS (with symlinks resolved) for both arguments,
+// so this helper's answer is accurate for symlink-containing trees too.
+import { relative, isAbsolute } from 'node:path';
+
+/**
+ * Return true if `candidateReal` is equal to `baseReal` or a descendant of it.
+ * Both inputs should already be absolute realpaths (pass them through
+ * `fs.promises.realpath` first).
+ */
+export function isPathInsideDir(candidateReal: string, baseReal: string): boolean {
+  if (!isAbsolute(candidateReal) || !isAbsolute(baseReal)) return false;
+  const rel = relative(baseReal, candidateReal);
+  // An empty relative path means candidate === base (inside by definition).
+  if (rel === '') return true;
+  // If rel starts with '..' or is itself absolute, candidate is outside base.
+  if (rel.startsWith('..')) return false;
+  if (isAbsolute(rel)) return false;
+  return true;
+}

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -46,6 +46,12 @@ export { parseFrontmatter } from './content/frontmatter.js';
 export type { FrontmatterFields } from './content/frontmatter.js';
 export { resolveBodyFile, truncateBody, BODY_SIZE_LIMIT } from './content/body-loader.js';
 export {
+  resolveAttachments,
+  ATTACHMENT_MAX_SIZE,
+  ATTACHMENT_DIR_ENV,
+} from './content/attachment-loader.js';
+export type { AttachmentLoaderError, AttachmentLoaderResult } from './content/attachment-loader.js';
+export {
   checkMailboxRequired,
   resolveComposeFields,
   validateRequiredFields,

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -51,6 +51,8 @@ export {
   ATTACHMENT_DIR_ENV,
 } from './content/attachment-loader.js';
 export type { AttachmentLoaderError, AttachmentLoaderResult } from './content/attachment-loader.js';
+export { patchFrontmatter } from './content/frontmatter-writer.js';
+export type { PatchResult } from './content/frontmatter-writer.js';
 export {
   checkMailboxRequired,
   resolveComposeFields,

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -7,6 +7,7 @@ export type {
   EmailThread,
   EmailAttachment,
   ComposeMessage,
+  OutboundAttachment,
   SendResult,
   DraftResult,
   ListOptions,
@@ -20,6 +21,7 @@ export type {
   EmailProvider,
   AuthManager,
 } from './providers/provider.js';
+export { ProviderError } from './providers/provider.js';
 export {
   isAllowedSender,
   loadReceiveAllowlist,

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -1,5 +1,6 @@
 // Mock email provider for testing — implements all capability interfaces in-memory
 import type {
+  EmailAddress,
   EmailMessage,
   EmailThread,
   ComposeMessage,
@@ -26,6 +27,10 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
   private subscriptions: Map<string, (msg: EmailMessage) => void> = new Map();
   private attachmentData: Map<string, Buffer> = new Map();
   private nextId = 1;
+  // The "self" address — excluded from auto-populated cc in createReplyDraft
+  // so reply-all simulation doesn't cc yourself. Matches the default returned
+  // by getMessage() for drafts.
+  public selfAddress = 'me@company.com';
 
   // --- Setup helpers for tests ---
 
@@ -255,12 +260,37 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
       throw new Error(`Message not found: ${messageId}`);
     }
     const draftId = `draft-${this.nextId++}`;
+
+    // Simulate real provider reply-all behavior: when replyAll !== false,
+    // populate cc from the original thread's to + cc (excluding self). Tests
+    // can then assert that email-core allowlist-checks these auto-populated
+    // recipients.
+    const replyAll = opts?.replyAll !== false;
+    let cc: EmailAddress[] | undefined;
+    if (replyAll) {
+      const autoCc = [
+        ...(original.to ?? []),
+        ...(original.cc ?? []),
+      ].filter(a => a.email !== this.selfAddress);
+      const extraCc = opts?.cc ?? [];
+      const seen = new Set<string>();
+      const merged = [...autoCc, ...extraCc].filter(a => {
+        if (seen.has(a.email)) return false;
+        seen.add(a.email);
+        return true;
+      });
+      cc = merged.length > 0 ? merged : undefined;
+    } else {
+      cc = opts?.cc;
+    }
+
     this.drafts.set(draftId, {
       to: [original.from],
-      cc: opts?.cc,
+      cc,
       subject: `Re: ${original.subject}`,
       body,
       bodyHtml: opts?.bodyHtml,
+      attachments: opts?.attachments,
     });
     return { success: true, draftId };
   }
@@ -350,6 +380,12 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
 
   async deleteMessage(messageId: string, hard?: boolean): Promise<void> {
     this.maybeThrow();
+    // Drafts are stored separately — hard-delete removes them regardless of
+    // the `hard` flag (there's no trash concept for drafts).
+    if (this.drafts.has(messageId)) {
+      this.drafts.delete(messageId);
+      return;
+    }
     if (hard) {
       this.messages = this.messages.filter(m => m.id !== messageId);
     } else {

--- a/packages/email-core/src/types.ts
+++ b/packages/email-core/src/types.ts
@@ -124,6 +124,15 @@ export interface ReplyOptions {
    * send with plain-text content-type.
    */
   bodyHtml?: string;
+  /**
+   * When true (default), reply to all original recipients (to + cc).
+   * When false, reply only to the original sender.
+   * Providers that natively distinguish reply vs reply-all use this to
+   * select the correct endpoint (Graph: createReply vs createReplyAll);
+   * providers that construct MIME themselves use it to toggle whether
+   * to include the original to/cc as the reply's cc.
+   */
+  replyAll?: boolean;
 }
 
 export interface Subscription {

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -10,6 +10,7 @@ import type {
   ListOptions,
   ReplyOptions,
 } from '@usejunior/email-core';
+import { ProviderError } from '@usejunior/email-core';
 
 // Gmail label mapping
 const FOLDER_TO_LABEL: Record<string, string> = {
@@ -129,18 +130,35 @@ export class GmailEmailProvider {
   }
 
   async sendMessage(msg: ComposeMessage): Promise<SendResult> {
+    if (msg.attachments?.length) {
+      throw new ProviderError(
+        'NOT_SUPPORTED',
+        'Outbound attachments are not yet supported on Gmail — buildRawMessage does not emit multipart/mixed',
+        'gmail',
+        false,
+      );
+    }
     const raw = buildRawMessage(msg);
     const result = await this.client.sendMessage(raw, msg.threadId);
     return { success: true, messageId: result.id };
   }
 
   async replyToMessage(messageId: string, body: string, opts?: ReplyOptions): Promise<SendResult> {
-    // Match Microsoft's createReplyAll semantics: reply to sender and cc
-    // everyone else on the original message. Caller-supplied opts.cc/bcc
-    // layer on top. Shipping without self-exclusion — an agent that replies
-    // to its own sent mail may cc itself; documented caveat.
+    if (opts?.attachments?.length) {
+      throw new ProviderError(
+        'NOT_SUPPORTED',
+        'Outbound attachments are not yet supported on Gmail',
+        'gmail',
+        false,
+      );
+    }
+    // Reply-all is the default (matches Microsoft's createReplyAll semantics
+    // and pre-existing Gmail behavior). When opts.replyAll === false, narrow
+    // to sender only and skip the original.to/original.cc merge.
     const original = await this.getMessage(messageId);
-    const replyAllCc = mergeAddressLists(original.to, original.cc, opts?.cc);
+    const replyAllCc = opts?.replyAll === false
+      ? (opts?.cc ?? [])
+      : mergeAddressLists(original.to, original.cc, opts?.cc);
     const subject = prefixReSubject(original.subject);
     const references = buildReferences(original.references, original.messageId);
 
@@ -164,6 +182,14 @@ export class GmailEmailProvider {
   }
 
   async createDraft(msg: ComposeMessage): Promise<DraftResult> {
+    if (msg.attachments?.length) {
+      throw new ProviderError(
+        'NOT_SUPPORTED',
+        'Outbound attachments are not yet supported on Gmail',
+        'gmail',
+        false,
+      );
+    }
     const raw = buildRawMessage(msg);
     const result = await this.client.createDraft(raw, msg.threadId);
     return { success: true, draftId: result.id };
@@ -175,9 +201,22 @@ export class GmailEmailProvider {
   }
 
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
+    if (opts?.attachments?.length) {
+      return {
+        success: false,
+        error: {
+          code: 'NOT_SUPPORTED',
+          message: 'Outbound attachments are not yet supported on Gmail',
+          recoverable: false,
+        },
+      };
+    }
     try {
       const original = await this.getMessage(messageId);
-      const replyAllCc = mergeAddressLists(original.to, original.cc, opts?.cc);
+      // Reply-all by default; opts.replyAll === false narrows to sender only.
+      const replyAllCc = opts?.replyAll === false
+        ? (opts?.cc ?? [])
+        : mergeAddressLists(original.to, original.cc, opts?.cc);
       const subject = prefixReSubject(original.subject);
       const references = buildReferences(original.references, original.messageId);
 

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -117,6 +117,108 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
   });
 });
 
+describe('provider-microsoft/Attachments (plan §2.1)', () => {
+  it('Scenario: createDraft uploads each attachment via follow-up POST', async () => {
+    const postCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const client = createMockClient({
+      post: vi.fn().mockImplementation(async (url: string, body: Record<string, unknown>) => {
+        postCalls.push({ url, body });
+        // First call returns the draft, subsequent calls are /attachments POSTs
+        if (postCalls.length === 1) return { id: 'draft-with-att' };
+        return { id: `att-${postCalls.length}` };
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.createDraft({
+      to: [{ email: 'alice@corp.com' }],
+      subject: 'With attachments',
+      body: 'See attached',
+      attachments: [
+        { filename: 'one.pdf', content: Buffer.from('first'), mimeType: 'application/pdf' },
+        { filename: 'two.txt', content: Buffer.from('second'), mimeType: 'text/plain' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.draftId).toBe('draft-with-att');
+    // First call is the draft creation; next two are attachment POSTs
+    expect(postCalls).toHaveLength(3);
+    expect(postCalls[0]!.url).toMatch(/\/messages$/);
+    expect(postCalls[1]!.url).toMatch(/\/messages\/draft-with-att\/attachments$/);
+    expect(postCalls[1]!.body).toMatchObject({
+      '@odata.type': '#microsoft.graph.fileAttachment',
+      name: 'one.pdf',
+      contentType: 'application/pdf',
+      contentBytes: Buffer.from('first').toString('base64'),
+    });
+    expect(postCalls[2]!.url).toMatch(/\/messages\/draft-with-att\/attachments$/);
+    expect(postCalls[2]!.body).toMatchObject({
+      name: 'two.txt',
+      contentBytes: Buffer.from('second').toString('base64'),
+    });
+  });
+
+  it('Scenario: createDraft rolls back draft when attachment upload fails', async () => {
+    let postCallCount = 0;
+    const client = createMockClient({
+      post: vi.fn().mockImplementation(async () => {
+        postCallCount++;
+        if (postCallCount === 1) return { id: 'orphan-draft' }; // initial draft
+        throw new Error('Graph attachment endpoint exploded'); // attachment upload fails
+      }),
+      delete: vi.fn().mockResolvedValue(undefined),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    let caught: unknown;
+    try {
+      await provider.createDraft({
+        to: [{ email: 'alice@corp.com' }],
+        subject: 'Rollback test',
+        body: 'body',
+        attachments: [
+          { filename: 'x.pdf', content: Buffer.from('x'), mimeType: 'application/pdf' },
+        ],
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as { code: string }).code).toBe('ATTACHMENT_UPLOAD_FAILED');
+
+    // Verify cleanup delete was issued
+    expect(client.delete).toHaveBeenCalledWith(
+      expect.stringContaining('/messages/orphan-draft'),
+    );
+  });
+
+  it('Scenario: createReplyDraft(replyAll=false) attaches files and hits /createReply endpoint', async () => {
+    const postCalls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    const client = createMockClient({
+      post: vi.fn().mockImplementation(async (url: string, body: Record<string, unknown>) => {
+        postCalls.push({ url, body });
+        if (postCalls.length === 1) return { id: 'reply-draft-1' };
+        return {};
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.createReplyDraft('msg-1', 'Body', {
+      replyAll: false,
+      attachments: [
+        { filename: 'doc.pdf', content: Buffer.from('d'), mimeType: 'application/pdf' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(postCalls[0]!.url).toContain('/createReply');
+    expect(postCalls[0]!.url).not.toContain('createReplyAll');
+    expect(postCalls[1]!.url).toMatch(/\/messages\/reply-draft-1\/attachments$/);
+    expect(postCalls[1]!.body).toMatchObject({ name: 'doc.pdf' });
+  });
+});
+
 describe('provider-microsoft/Size Limits', () => {
   it('Scenario: Body size enforcement', async () => {
     const client = createMockClient();

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -46,11 +46,13 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
     );
   });
 
-  it('Scenario: Fallback to sendMail on 404', async () => {
+  it('Scenario: replyToMessage throws when createReply endpoint fails', async () => {
+    // The old fallback-to-sendMail path was removed (it sent garbage with
+    // subject "Re: " and to: opts?.cc). replyToMessage now cleanly errors
+    // when the provider can't create the reply draft; the email-core
+    // reply action handles cleanup.
     const client = createMockClient({
-      post: vi.fn()
-        .mockRejectedValueOnce(new Error('404 Not Found')) // createReplyAll fails
-        .mockResolvedValueOnce({ id: 'sent-msg' }), // sendMail fallback
+      post: vi.fn().mockRejectedValueOnce(new Error('404 Not Found')),
       get: vi.fn().mockResolvedValue({
         id: 'deleted-msg',
         subject: 'Deleted',
@@ -60,14 +62,58 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
     });
     const provider = new GraphEmailProvider(client);
 
-    const result = await provider.replyToMessage('deleted-msg', 'Response');
+    await expect(provider.replyToMessage('deleted-msg', 'Response')).rejects.toThrow('404 Not Found');
+  });
+
+  it('Scenario: createReplyDraft(replyAll=false) hits createReply endpoint', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce({ id: 'draft-rp' }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.createReplyDraft('msg-1', 'Body', { replyAll: false });
 
     expect(result.success).toBe(true);
-    // Falls back to sendMail
-    expect(client.post).toHaveBeenCalledWith(
-      expect.stringContaining('sendMail'),
-      expect.anything(),
-    );
+    expect(result.draftId).toBe('draft-rp');
+    // Should hit /createReply (NOT /createReplyAll)
+    const firstCall = (client.post as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(firstCall[0]).toContain('/createReply');
+    expect(firstCall[0]).not.toContain('createReplyAll');
+  });
+
+  it('Scenario: createReplyDraft(replyAll=true) hits createReplyAll endpoint', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce({ id: 'draft-ra' }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.createReplyDraft('msg-1', 'Body', { replyAll: true });
+
+    expect(result.success).toBe(true);
+    const firstCall = (client.post as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(firstCall[0]).toContain('/createReplyAll');
+  });
+
+  it('Scenario: createDraft emits ccRecipients (regression for dropped cc bug)', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce({ id: 'draft-cc' }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createDraft({
+      to: [{ email: 'to@corp.com' }],
+      cc: [{ email: 'cc1@corp.com' }, { email: 'cc2@corp.com' }],
+      subject: 'Test',
+      body: 'Body',
+    });
+
+    const firstCall = (client.post as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(firstCall[1]).toMatchObject({
+      ccRecipients: [
+        { emailAddress: { address: 'cc1@corp.com' } },
+        { emailAddress: { address: 'cc2@corp.com' } },
+      ],
+    });
   });
 });
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -10,7 +10,9 @@ import type {
   EmailReader,
   EmailSender,
   EmailCategorizer,
+  OutboundAttachment,
 } from '@usejunior/email-core';
+import { ProviderError } from '@usejunior/email-core';
 
 const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 const SUBJECT_MAX_LENGTH = 255;
@@ -289,45 +291,53 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async replyToMessage(messageId: string, body: string, opts?: ReplyOptions): Promise<SendResult> {
-    // Use createReplyAll to preserve embedded images and CID references
-    try {
-      const draft = await this.client.post(
-        `${this.basePath}/messages/${messageId}/createReplyAll`,
-        {},
-      );
-
-      if (draft.id) {
-        // Update draft body — pick HTML if caller rendered it, else plain text
-        await this.client.patch(`${this.basePath}/messages/${draft.id}`, {
-          body: buildGraphBody(opts?.bodyHtml, body),
-        });
-
-        // Send the draft
-        await this.client.post(`${this.basePath}/messages/${draft.id}/send`, {});
-        return { success: true, messageId: draft.id };
-      }
-    } catch {
-      // Fallback to sendMail on 404 (original deleted)
+    // Thin delegate: create a reply draft and send it. The reply action in
+    // email-core now drives the draft-first flow directly (so it can
+    // allowlist-check the populated recipients), but we keep this method for
+    // backward compatibility with callers that used the flat send API.
+    const draftResult = await this.createReplyDraft(messageId, body, opts);
+    if (!draftResult.success || !draftResult.draftId) {
+      return {
+        success: false,
+        error: draftResult.error ?? { code: 'REPLY_FAILED', message: 'createReplyDraft returned no draftId', provider: 'microsoft', recoverable: false },
+      };
     }
-
-    // Fallback: construct reply manually via sendMail
-    return this.sendMessage({
-      to: opts?.cc ?? [],
-      subject: `Re: `,
-      body,
-      bodyHtml: opts?.bodyHtml,
-    });
+    try {
+      return await this.sendDraft(draftResult.draftId);
+    } catch (err) {
+      // If send fails, try to clean up the half-formed draft
+      try {
+        await this.client.delete(`${this.basePath}/messages/${draftResult.draftId}`);
+      } catch {
+        process.stderr.write(
+          `[email-agent-mcp] WARNING: failed to clean up reply draft ${draftResult.draftId} after send failure\n`,
+        );
+      }
+      throw err;
+    }
   }
 
   async createDraft(msg: ComposeMessage): Promise<DraftResult> {
-    const graphMsg = {
+    const graphMsg: Record<string, unknown> = {
       subject: msg.subject,
       body: buildGraphBody(msg.bodyHtml, msg.body),
       toRecipients: msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } })),
     };
+    if (msg.cc?.length) {
+      graphMsg.ccRecipients = msg.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
+    }
+    if (msg.bcc?.length) {
+      graphMsg.bccRecipients = msg.bcc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
+    }
 
     const response = await this.client.post(`${this.basePath}/messages`, graphMsg);
-    return { success: true, draftId: response.id };
+    const draftId = response.id as string;
+
+    if (msg.attachments?.length) {
+      await this.uploadAttachments(draftId, msg.attachments);
+    }
+
+    return { success: true, draftId };
   }
 
   async sendDraft(draftId: string): Promise<SendResult> {
@@ -336,25 +346,80 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
-    // Use createReplyAll to preserve embedded images and CID references
+    // Switch between createReply (sender only) and createReplyAll (to + cc)
+    // based on opts.replyAll. Default is reply-all to preserve embedded
+    // images / CID references and match historical behavior.
+    const replyEndpoint = opts?.replyAll === false ? 'createReply' : 'createReplyAll';
     const draft = await this.client.post(
-      `${this.basePath}/messages/${messageId}/createReplyAll`,
+      `${this.basePath}/messages/${messageId}/${replyEndpoint}`,
       {},
     );
 
-    if (draft.id) {
-      // Update draft body — HTML if caller rendered it, else plain text
-      const patch: Record<string, unknown> = {
-        body: buildGraphBody(opts?.bodyHtml, body),
-      };
-      if (opts?.cc?.length) {
-        patch.ccRecipients = opts.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
-      }
-      await this.client.patch(`${this.basePath}/messages/${draft.id}`, patch);
-      return { success: true, draftId: draft.id };
+    if (!draft.id) {
+      return { success: false, error: { code: 'DRAFT_FAILED', message: 'Failed to create reply draft', provider: 'microsoft', recoverable: false } };
     }
 
-    return { success: false, error: { code: 'DRAFT_FAILED', message: 'Failed to create reply draft', recoverable: false } };
+    // Update draft body — HTML if caller rendered it, else plain text
+    const patch: Record<string, unknown> = {
+      body: buildGraphBody(opts?.bodyHtml, body),
+    };
+    if (opts?.cc?.length) {
+      patch.ccRecipients = opts.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
+    }
+    await this.client.patch(`${this.basePath}/messages/${draft.id}`, patch);
+
+    if (opts?.attachments?.length) {
+      await this.uploadAttachments(draft.id, opts.attachments);
+    }
+
+    return { success: true, draftId: draft.id };
+  }
+
+  /**
+   * Upload outbound attachments to an already-created draft via
+   * `POST /messages/{draftId}/attachments`. On any failure, attempt to
+   * DELETE the draft so we don't leave a half-attached draft in the user's
+   * mailbox. If the cleanup DELETE also fails, log the orphaned draftId to
+   * stderr so the user can clean it up manually.
+   *
+   * Throws ProviderError with code ATTACHMENT_UPLOAD_FAILED on any failure.
+   */
+  private async uploadAttachments(
+    draftId: string,
+    attachments: readonly OutboundAttachment[],
+  ): Promise<void> {
+    for (const att of attachments) {
+      const payload = {
+        '@odata.type': '#microsoft.graph.fileAttachment',
+        name: att.filename,
+        contentType: att.mimeType,
+        contentBytes: att.content.toString('base64'),
+      };
+      try {
+        await this.client.post(
+          `${this.basePath}/messages/${draftId}/attachments`,
+          payload,
+        );
+      } catch (err) {
+        // Rollback: delete the draft. If delete also fails, orphan is logged.
+        try {
+          await this.client.delete(`${this.basePath}/messages/${draftId}`);
+        } catch (deleteErr) {
+          process.stderr.write(
+            `[email-agent-mcp] WARNING: attachment upload failed AND draft cleanup failed. ` +
+            `Orphaned draftId=${draftId}. ` +
+            `Upload error: ${err instanceof Error ? err.message : String(err)}. ` +
+            `Cleanup error: ${deleteErr instanceof Error ? deleteErr.message : String(deleteErr)}\n`,
+          );
+        }
+        throw new ProviderError(
+          'ATTACHMENT_UPLOAD_FAILED',
+          `Failed to upload attachment "${att.filename}": ${err instanceof Error ? err.message : String(err)}`,
+          'microsoft',
+          false,
+        );
+      }
+    }
   }
 
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {


### PR DESCRIPTION
## Summary

Closes feature gaps between `create_draft`/`reply_to_email` and `save_draft_to_outlook.py`: outbound attachments, `reply_all` toggle, and opt-in frontmatter back-link. Also fixes a pre-existing P0 security bug where `reply_to_email(reply_all=true)` could send to recipients that were never allowlist-checked.

## Changes by area

### P0 fix — reply-all allowlist bypass (`reply.ts`)
Before: only `originalMessage.from.email` was checked against the send allowlist. But Microsoft's \`createReplyAll\` auto-populates every original to + cc recipient. A reply-all from an allowlisted sender could leak to non-allowlisted cc recipients that never passed the gate.

After: unified draft-first flow — \`createReplyDraft → getMessage(draftId) → checkSendAllowlist(populatedRecipients) → sendDraft\`. On allowlist failure, the draft is hard-deleted.

### Pre-existing bugs fixed while in the file
- \`create_draft(reply_to=...)\` over-validated \`to\` / \`subject\` — relaxed (the provider auto-populates from the thread). Still required when \`reply_all=false\`.
- \`body-loader.ts\` sibling-prefix path traversal: \`resolved.startsWith(baseDir)\` accepted \`/allowed-evil/x.md\` when \`baseDir=/allowed\`. New \`safe-path.ts\` helper uses \`path.relative()\`.
- Microsoft \`createDraft\` was silently dropping \`cc\`.
- Microsoft \`replyToMessage\` fallback was garbage (subject=\`Re: \`, to=\`opts?.cc\`). Deleted — the email-core action now drives the draft-first flow directly.

### New features

**Attachments** (\`attachment-loader.ts\`, \`create_draft\` + \`reply_to_email\`)
- Files must live in \`EMAIL_AGENT_MCP_ATTACHMENT_DIR\` (required, absolute, existing)
- 3 MiB cap per file; zero-byte files allowed
- Realpath-based dedupe; basename collisions get \` (2)\`, \` (3)\` suffixes
- Frontmatter \`attachments:\` is **additive** with the param list (the one exception to "frontmatter wins")
- Microsoft: follow-up \`POST /messages/{id}/attachments\` with \`DELETE\` rollback; if cleanup fails, orphaned draftId logged to stderr
- Gmail: \`NOT_SUPPORTED\` (buildRawMessage doesn't emit multipart/mixed)
- New deps: \`mime-types\` + \`@types/mime-types\`

**\`reply_all\` toggle** (default \`true\`)
- Microsoft: switches between \`/createReplyAll\` and \`/createReply\` endpoints
- Gmail: conditionally skips the \`mergeAddressLists\` auto-population

**\`update_source_frontmatter\` flag** (opt-in, default \`false\`)
- After successful draft creation, patches the source \`body_file\` frontmatter with \`draft_id\` + \`draft_link\` (or \`draft_reply_id\` + \`draft_reply_link\`)
- Silent-fail: logs to stderr, doesn't abort the draft
- New \`patchFrontmatter\` helper handles prepend-new-block, replace-first-occurrence, duplicate-key warning, multiline-scalar refusal, and CRLF preservation

## Security hardening

- \`EMAIL_AGENT_MCP_ATTACHMENT_DIR\` fails closed with distinct error codes (\`_NOT_CONFIGURED\`, \`_NOT_ABSOLUTE\`, \`_NOT_FOUND\`)
- Both body-loader and attachment-loader now use \`isPathInsideDir(realCandidate, realBase)\` (realpath + \`path.relative()\`) — no more sibling-prefix vulnerability
- Attachment rollback on upload failure prevents half-attached drafts

## Test coverage

484/484 passing (+54 from baseline).

New test files:
- \`content/attachment-loader.test.ts\` — 20 cases: happy path, size boundary (exactly 3 MiB vs +1), env var validation, path traversal, **sibling-prefix attack**, symlink escape, dedupe across rel/abs/symlink, filename collision, mime detection, zero-byte
- \`content/frontmatter-writer.test.ts\` — 12 cases: prepend, append, replace, body-byte-exact, duplicate-key warning, multiline refusal, unclosed refusal, CRLF, key/value validation, missing/readonly file

New cases in existing files:
- \`actions/reply.test.ts\` — **P0 regression**: reply-all with evil cc blocked + draft cleaned up; \`reply_all=false\` narrowing
- \`actions/draft.test.ts\` — attachment wire-up, relaxed reply validation, frontmatter reply_all override, update_source_frontmatter (reply + standard, silent-fail)
- \`provider-microsoft/email-graph-provider.test.ts\` — \`createReplyDraft({replyAll})\` endpoint selection, \`createDraft\` cc regression, \`uploadAttachments\` flow, rollback on upload failure

## Test plan

- [x] \`npm run build\` clean across all four workspaces
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 484/484 passing
- [ ] Manual smoke test against a real Microsoft account:
  - \`export EMAIL_AGENT_MCP_ATTACHMENT_DIR=/tmp/attach && mkdir -p \$EMAIL_AGENT_MCP_ATTACHMENT_DIR\`
  - \`create_draft\` with \`attachments=["file.pdf"]\` → open Outlook, confirm attachment
  - \`reply_to_email\` reply-all to a thread with evil cc → confirm \`ALLOWLIST_BLOCKED\`
  - \`create_draft(body_file=x.md, update_source_frontmatter=true)\` → confirm keys written back

## Breaking changes

\`fix(reply)!\` — the \`reply_to_email\` send path now creates a draft and fetches recipients before sending. External callers relying on the old \`replyToMessage\` fallback-to-sendMail path will see behavior changes (the fallback was broken anyway).