### PR TITLE
[codex] Fix OpenClaw schema compatibility

### DIFF
--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -71,6 +71,14 @@ describe('mcp-transport/Zod Schema Constraints', () => {
     }
   });
 
+  it('Scenario: root $schema is omitted for OpenClaw compatibility', () => {
+    const tools = actionsToMcpTools(testActions);
+
+    for (const tool of tools) {
+      expect(tool.inputSchema.$schema).toBeUndefined();
+    }
+  });
+
   it('Scenario: ZodUnion fields emit anyOf, not {}', () => {
     // Regression lock for the `z.toJsonSchema` casing bug: previously the
     // feature-detect fell through to a hand-rolled generator that returned

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -219,9 +219,19 @@ export async function handleToolCall(
  * `ZodUnion`, which is why `send_email.to` (a `string | string[]` union)
  * previously emitted `{}` in `tools/list` and some MCP clients couldn't
  * validate calls to it. Fixed by calling the real API directly.
+ *
+ * Compatibility note: Zod v4 annotates schemas with
+ * `$schema: "https://json-schema.org/draft/2020-12/schema"`. OpenClaw's
+ * current MCP validator rejects that draft header during tool-call
+ * validation, even though the emitted keywords we rely on (`type`, `anyOf`,
+ * `default`, `properties`) are otherwise compatible. Strip the root
+ * `$schema` marker so OpenClaw can compile the tool schema while we keep the
+ * richer generated shape.
  */
 function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
-  return z.toJSONSchema(schema, { io: 'input' }) as Record<string, unknown>;
+  const jsonSchema = z.toJSONSchema(schema, { io: 'input' }) as Record<string, unknown>;
+  delete jsonSchema.$schema;
+  return jsonSchema;
 }
 
 /**


### PR DESCRIPTION
## What changed
This strips the root `$schema` field from the JSON Schemas emitted for MCP tool inputs in `email-mcp`, while keeping the richer Zod v4 `toJSONSchema()` output for the rest of the schema.

## Why
OpenClaw's current validator rejects schemas that declare the Draft 2020-12 meta-schema at the root, which caused `list_emails` and other email MCP tools to fail with:

`no schema with key or ref "https://json-schema.org/draft/2020-12/schema"`

That broke the OpenClaw heartbeat flow after the gateway reloaded the updated MCP tool definitions.

## Impact
This restores compatibility with OpenClaw/NemoClaw without changing the tool argument structure seen by MCP clients.

## Validation
- `npm run test:run -w @usejunior/email-mcp`
- `npm run build -w @usejunior/email-mcp`
- Verified end-to-end against a live OpenClaw instance after repointing it at this branch:
  - reset the isolated heartbeat session
  - forced a fresh heartbeat run
  - confirmed a new `list_emails` tool call completed successfully instead of failing with the Draft 2020-12 schema error
- Added a regression test asserting emitted tool schemas do not include a root `$schema`
