### PR TITLE
feat: add Gmail configure flow and mailbox-safe MCP routing

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -101,9 +101,9 @@ Agent Email stellt 15 MCP-Tools bereit:
 | Anbieter | Status | Paket |
 |----------|--------|-------|
 | Microsoft 365 (Graph API) | Vollstaendig unterstuetzt | `@usejunior/provider-microsoft` |
-| Gmail | In Kuerze verfuegbar | `@usejunior/provider-gmail` |
+| Gmail | Unterstuetzt per manuellem Refresh-Token-Setup | `@usejunior/provider-gmail` |
 
-Das Gmail-Provider-Paket existiert mit vollstaendiger Testabdeckung. Die Anbindung an den MCP-Server ist in Arbeit.
+Gmail funktioniert jetzt im MCP-Server ueber eine manuelle Datei unter `~/.email-agent-mcp/tokens/`. Der interaktive Gmail-Assistent ist weiterhin ein Follow-up. Siehe `packages/provider-gmail/README.md`.
 
 ## Sicherheitsstandards
 

--- a/README.es.md
+++ b/README.es.md
@@ -101,9 +101,9 @@ Agent Email expone 15 herramientas MCP:
 | Proveedor | Estado | Paquete |
 |-----------|--------|---------|
 | Microsoft 365 (Graph API) | Totalmente soportado | `@usejunior/provider-microsoft` |
-| Gmail | Proximamente | `@usejunior/provider-gmail` |
+| Gmail | Compatible mediante OAuth interactivo por CLI o configuracion manual de refresh token | `@usejunior/provider-gmail` |
 
-El paquete del proveedor de Gmail existe con cobertura completa de pruebas. La integracion con el servidor MCP esta en progreso.
+Usa `email-agent-mcp configure --provider gmail` para ejecutar el flujo OAuth local en el navegador, o agrega un archivo manual en `~/.email-agent-mcp/tokens/`. Consulta `packages/provider-gmail/README.md`.
 
 ## Seguridad por defecto
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 **email-agent-mcp** by [UseJunior](https://usejunior.com) -- local email connectivity for AI agents.
 
-Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook is supported today; Gmail wiring is in progress. Security-first defaults mean agents cannot send email until you explicitly configure an allowlist.
+Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook and Gmail are supported today. Security-first defaults mean agents cannot send email until you explicitly configure an allowlist.
 
 ## Quick Start
 
@@ -167,9 +167,9 @@ Agent Email exposes 15 MCP tools:
 | Provider | Status | Package |
 |----------|--------|---------|
 | Microsoft 365 (Graph API) | Fully supported | `@usejunior/provider-microsoft` |
-| Gmail | Coming soon | `@usejunior/provider-gmail` |
+| Gmail | Supported via interactive CLI OAuth or manual refresh-token setup | `@usejunior/provider-gmail` |
 
-The Gmail provider package exists with full test coverage. Wiring into the MCP server is in progress.
+Use `email-agent-mcp configure --provider gmail` to run the local browser OAuth flow, or add a manual mailbox token file under `~/.email-agent-mcp/tokens/`. See [packages/provider-gmail/README.md](./packages/provider-gmail/README.md).
 
 ## Security Defaults
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -101,9 +101,9 @@ O Agent Email expoe 15 ferramentas MCP:
 | Provedor | Status | Pacote |
 |----------|--------|--------|
 | Microsoft 365 (Graph API) | Totalmente suportado | `@usejunior/provider-microsoft` |
-| Gmail | Em breve | `@usejunior/provider-gmail` |
+| Gmail | Suportado via OAuth interativo no CLI ou configuracao manual de refresh token | `@usejunior/provider-gmail` |
 
-O pacote do provedor Gmail ja existe com cobertura completa de testes. A integracao com o servidor MCP esta em andamento.
+Use `email-agent-mcp configure --provider gmail` para executar o fluxo OAuth local no navegador, ou adicione um arquivo manual em `~/.email-agent-mcp/tokens/`. Veja `packages/provider-gmail/README.md`.
 
 ## Configuracoes Padrao de Seguranca
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -101,9 +101,9 @@ Agent Email 提供 15 个 MCP 工具：
 | 提供商 | 状态 | 包名 |
 |--------|------|------|
 | Microsoft 365 (Graph API) | 完全支持 | `@usejunior/provider-microsoft` |
-| Gmail | 即将推出 | `@usejunior/provider-gmail` |
+| Gmail | 支持通过手动 refresh token 配置接入 | `@usejunior/provider-gmail` |
 
-Gmail 提供商包已编写完成并具有完整的测试覆盖。接入 MCP 服务器的工作正在进行中。
+Gmail 现在可以通过写入 `~/.email-agent-mcp/tokens/` 下的手动配置文件接入 MCP 服务器。交互式 Gmail 配置向导仍是后续工作。参见 `packages/provider-gmail/README.md`。
 
 ## 安全默认值
 

--- a/openspec/changes/add-gmail-cli-configure/proposal.md
+++ b/openspec/changes/add-gmail-cli-configure/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+The repository now supports Gmail mailbox loading from stored refresh tokens, but the CLI still rejects `email-agent-mcp configure --provider gmail` and the wizard still describes Gmail as a manual-only path. This leaves the advertised multi-provider architecture incomplete and forces users to create token files by hand.
+
+## What Changes
+
+- Add an interactive Gmail configure flow behind `email-agent-mcp configure --provider gmail`
+- Use a localhost OAuth callback flow with PKCE to obtain Gmail refresh tokens from a Google OAuth client
+- Persist Gmail mailbox metadata under `~/.email-agent-mcp/tokens/` using the mailbox email as the canonical storage key
+- Auto-add the authenticated Gmail address to the send allowlist, matching the Microsoft configure path
+- Update the wizard and CLI docs so Gmail is presented as an available interactive provider instead of "coming soon" or manual-only
+
+## Impact
+
+- Affected specs: `cli`, `mailbox-config`, `provider-gmail`
+- Affected code: `packages/email-mcp`, `packages/provider-gmail`
+- User-visible behavior: `configure` and first-run wizard can complete Gmail setup without manual token file editing

--- a/openspec/changes/add-gmail-cli-configure/specs/cli/spec.md
+++ b/openspec/changes/add-gmail-cli-configure/specs/cli/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Subcommand
+
+The system SHALL provide a `configure` subcommand (aliased as `setup`) with an interactive setup wizard: provider picker, credentials entry, connection test, and config persistence.
+
+#### Scenario: Interactive setup
+- **WHEN** `email-agent-mcp configure` is run
+- **THEN** the system launches the interactive wizard with a provider picker for Outlook and Gmail and tests the selected connection
+
+#### Scenario: Direct Gmail configure
+- **WHEN** `email-agent-mcp configure --provider gmail` is run
+- **THEN** the system starts the Gmail OAuth flow
+- **AND** persists mailbox metadata after the callback completes successfully
+
+#### Scenario: Setup alias
+- **WHEN** `email-agent-mcp setup` is run
+- **THEN** the system behaves identically to `email-agent-mcp configure`
+
+### Requirement: Interactive Wizard
+
+The interactive wizard SHALL guide the user through provider selection, credential entry, and connection verification. It uses a provider picker presenting available options.
+
+#### Scenario: Provider picker shows available providers
+- **WHEN** the interactive wizard starts
+- **THEN** it presents a provider picker with both Outlook and Gmail as selectable providers
+
+#### Scenario: Wizard persists config on success
+- **WHEN** the wizard completes successfully (credentials validated, connection tested)
+- **THEN** it writes the configuration to `~/.email-agent-mcp/config.json`
+- **AND** the configured email address is auto-added to the send allowlist

--- a/openspec/changes/add-gmail-cli-configure/specs/mailbox-config/spec.md
+++ b/openspec/changes/add-gmail-cli-configure/specs/mailbox-config/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Mailbox
+
+The system SHALL provide a `configure_mailbox` action that connects a named mailbox to a provider with credentials. The resulting metadata SHALL include the `emailAddress` field fetched from the provider during configuration.
+
+#### Scenario: Add work mailbox
+- **WHEN** `configure_mailbox` is called with `{name: "work", provider: "microsoft", credentials: {...}, default: true}`
+- **THEN** the system connects to the Microsoft Graph API, fetches the email address, and marks "work" as the default mailbox
+- **AND** the stored metadata includes `emailAddress`
+
+#### Scenario: Add Gmail mailbox
+- **WHEN** `configure_mailbox` is called with `{name: "personal", provider: "gmail", credentials: {...}}`
+- **THEN** the system completes the Gmail OAuth exchange, fetches the Gmail account email address, and persists Gmail mailbox metadata under `~/.email-agent-mcp/tokens/`
+- **AND** the stored metadata includes `emailAddress`
+
+### Requirement: Convention-Over-Configuration Paths
+
+The system SHALL use `~/.email-agent-mcp/` as the default home directory (overridable via `EMAIL_AGENT_MCP_HOME` env var) with well-known subdirectories and files loaded by convention.
+
+#### Scenario: Default home directory
+- **WHEN** `EMAIL_AGENT_MCP_HOME` is not set
+- **THEN** the system uses `~/.email-agent-mcp/` as the home directory
+
+#### Scenario: Custom home directory via env var
+- **WHEN** `EMAIL_AGENT_MCP_HOME` is set to `/tmp/ae-test`
+- **THEN** the system uses `/tmp/ae-test/` as the home directory instead of `~/.email-agent-mcp/`
+
+#### Scenario: Tokens directory for auth metadata
+- **WHEN** the system stores authentication metadata (OAuth tokens, refresh tokens)
+- **THEN** it writes to `~/.email-agent-mcp/tokens/`
+
+#### Scenario: State directory for watcher state and locks
+- **WHEN** the system stores watcher checkpoints or lock files
+- **THEN** it writes to `~/.email-agent-mcp/state/`
+
+#### Scenario: Config file for persistent settings
+- **WHEN** the system reads or writes persistent configuration
+- **THEN** it uses `~/.email-agent-mcp/config.json` containing wakeUrl, hooksToken, and pollIntervalSeconds
+
+#### Scenario: Allowlist files loaded by convention
+- **WHEN** the system checks send or receive allowlists
+- **THEN** it loads `~/.email-agent-mcp/send-allowlist.json` and `~/.email-agent-mcp/receive-allowlist.json` by convention
+
+#### Scenario: Auto-add email to send allowlist during configure
+- **WHEN** a mailbox is successfully configured
+- **THEN** the configured email address is automatically added to `send-allowlist.json`

--- a/openspec/changes/add-gmail-cli-configure/specs/provider-gmail/spec.md
+++ b/openspec/changes/add-gmail-cli-configure/specs/provider-gmail/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: OAuth2 Authentication
+
+The system SHALL authenticate to Gmail via OAuth2 using `@googleapis/gmail` (NOT the full `googleapis` package at 200MB).
+
+#### Scenario: Gmail OAuth
+- **WHEN** `configure_mailbox` is called with `{provider: "gmail"}`
+- **THEN** the system initiates OAuth2 flow and persists refresh tokens
+
+#### Scenario: Gmail CLI OAuth callback
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with a valid Google OAuth client configuration
+- **THEN** the system opens a browser authorization URL or prints it for the user to visit
+- **AND** receives the authorization callback on a local loopback address
+- **AND** exchanges the code for tokens using PKCE before persisting the refresh token

--- a/openspec/changes/add-gmail-cli-configure/tasks.md
+++ b/openspec/changes/add-gmail-cli-configure/tasks.md
@@ -1,0 +1,8 @@
+- [x] Update OpenSpec deltas for CLI, mailbox config, and Gmail provider
+- [x] Implement Gmail CLI configure flow with local OAuth callback and PKCE
+- [x] Persist Gmail mailbox metadata using canonical email-based filenames
+- [x] Auto-add configured Gmail addresses to the send allowlist
+- [x] Update wizard and docs to present Gmail interactive configure as available
+- [x] Add or update tests for Gmail configure, auth helpers, and wizard behavior
+- [x] Run `openspec validate add-gmail-cli-configure --strict`
+- [x] Run targeted package tests and project validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -4121,6 +4121,7 @@
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@usejunior/email-core": "^0.1.5",
+        "@usejunior/provider-gmail": "^0.1.5",
         "@usejunior/provider-microsoft": "^0.1.5"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "email-agent-mcp-suite",
   "version": "0.1.5",
   "private": true,
-  "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 today, Gmail wiring in progress",
+  "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 and manual-token Gmail setup",
   "type": "module",
   "workspaces": [
     "packages/*"

--- a/packages/email-agent-mcp/README.de.md
+++ b/packages/email-agent-mcp/README.de.md
@@ -99,9 +99,9 @@ Agent Email stellt 15 MCP-Tools bereit:
 | Anbieter | Status | Paket |
 |----------|--------|-------|
 | Microsoft 365 (Graph API) | Vollstaendig unterstuetzt | `@usejunior/provider-microsoft` |
-| Gmail | In Kuerze verfuegbar | `@usejunior/provider-gmail` |
+| Gmail | Unterstuetzt per manuellem Refresh-Token-Setup | `@usejunior/provider-gmail` |
 
-Das Gmail-Provider-Paket existiert mit vollstaendiger Testabdeckung. Die Anbindung an den MCP-Server ist in Arbeit.
+Gmail funktioniert jetzt im MCP-Server ueber eine manuelle Datei unter `~/.email-agent-mcp/tokens/`. Der interaktive Gmail-Assistent ist weiterhin ein Follow-up. Siehe `packages/provider-gmail/README.md`.
 
 ## Sicherheitsstandards
 

--- a/packages/email-agent-mcp/README.es.md
+++ b/packages/email-agent-mcp/README.es.md
@@ -99,9 +99,9 @@ Agent Email expone 15 herramientas MCP:
 | Proveedor | Estado | Paquete |
 |-----------|--------|---------|
 | Microsoft 365 (Graph API) | Totalmente soportado | `@usejunior/provider-microsoft` |
-| Gmail | Proximamente | `@usejunior/provider-gmail` |
+| Gmail | Compatible mediante OAuth interactivo por CLI o configuracion manual de refresh token | `@usejunior/provider-gmail` |
 
-El paquete del proveedor de Gmail existe con cobertura completa de pruebas. La integracion con el servidor MCP esta en progreso.
+Usa `email-agent-mcp configure --provider gmail` para ejecutar el flujo OAuth local en el navegador, o agrega un archivo manual en `~/.email-agent-mcp/tokens/`. Consulta `packages/provider-gmail/README.md`.
 
 ## Seguridad por defecto
 

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -13,7 +13,7 @@
 
 **email-agent-mcp** by [UseJunior](https://usejunior.com) -- local email connectivity for AI agents.
 
-Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook is supported today; Gmail wiring is in progress.
+Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook and Gmail are supported today.
 
 ## Quick Start
 
@@ -96,7 +96,7 @@ Agent Email exposes 15 MCP tools:
 | Provider | Status | Package |
 |----------|--------|---------|
 | Microsoft 365 (Graph API) | Fully supported | `@usejunior/provider-microsoft` |
-| Gmail | Coming soon | `@usejunior/provider-gmail` |
+| Gmail | Supported via interactive CLI OAuth or manual refresh-token setup | `@usejunior/provider-gmail` |
 
 ## Security Defaults
 

--- a/packages/email-agent-mcp/README.pt-br.md
+++ b/packages/email-agent-mcp/README.pt-br.md
@@ -99,9 +99,9 @@ O Agent Email expoe 15 ferramentas MCP:
 | Provedor | Status | Pacote |
 |----------|--------|--------|
 | Microsoft 365 (Graph API) | Totalmente suportado | `@usejunior/provider-microsoft` |
-| Gmail | Em breve | `@usejunior/provider-gmail` |
+| Gmail | Suportado via OAuth interativo no CLI ou configuracao manual de refresh token | `@usejunior/provider-gmail` |
 
-O pacote do provedor Gmail ja existe com cobertura completa de testes. A integracao com o servidor MCP esta em andamento.
+Use `email-agent-mcp configure --provider gmail` para executar o fluxo OAuth local no navegador, ou adicione um arquivo manual em `~/.email-agent-mcp/tokens/`. Veja `packages/provider-gmail/README.md`.
 
 ## Configuracoes Padrao de Seguranca
 

--- a/packages/email-agent-mcp/README.zh.md
+++ b/packages/email-agent-mcp/README.zh.md
@@ -99,9 +99,9 @@ Agent Email 提供 15 个 MCP 工具：
 | 提供商 | 状态 | 包名 |
 |--------|------|------|
 | Microsoft 365 (Graph API) | 完全支持 | `@usejunior/provider-microsoft` |
-| Gmail | 即将推出 | `@usejunior/provider-gmail` |
+| Gmail | 支持通过手动 refresh token 配置接入 | `@usejunior/provider-gmail` |
 
-Gmail 提供商包已编写完成并具有完整的测试覆盖。接入 MCP 服务器的工作正在进行中。
+Gmail 现在可以通过写入 `~/.email-agent-mcp/tokens/` 下的手动配置文件接入 MCP 服务器。交互式 Gmail 配置向导仍是后续工作。参见 `packages/provider-gmail/README.md`。
 
 ## 安全默认值
 

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "email-agent-mcp",
   "version": "0.1.5",
-  "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook with Gmail wiring in progress",
+  "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook and manual-token Gmail setup",
   "type": "module",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -38,6 +38,7 @@ export { sendEmailAction } from './actions/send.js';
 export { replyToEmailAction } from './actions/reply.js';
 export { createDraftAction, sendDraftAction, updateDraftAction } from './actions/draft.js';
 export { getThreadAction } from './actions/conversation.js';
+export { listAttachmentsAction } from './actions/attachments.js';
 export { labelEmailAction, flagEmailAction, markReadAction, deleteEmailAction } from './actions/label.js';
 export { moveToFolderAction } from './actions/move.js';
 export { parseFrontmatter } from './content/frontmatter.js';

--- a/packages/email-core/src/security/watched-allowlist.test.ts
+++ b/packages/email-core/src/security/watched-allowlist.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { WatchedAllowlist } from './watched-allowlist.js';
 import { writeFile, rm, mkdtemp, rename, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -187,5 +187,55 @@ describe('security/WatchedAllowlist', () => {
     await waitFor(() => watcher!.config !== undefined);
 
     expect(watcher.config!.entries).toEqual(['new@test.com']);
+  });
+
+  it('Scenario: Startup watch failure falls back to static config load', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['fallback@test.com'] }));
+
+    watcher = new WatchedAllowlist(
+      filePath,
+      testLoader,
+      50,
+      () => {
+        const err = Object.assign(new Error('EMFILE: too many open files, watch'), { code: 'EMFILE' });
+        throw err;
+      },
+    );
+    await watcher.start();
+
+    expect(watcher.config).toEqual({ entries: ['fallback@test.com'] });
+  });
+
+  it('Scenario: Runtime watcher error disables hot reload cleanly', async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'watched-allowlist-'));
+    const filePath = join(tmpDir, 'allowlist.json');
+    await writeFile(filePath, JSON.stringify({ entries: ['initial@test.com'] }));
+
+    const close = vi.fn();
+    let onError: ((err: Error) => void) | undefined;
+    const fakeWatcher = {
+      on: vi.fn((event: string, handler: (err: Error) => void) => {
+        if (event === 'error') onError = handler;
+        return fakeWatcher;
+      }),
+      unref: vi.fn(),
+      close,
+    };
+
+    watcher = new WatchedAllowlist(
+      filePath,
+      testLoader,
+      50,
+      () => fakeWatcher as never,
+    );
+    await watcher.start();
+
+    expect(onError).toBeDefined();
+    onError!(new Error('EMFILE: too many open files, watch'));
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(watcher.config).toEqual({ entries: ['initial@test.com'] });
   });
 });

--- a/packages/email-core/src/security/watched-allowlist.ts
+++ b/packages/email-core/src/security/watched-allowlist.ts
@@ -16,6 +16,7 @@ export class WatchedAllowlist {
     private readonly filePath: string,
     private readonly loader: (path: string) => Promise<AllowlistConfig | undefined>,
     private readonly debounceMs = 150,
+    private readonly watchFactory: typeof watch = watch,
   ) {}
 
   /** Current allowlist config. undefined if file doesn't exist or hasn't been loaded. */
@@ -43,18 +44,18 @@ export class WatchedAllowlist {
 
     // 2. Arm the watch BEFORE loading — eliminates the startup race window
     try {
-      this._watcher = watch(dir, (_event, filename) => {
+      this._watcher = this.watchFactory(dir, (_event, filename) => {
         // filename can be null on some platforms — treat as possible target change
         if (!filename || filename === name) {
           this.scheduleReload();
         }
       });
       this._watcher.on('error', (err) => {
-        console.error(`[email-agent-mcp] Allowlist watcher error for ${this.filePath}: ${err.message}`);
+        this.disableWatching(err);
       });
       this._watcher.unref();
     } catch (err) {
-      console.error(`[email-agent-mcp] Cannot watch allowlist directory ${dir}: ${err instanceof Error ? err.message : err}`);
+      this.disableWatching(err);
     }
 
     // 3. Load initial config AFTER watch is armed
@@ -98,5 +99,20 @@ export class WatchedAllowlist {
     } catch {
       // Keep previous config on unexpected error
     }
+  }
+
+  private disableWatching(err: unknown): void {
+    const message = err instanceof Error ? err.message : String(err);
+    if (this._watcher) {
+      try {
+        this._watcher.close();
+      } catch {
+        // Best-effort cleanup on watcher failure.
+      }
+      this._watcher = undefined;
+    }
+    console.error(
+      `[email-agent-mcp] Allowlist watcher disabled for ${this.filePath}: ${message}. Continuing without hot reload.`,
+    );
   }
 }

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -25,6 +25,7 @@
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@usejunior/email-core": "^0.1.5",
+    "@usejunior/provider-gmail": "^0.1.5",
     "@usejunior/provider-microsoft": "^0.1.5"
   },
   "devDependencies": {

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { runCli, parseCliArgs, getNemoClawEgressDomains, getAgentEmailHome, loadConfig, saveConfig } from './cli.js';
+import {
+  runCli,
+  parseCliArgs,
+  getNemoClawEgressDomains,
+  getAgentEmailHome,
+  ensureGmailProfileMatchesIntent,
+  getEffectiveSendAllowlistPath,
+  loadConfig,
+  saveConfig,
+} from './cli.js';
 import { mkdtemp, rm, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -35,6 +44,102 @@ const watcherMockState = vi.hoisted(() => ({
   pollCountBeforeShutdown: 1,
   /** Track poll calls. */
   pollCount: 0,
+}));
+
+const gmailMockState = vi.hoisted(() => ({
+  enableConfigureMock: false,
+  authUrlOptions: null as null | Record<string, unknown>,
+  exchangeCodeArgs: null as null | Record<string, unknown>,
+  savedMetadata: null as null | Record<string, unknown>,
+  profileEmail: 'steven.obiajulu@gmail.com',
+  refreshToken: 'mock-refresh-token' as string | undefined,
+}));
+
+const promptMockState = vi.hoisted(() => ({
+  confirmResult: true as boolean,
+  textResult: '' as string,
+  passwordResult: '' as string,
+}));
+
+const httpMockState = vi.hoisted(() => ({
+  listenError: null as Error | null,
+  callbackQueryFactory: null as null | (() => string),
+  triggerCallback: true as boolean,
+  lastResponseStatus: null as number | null,
+  lastResponseBody: null as string | null,
+}));
+
+const originalStdoutIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY');
+
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    confirm: vi.fn(async () => promptMockState.confirmResult),
+    text: vi.fn(async () => promptMockState.textResult),
+    password: vi.fn(async () => promptMockState.passwordResult),
+    isCancel: vi.fn(() => false),
+  };
+});
+
+vi.mock('node:http', () => ({
+  createServer: vi.fn((handler: (req: { url?: string }, res: {
+    statusCode: number;
+    setHeader: (name: string, value: string) => void;
+    end: (body?: string) => void;
+  }) => void) => {
+    let errorHandler: ((err: Error) => void) | undefined;
+    let onceErrorHandler: ((err: Error) => void) | undefined;
+
+    const server = {
+      on: vi.fn((event: string, callback: (err: Error) => void) => {
+        if (event === 'error') errorHandler = callback;
+        return server;
+      }),
+      once: vi.fn((event: string, callback: (err: Error) => void) => {
+        if (event === 'error') onceErrorHandler = callback;
+        return server;
+      }),
+      listen: vi.fn((_port: number, _host: string, callback?: () => void) => {
+        if (httpMockState.listenError) {
+          queueMicrotask(() => {
+            onceErrorHandler?.(httpMockState.listenError!);
+            errorHandler?.(httpMockState.listenError!);
+          });
+          return server;
+        }
+
+        callback?.();
+
+        if (httpMockState.triggerCallback) {
+          setTimeout(() => {
+            const query = httpMockState.callbackQueryFactory?.();
+            if (!query) return;
+
+            const response = {
+              statusCode: 0,
+              setHeader: vi.fn(),
+              end: (body?: string) => {
+                httpMockState.lastResponseStatus = response.statusCode;
+                httpMockState.lastResponseBody = body ?? null;
+              },
+            };
+
+            handler({ url: `/oauth2callback?${query}` }, response);
+          }, 0);
+        }
+
+        return server;
+      }),
+      close: vi.fn((callback?: () => void) => {
+        callback?.();
+        return server;
+      }),
+      address: vi.fn(() => ({ port: 62018, family: 'IPv4', address: '127.0.0.1' })),
+    };
+
+    return server;
+  }),
 }));
 
 // Mock @usejunior/provider-microsoft for watcher poll-loop tests.
@@ -107,11 +212,75 @@ vi.mock('@usejunior/provider-microsoft', async (importOriginal) => {
   };
 });
 
+vi.mock('@usejunior/provider-gmail', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+
+  class MockGmailAuthManager {
+    constructor(_config: Record<string, unknown>) {}
+    async generateCodeVerifierAsync() {
+      return { codeVerifier: 'mock-code-verifier', codeChallenge: 'mock-code-challenge' };
+    }
+    generateAuthUrl(options: Record<string, unknown>) {
+      gmailMockState.authUrlOptions = options;
+      return 'https://accounts.google.com/o/oauth2/v2/auth?mock=1';
+    }
+    async exchangeCode(code: string, options: Record<string, unknown>) {
+      gmailMockState.exchangeCodeArgs = { code, options };
+    }
+    getRefreshToken() {
+      return gmailMockState.refreshToken;
+    }
+    async fetchProfile() {
+      return { emailAddress: gmailMockState.profileEmail };
+    }
+  }
+
+  const actualSave = actual.saveGmailMailboxMetadata as (metadata: Record<string, unknown>) => Promise<void>;
+  const actualToSafeKey = actual.toFilesystemSafeKey as (email: string) => string;
+
+  return {
+    ...actual,
+    GmailAuthManager: new Proxy(MockGmailAuthManager, {
+      construct(target, args) {
+        if (gmailMockState.enableConfigureMock) return new target(...args);
+        const RealAuth = actual.GmailAuthManager as new (...realArgs: unknown[]) => unknown;
+        return new RealAuth(...args);
+      },
+    }),
+    saveGmailMailboxMetadata: vi.fn(async (metadata: Record<string, unknown>) => {
+      if (gmailMockState.enableConfigureMock) {
+        gmailMockState.savedMetadata = metadata;
+        return;
+      }
+      await actualSave(metadata);
+    }),
+    toFilesystemSafeKey: vi.fn((email: string) => actualToSafeKey(email)),
+  };
+});
+
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
+  gmailMockState.enableConfigureMock = false;
+  gmailMockState.authUrlOptions = null;
+  gmailMockState.exchangeCodeArgs = null;
+  gmailMockState.savedMetadata = null;
+  gmailMockState.profileEmail = 'steven.obiajulu@gmail.com';
+  gmailMockState.refreshToken = 'mock-refresh-token';
+  promptMockState.confirmResult = true;
+  promptMockState.textResult = '';
+  promptMockState.passwordResult = '';
+  httpMockState.listenError = null;
+  httpMockState.callbackQueryFactory = null;
+  httpMockState.triggerCallback = true;
+  httpMockState.lastResponseStatus = null;
+  httpMockState.lastResponseBody = null;
+  Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
 });
 
 afterEach(() => {
+  if (originalStdoutIsTTYDescriptor) {
+    Object.defineProperty(process.stdout, 'isTTY', originalStdoutIsTTYDescriptor);
+  }
   vi.restoreAllMocks();
 });
 
@@ -157,12 +326,268 @@ describe('cli/Configure Subcommand', () => {
     expect(opts.clientId).toBe('test-id');
   });
 
+  it('parseCliArgs accepts --client-secret', () => {
+    const opts = parseCliArgs(['configure', '--provider', 'gmail', '--client-secret', 'secret-value']);
+    expect(opts.clientSecret).toBe('secret-value');
+  });
+
   it('Scenario: Setup alias', () => {
     // WHEN email-agent-mcp setup is run
     // THEN the system behaves identically to email-agent-mcp configure
     const opts = parseCliArgs(['setup', '--provider', 'microsoft']);
     expect(opts.command).toBe('setup');
     expect(opts.provider).toBe('microsoft');
+  });
+
+  it('Gmail configure returns an error when credentials are missing', async () => {
+    const exitCode = await runCli(['configure', '--provider', 'gmail']);
+    expect(exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Missing Gmail OAuth client ID'),
+    );
+  });
+});
+
+describe('cli/Gmail Account Intent Checks', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-gmail-intent-'));
+    originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env['EMAIL_AGENT_MCP_HOME'];
+    } else {
+      process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
+    }
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('Scenario: Explicit Gmail mailbox email must match the authenticated Google profile', async () => {
+    await expect(
+      ensureGmailProfileMatchesIntent('expected@gmail.com', 'other@gmail.com'),
+    ).rejects.toThrow(/configure was asked to link expected@gmail.com/i);
+  });
+
+  it('Scenario: Alias-based Gmail configure fails closed in non-TTY sessions', async () => {
+    await expect(
+      ensureGmailProfileMatchesIntent('personal', 'steven.obiajulu@gmail.com'),
+    ).rejects.toThrow(/Re-run in a TTY|pass --mailbox steven\.obiajulu@gmail\.com/i);
+  });
+
+  it('Scenario: Alias-based Gmail configure can proceed after explicit TTY confirmation', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    promptMockState.confirmResult = true;
+
+    try {
+      await expect(
+        ensureGmailProfileMatchesIntent('personal', 'steven.obiajulu@gmail.com'),
+      ).resolves.toBeUndefined();
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    }
+  });
+
+  it('Scenario: Alias-based Gmail configure rejects when an existing alias maps to another account', async () => {
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    const tokensDir = join(tmpHome, 'tokens');
+    await mkdir(tokensDir, { recursive: true });
+    await writeFile(join(tokensDir, 'personal.json'), JSON.stringify({
+      provider: 'gmail',
+      mailboxName: 'personal',
+      emailAddress: 'existing@gmail.com',
+      clientId: 'gmail-client-id',
+      clientSecret: 'gmail-client-secret',
+      refreshToken: 'gmail-refresh-token',
+      lastInteractiveAuthAt: '2026-04-08T12:00:00.000Z',
+    }, null, 2) + '\n');
+
+    await expect(
+      ensureGmailProfileMatchesIntent('personal', 'other@gmail.com'),
+    ).rejects.toThrow(/already linked to existing@gmail.com/i);
+  });
+});
+
+describe('cli/Gmail Configure', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalClientId: string | undefined;
+  let originalClientSecret: string | undefined;
+  let originalAllowlistPath: string | undefined;
+
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-gmail-configure-'));
+    originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    originalClientId = process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'];
+    originalClientSecret = process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'];
+    originalAllowlistPath = process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+    process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+    delete process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'];
+    delete process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'];
+    delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+
+    gmailMockState.enableConfigureMock = true;
+    httpMockState.callbackQueryFactory = () => {
+      const state = (gmailMockState.authUrlOptions?.['state'] as string | undefined) ?? 'missing-state';
+      return `code=oauth-code&state=${encodeURIComponent(state)}`;
+    };
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) {
+      delete process.env['EMAIL_AGENT_MCP_HOME'];
+    } else {
+      process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
+    }
+
+    if (originalClientId === undefined) {
+      delete process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'];
+    } else {
+      process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'] = originalClientId;
+    }
+
+    if (originalClientSecret === undefined) {
+      delete process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'];
+    } else {
+      process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'] = originalClientSecret;
+    }
+
+    if (originalAllowlistPath === undefined) {
+      delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+    } else {
+      process.env['AGENT_EMAIL_SEND_ALLOWLIST'] = originalAllowlistPath;
+    }
+
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it('Scenario: Gmail configure saves metadata and updates the send allowlist', async () => {
+    const exitCode = await runCli([
+      'configure',
+      '--provider',
+      'gmail',
+      '--mailbox',
+      'steven.obiajulu@gmail.com',
+      '--client-id',
+      'cli-client-id',
+      '--client-secret',
+      'cli-client-secret',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(gmailMockState.savedMetadata).toMatchObject({
+      provider: 'gmail',
+      mailboxName: 'steven.obiajulu@gmail.com',
+      emailAddress: 'steven.obiajulu@gmail.com',
+      clientId: 'cli-client-id',
+      clientSecret: 'cli-client-secret',
+      refreshToken: 'mock-refresh-token',
+    });
+    expect(gmailMockState.exchangeCodeArgs).toEqual({
+      code: 'oauth-code',
+      options: {
+        codeVerifier: 'mock-code-verifier',
+        redirectUri: 'http://127.0.0.1:62018/oauth2callback',
+      },
+    });
+    expect(gmailMockState.authUrlOptions).toMatchObject({
+      redirectUri: 'http://127.0.0.1:62018/oauth2callback',
+      codeChallenge: 'mock-code-challenge',
+      loginHint: 'steven.obiajulu@gmail.com',
+      scopes: ['https://mail.google.com/'],
+    });
+
+    const allowlistPath = await getEffectiveSendAllowlistPath();
+    const allowlist = JSON.parse(await readFile(allowlistPath, 'utf-8')) as { entries: string[] };
+    expect(allowlist.entries).toEqual(['steven.obiajulu@gmail.com']);
+    expect(httpMockState.lastResponseStatus).toBe(200);
+    expect(httpMockState.lastResponseBody).toContain('Authentication complete');
+  });
+
+  it('Scenario: Gmail configure can prompt for missing OAuth credentials in TTY mode', async () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
+    promptMockState.textResult = 'prompt-client-id';
+    promptMockState.passwordResult = 'prompt-client-secret';
+
+    try {
+      const exitCode = await runCli(['configure', '--provider', 'gmail', '--mailbox', 'personal']);
+
+      expect(exitCode).toBe(0);
+      expect(gmailMockState.savedMetadata).toMatchObject({
+        mailboxName: 'personal',
+        emailAddress: 'steven.obiajulu@gmail.com',
+        clientId: 'prompt-client-id',
+        clientSecret: 'prompt-client-secret',
+      });
+      expect(gmailMockState.authUrlOptions?.['loginHint']).toBeUndefined();
+    } finally {
+      Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+    }
+  });
+
+  it('Scenario: Gmail configure fails when the OAuth callback state does not match', async () => {
+    httpMockState.callbackQueryFactory = () => 'code=oauth-code&state=wrong-state';
+
+    const exitCode = await runCli([
+      'configure',
+      '--provider',
+      'gmail',
+      '--mailbox',
+      'steven.obiajulu@gmail.com',
+      '--client-id',
+      'cli-client-id',
+      '--client-secret',
+      'cli-client-secret',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Google OAuth state mismatch'),
+    );
+  });
+
+  it('Scenario: Gmail configure fails closed when Google returns no refresh token', async () => {
+    gmailMockState.refreshToken = undefined as unknown as string;
+
+    const exitCode = await runCli([
+      'configure',
+      '--provider',
+      'gmail',
+      '--mailbox',
+      'steven.obiajulu@gmail.com',
+      '--client-id',
+      'cli-client-id',
+      '--client-secret',
+      'cli-client-secret',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('did not return a refresh token'),
+    );
+  });
+
+  it('Scenario: Gmail configure uses environment credentials when flags are omitted', async () => {
+    process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'] = 'env-client-id';
+    process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'] = 'env-client-secret';
+
+    const exitCode = await runCli([
+      'configure',
+      '--provider',
+      'gmail',
+      '--mailbox',
+      'steven.obiajulu@gmail.com',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(gmailMockState.savedMetadata).toMatchObject({
+      clientId: 'env-client-id',
+      clientSecret: 'env-client-secret',
+    });
   });
 });
 
@@ -315,6 +740,40 @@ describe('cli/Status Subcommand', () => {
     );
   });
 
+  it('Status includes Gmail-only mailboxes', async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-gmail-status-test-'));
+    const savedHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+
+    try {
+      const { mkdir, writeFile } = await import('node:fs/promises');
+      const tokensDir = join(tmpHome, 'tokens');
+      await mkdir(tokensDir, { recursive: true });
+      await writeFile(join(tokensDir, 'steven-obiajulu-at-gmail-com.json'), JSON.stringify({
+        provider: 'gmail',
+        mailboxName: 'personal',
+        emailAddress: 'steven.obiajulu@gmail.com',
+        clientId: 'gmail-client-id',
+        clientSecret: 'gmail-client-secret',
+        refreshToken: 'gmail-refresh-token',
+        lastInteractiveAuthAt: '2026-04-08T12:00:00.000Z',
+      }, null, 2) + '\n');
+
+      const exitCode = await runCli(['status']);
+      expect(exitCode).toBe(0);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Provider: gmail'),
+      );
+    } finally {
+      if (savedHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = savedHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
   it('Scenario: Status with no config', async () => {
     // WHEN email-agent-mcp status is run with no configuration
     // THEN the system prints a message indicating no accounts are configured
@@ -446,6 +905,27 @@ describe('cli/EMAIL_AGENT_MCP_HOME', () => {
     } finally {
       if (original !== undefined) {
         process.env['EMAIL_AGENT_MCP_HOME'] = original;
+      }
+    }
+  });
+
+  it('Scenario: CLI send allowlist path follows runtime env precedence', async () => {
+    const originalAllowlist = process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+    const originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    try {
+      process.env['EMAIL_AGENT_MCP_HOME'] = '/tmp/email-agent-home';
+      process.env['AGENT_EMAIL_SEND_ALLOWLIST'] = '/tmp/runtime/send-allowlist.json';
+      await expect(getEffectiveSendAllowlistPath()).resolves.toBe('/tmp/runtime/send-allowlist.json');
+    } finally {
+      if (originalAllowlist === undefined) {
+        delete process.env['AGENT_EMAIL_SEND_ALLOWLIST'];
+      } else {
+        process.env['AGENT_EMAIL_SEND_ALLOWLIST'] = originalAllowlist;
+      }
+      if (originalHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
       }
     }
   });

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // CLI entry point — serve, watch, configure, setup subcommands + TTY-aware default
 
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 
@@ -19,6 +21,7 @@ export interface CliOptions {
   mailbox?: string;
   provider?: string;
   clientId?: string;
+  clientSecret?: string;
   pollInterval?: number; // seconds
 }
 
@@ -43,6 +46,13 @@ export interface AgentEmailConfig {
   wakeUrl?: string;
   hooksToken?: string;
   pollIntervalSeconds?: number;
+}
+
+export interface ConfiguredMailboxSummary {
+  provider: 'microsoft' | 'gmail';
+  mailboxName: string;
+  emailAddress?: string;
+  lastInteractiveAuthAt?: string;
 }
 
 /**
@@ -75,6 +85,235 @@ export async function saveConfig(updates: Partial<AgentEmailConfig>): Promise<vo
   const dir = getAgentEmailHome();
   await mkdir(dir, { recursive: true });
   await writeFile(getConfigPath(), JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+}
+
+function getAuthTimestamp(value?: string): number {
+  if (!value) return 0;
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+async function listConfiguredMailboxSummaries(): Promise<ConfiguredMailboxSummary[]> {
+  const summaries: ConfiguredMailboxSummary[] = [];
+
+  try {
+    const { listConfiguredMailboxesWithMetadata } = await import('@usejunior/provider-microsoft');
+    const mailboxes = await listConfiguredMailboxesWithMetadata();
+    summaries.push(
+      ...mailboxes.map(mailbox => ({
+        provider: 'microsoft' as const,
+        mailboxName: mailbox.mailboxName,
+        emailAddress: mailbox.emailAddress,
+        lastInteractiveAuthAt: mailbox.lastInteractiveAuthAt,
+      })),
+    );
+  } catch {
+    // Provider package may not be installed.
+  }
+
+  try {
+    const { listConfiguredGmailMailboxes } = await import('@usejunior/provider-gmail');
+    const mailboxes = await listConfiguredGmailMailboxes();
+    summaries.push(
+      ...mailboxes.map(mailbox => ({
+        provider: 'gmail' as const,
+        mailboxName: mailbox.mailboxName,
+        emailAddress: mailbox.emailAddress,
+        lastInteractiveAuthAt: mailbox.lastInteractiveAuthAt,
+      })),
+    );
+  } catch {
+    // Provider package may not be installed.
+  }
+
+  summaries.sort((a, b) => getAuthTimestamp(b.lastInteractiveAuthAt) - getAuthTimestamp(a.lastInteractiveAuthAt));
+  return summaries;
+}
+
+export async function getEffectiveSendAllowlistPath(): Promise<string> {
+  const { getSendAllowlistPath } = await import('@usejunior/email-core');
+  return getSendAllowlistPath();
+}
+
+function normalizeMailboxValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export async function ensureGmailProfileMatchesIntent(
+  mailboxName: string,
+  emailAddress: string,
+): Promise<void> {
+  const normalizedMailboxName = normalizeMailboxValue(mailboxName);
+  const normalizedEmailAddress = normalizeMailboxValue(emailAddress);
+
+  if (mailboxName.includes('@')) {
+    if (normalizedMailboxName !== normalizedEmailAddress) {
+      throw new Error(
+        `Google authenticated ${emailAddress}, but configure was asked to link ${mailboxName}. Re-run configure and choose the intended Google account.`,
+      );
+    }
+    return;
+  }
+
+  const existingMailbox = (await listConfiguredMailboxSummaries()).find(summary =>
+    summary.provider === 'gmail' &&
+    normalizeMailboxValue(summary.mailboxName) === normalizedMailboxName &&
+    summary.emailAddress,
+  );
+
+  if (existingMailbox?.emailAddress) {
+    if (normalizeMailboxValue(existingMailbox.emailAddress) !== normalizedEmailAddress) {
+      throw new Error(
+        `Mailbox "${mailboxName}" is already linked to ${existingMailbox.emailAddress}, but Google authenticated ${emailAddress}. Use a different mailbox name or re-run configure with the intended Google account.`,
+      );
+    }
+    return;
+  }
+
+  if (!process.stdout.isTTY) {
+    throw new Error(
+      `Google authenticated ${emailAddress} for mailbox alias "${mailboxName}", but the alias does not prove which account you intended. Re-run in a TTY to confirm, or pass --mailbox ${emailAddress}.`,
+    );
+  }
+
+  const p = await import('@clack/prompts');
+  const confirmed = await p.confirm({
+    message: `Google authenticated ${emailAddress}. Save it as mailbox "${mailboxName}"?`,
+  });
+  if (p.isCancel(confirmed) || !confirmed) {
+    throw new Error('Gmail configuration cancelled because the authenticated account was not confirmed');
+  }
+}
+
+async function addEmailToSendAllowlist(emailAddress: string): Promise<void> {
+  // Keep CLI writes aligned with the runtime/server path resolution so
+  // configure-time edits land in the file the MCP server will actually watch.
+  const allowlistPath = await getEffectiveSendAllowlistPath();
+  const agentHome = dirname(allowlistPath);
+
+  await mkdir(agentHome, { recursive: true });
+
+  let entries: string[] = [];
+  try {
+    const raw = await readFile(allowlistPath, 'utf-8');
+    const data = JSON.parse(raw) as { entries?: string[] };
+    entries = data.entries ?? [];
+  } catch {
+    // Start with a new allowlist file.
+  }
+
+  const lowerEmail = emailAddress.toLowerCase();
+  if (!entries.some(entry => entry.toLowerCase() === lowerEmail)) {
+    entries.push(emailAddress);
+  }
+
+  await writeFile(allowlistPath, JSON.stringify({ entries }, null, 2) + '\n', 'utf-8');
+}
+
+interface OAuthCallbackResult {
+  code: string;
+  state?: string;
+}
+
+async function startLoopbackOAuthListener(timeoutMs = 5 * 60 * 1000): Promise<{
+  redirectUri: string;
+  waitForCallback: Promise<OAuthCallbackResult>;
+}> {
+  const callbackPath = '/oauth2callback';
+  let resolveCallback!: (value: OAuthCallbackResult) => void;
+  let rejectCallback!: (reason?: unknown) => void;
+  const waitForCallback = new Promise<OAuthCallbackResult>((resolve, reject) => {
+    resolveCallback = resolve;
+    rejectCallback = reject;
+  });
+
+  let settled = false;
+  let activePort = 0;
+
+  const settle = (handler: () => void) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timeoutId);
+    server.close(() => {
+      handler();
+    });
+  };
+
+  const server = createServer((req, res) => {
+    const requestUrl = new URL(req.url ?? '/', `http://127.0.0.1:${activePort || 80}`);
+    if (requestUrl.pathname !== callbackPath) {
+      res.statusCode = 404;
+      res.end('Not found.');
+      return;
+    }
+
+    const error = requestUrl.searchParams.get('error');
+    if (error) {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'text/html; charset=utf-8');
+      res.end('<html><body><h1>Authentication failed</h1><p>You can return to the terminal.</p></body></html>');
+      settle(() => {
+        rejectCallback(new Error(`Google OAuth returned ${error}`));
+      });
+      return;
+    }
+
+    const code = requestUrl.searchParams.get('code');
+    if (!code) {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'text/html; charset=utf-8');
+      res.end('<html><body><h1>Missing authorization code</h1><p>You can return to the terminal.</p></body></html>');
+      settle(() => {
+        rejectCallback(new Error('Google OAuth callback did not include an authorization code'));
+      });
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader('content-type', 'text/html; charset=utf-8');
+    res.end('<html><body><h1>Authentication complete</h1><p>You can return to the terminal and close this tab.</p></body></html>');
+    settle(() => {
+      resolveCallback({
+        code,
+        state: requestUrl.searchParams.get('state') ?? undefined,
+      });
+    });
+  });
+
+  server.on('error', err => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timeoutId);
+    rejectCallback(err);
+  });
+
+  const timeoutId = setTimeout(() => {
+    settle(() => {
+      rejectCallback(new Error('Timed out waiting for the Google OAuth callback'));
+    });
+  }, timeoutMs);
+  timeoutId.unref();
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve();
+    });
+    server.once('error', reject);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    settle(() => {
+      rejectCallback(new Error('Could not determine the local OAuth callback port'));
+    });
+    throw new Error('Could not determine the local OAuth callback port');
+  }
+
+  activePort = address.port;
+  return {
+    redirectUri: `http://127.0.0.1:${address.port}${callbackPath}`,
+    waitForCallback,
+  };
 }
 
 export function parseCliArgs(args: string[]): CliOptions {
@@ -113,6 +352,10 @@ export function parseCliArgs(args: string[]): CliOptions {
     }
     if (arg === '--client-id' && i + 1 < args.length) {
       opts.clientId = args[++i];
+      continue;
+    }
+    if (arg === '--client-secret' && i + 1 < args.length) {
+      opts.clientSecret = args[++i];
       continue;
     }
     if (arg === '--poll-interval' && i + 1 < args.length) {
@@ -171,8 +414,7 @@ export async function runCli(args: string[]): Promise<number> {
         }
 
         // TTY: check if any mailboxes are configured
-        const { listConfiguredMailboxesWithMetadata } = await import('@usejunior/provider-microsoft');
-        const mailboxes = await listConfiguredMailboxesWithMetadata();
+        const mailboxes = await listConfiguredMailboxSummaries();
 
         if (mailboxes.length === 0) {
           // No config -> run guided setup wizard
@@ -465,6 +707,143 @@ export async function runWatch(opts: CliOptions): Promise<number> {
   });
 }
 
+async function resolveGmailOAuthClient(opts: CliOptions): Promise<{ clientId: string; clientSecret: string }> {
+  let clientId = opts.clientId
+    ?? process.env['AGENT_EMAIL_GMAIL_CLIENT_ID']
+    ?? process.env['GOOGLE_CLIENT_ID'];
+  let clientSecret = opts.clientSecret
+    ?? process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET']
+    ?? process.env['GOOGLE_CLIENT_SECRET']
+    ?? '';
+
+  if ((!clientId || !clientSecret) && process.stdout.isTTY) {
+    const p = await import('@clack/prompts');
+
+    if (!clientId) {
+      const input = await p.text({
+        message: 'Enter the Google OAuth client ID for Gmail',
+        placeholder: 'xxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com',
+      });
+      if (p.isCancel(input)) {
+        throw new Error('Gmail configuration cancelled');
+      }
+      clientId = input.trim();
+    }
+
+    if (!clientSecret) {
+      const input = await p.password({
+        message: 'Enter the Google OAuth client secret for Gmail',
+        mask: '▪',
+      });
+      if (p.isCancel(input)) {
+        throw new Error('Gmail configuration cancelled');
+      }
+      clientSecret = input.trim();
+    }
+  }
+
+  if (!clientId) {
+    throw new Error(
+      'Missing Gmail OAuth client ID. Pass --client-id or set AGENT_EMAIL_GMAIL_CLIENT_ID.',
+    );
+  }
+
+  if (!clientSecret) {
+    throw new Error(
+      'Missing Gmail OAuth client secret. Pass --client-secret or set AGENT_EMAIL_GMAIL_CLIENT_SECRET.',
+    );
+  }
+
+  return {
+    clientId,
+    clientSecret,
+  };
+}
+
+async function runGmailConfigure(opts: CliOptions): Promise<number> {
+  const mailboxName = opts.mailbox ?? 'default';
+  const { clientId, clientSecret } = await resolveGmailOAuthClient(opts);
+
+  const {
+    GMAIL_OAUTH_SCOPES,
+    GmailAuthManager,
+    saveGmailMailboxMetadata,
+    toFilesystemSafeKey,
+  } = await import('@usejunior/provider-gmail');
+
+  console.error(`[email-agent-mcp] Configuring mailbox "${mailboxName}" with Gmail`);
+  console.error(`[email-agent-mcp] OAuth client ID: ${clientId}`);
+  console.error('');
+
+  const auth = new GmailAuthManager({ clientId, clientSecret });
+  const { redirectUri, waitForCallback } = await startLoopbackOAuthListener();
+  const { codeVerifier, codeChallenge } = await auth.generateCodeVerifierAsync();
+  const state = randomUUID();
+  const authUrl = auth.generateAuthUrl({
+    scopes: GMAIL_OAUTH_SCOPES,
+    redirectUri,
+    state,
+    codeChallenge,
+    loginHint: mailboxName.includes('@') ? mailboxName : undefined,
+  });
+
+  console.error('[email-agent-mcp] Open this URL in your browser to authorize Gmail access:');
+  console.error(`  ${authUrl}`);
+  console.error(`[email-agent-mcp] Waiting for Google OAuth callback on ${redirectUri}`);
+
+  const callback = await waitForCallback;
+  if (callback.state !== state) {
+    throw new Error('Google OAuth state mismatch');
+  }
+
+  await auth.exchangeCode(callback.code, { codeVerifier, redirectUri });
+
+  const refreshToken = auth.getRefreshToken();
+  if (!refreshToken) {
+    throw new Error(
+      'Google OAuth did not return a refresh token. Re-run configure after revoking the prior grant or forcing consent.',
+    );
+  }
+
+  const profile = await auth.fetchProfile();
+  const emailAddress = profile.emailAddress;
+  if (!emailAddress) {
+    throw new Error('Gmail profile did not include an email address');
+  }
+
+  await ensureGmailProfileMatchesIntent(mailboxName, emailAddress);
+
+  const lastInteractiveAuthAt = new Date().toISOString();
+  await saveGmailMailboxMetadata({
+    provider: 'gmail',
+    mailboxName,
+    emailAddress,
+    clientId,
+    clientSecret,
+    refreshToken,
+    lastInteractiveAuthAt,
+  });
+
+  try {
+    await addEmailToSendAllowlist(emailAddress);
+    console.error(`[email-agent-mcp] Send allowlist: ${emailAddress} (outbound email enabled to this address)`);
+  } catch (allowlistErr) {
+    console.error(`[email-agent-mcp] WARNING: Could not update send allowlist: ${allowlistErr instanceof Error ? allowlistErr.message : allowlistErr}`);
+  }
+
+  const safeKey = toFilesystemSafeKey(emailAddress);
+
+  console.error('');
+  console.error(`✅ Connected as: ${emailAddress}`);
+  console.error(`   Mailbox saved to ~/.email-agent-mcp/tokens/${safeKey}.json`);
+  console.error('');
+  console.error('To start the MCP server, run:');
+  console.error('   npx tsx packages/email-mcp/src/cli.ts serve   # from source');
+  console.error('   npx email-agent-mcp serve             # after npm publish');
+
+  return 0;
+}
+
 export async function runConfigure(opts: CliOptions): Promise<number> {
   if (opts.nemoclaw) {
     console.error('[email-agent-mcp] NemoClaw bootstrap — adding egress domains:');
@@ -477,8 +856,17 @@ export async function runConfigure(opts: CliOptions): Promise<number> {
   const mailboxName = opts.mailbox ?? 'default';
   const provider = opts.provider ?? 'microsoft';
 
+  if (provider === 'gmail') {
+    try {
+      return await runGmailConfigure(opts);
+    } catch (err) {
+      console.error(`\n❌ Configuration failed: ${err instanceof Error ? err.message : err}`);
+      return 1;
+    }
+  }
+
   if (provider !== 'microsoft') {
-    console.error(`[email-agent-mcp] Provider "${provider}" not yet supported for configure. Use --provider microsoft`);
+    console.error(`[email-agent-mcp] Provider "${provider}" not yet supported for configure. Use --provider microsoft or --provider gmail`);
     return 1;
   }
 
@@ -520,7 +908,7 @@ export async function runConfigure(opts: CliOptions): Promise<number> {
         // This handles: work.json -> test-user-at-example-com.json migration
         // and any other stale alias files
         {
-          const { unlink, readdir, readFile: readFileAsync, writeFile: writeFileAsync, mkdir } = await import('node:fs/promises');
+          const { unlink, readdir, readFile: readFileAsync } = await import('node:fs/promises');
           const agentHome = getAgentEmailHome();
           const tokensDir = join(agentHome, 'tokens');
           const newFilename = `${safeKey}.json`;
@@ -545,29 +933,8 @@ export async function runConfigure(opts: CliOptions): Promise<number> {
           }
 
           // Auto-add the authenticated email to the send allowlist
-          const allowlistPath = join(agentHome, 'send-allowlist.json');
           try {
-            // Ensure directory exists
-            await mkdir(agentHome, { recursive: true });
-
-            // Read existing allowlist or start empty
-            let entries: string[] = [];
-            try {
-              const raw = await readFileAsync(allowlistPath, 'utf-8');
-              const data = JSON.parse(raw) as { entries?: string[] };
-              entries = data.entries ?? [];
-            } catch {
-              // File doesn't exist yet — start fresh
-            }
-
-            // Dedupe-add (case-insensitive)
-            const lowerEmail = emailAddress.toLowerCase();
-            if (!entries.some(e => e.toLowerCase() === lowerEmail)) {
-              entries.push(emailAddress);
-            }
-
-            // Write back pretty-printed
-            await writeFileAsync(allowlistPath, JSON.stringify({ entries }, null, 2) + '\n', 'utf-8');
+            await addEmailToSendAllowlist(emailAddress);
             console.error(`[email-agent-mcp] Send allowlist: ${emailAddress} (outbound email enabled to this address)`);
           } catch (allowlistErr) {
             console.error(`[email-agent-mcp] WARNING: Could not update send allowlist: ${allowlistErr instanceof Error ? allowlistErr.message : allowlistErr}`);
@@ -603,8 +970,7 @@ export async function runConfigure(opts: CliOptions): Promise<number> {
  * Show detailed status of all configured mailboxes.
  */
 export async function runStatus(): Promise<number> {
-  const { listConfiguredMailboxesWithMetadata } = await import('@usejunior/provider-microsoft');
-  const mailboxes = await listConfiguredMailboxesWithMetadata();
+  const mailboxes = await listConfiguredMailboxSummaries();
 
   console.error('');
   console.error('  \uD83E\uDD9E email-agent-mcp status');
@@ -625,6 +991,7 @@ export async function runStatus(): Promise<number> {
       : null;
 
     console.error(`  Account: ${name}`);
+    console.error(`    Provider: ${mb.provider}`);
     console.error(`    Last authenticated: ${lastAuth}`);
     if (daysSinceAuth !== null) {
       if (daysSinceAuth > 80) {
@@ -743,6 +1110,7 @@ OPTIONS:
   --mailbox <name>       Mailbox alias or email address (required if multiple configured)
   --provider <name>      Auth provider (microsoft, gmail)
   --client-id <id>       OAuth client ID override
+  --client-secret <val>  OAuth client secret override (used for Gmail configure)
 `.trim());
 }
 

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -170,8 +170,8 @@ describe('mcp-transport/Lazy Provider State', () => {
     // No init has been triggered — state is still 'pending'.
     const actions = await buildLazyActions(state, noAllowlist);
 
-    // 4 custom tools + 11 email-core actions = 15 tools, no auth performed.
-    expect(actions.length).toBe(15);
+    // 4 custom tools + 12 email-core actions = 16 tools, no auth performed.
+    expect(actions.length).toBe(16);
     expect(state.status).toBe('pending');
     expect(state.initPromise).toBeNull();
     expect(state.provider).toBeNull();
@@ -179,6 +179,7 @@ describe('mcp-transport/Lazy Provider State', () => {
     const tools = actionsToMcpTools(actions);
     expect(tools.map(t => t.name)).toContain('list_emails');
     expect(tools.map(t => t.name)).toContain('get_mailbox_status');
+    expect(tools.map(t => t.name)).toContain('list_attachments');
     expect(tools.map(t => t.name)).toContain('send_email');
   });
 
@@ -305,6 +306,501 @@ describe('mcp-transport/Lazy Provider State', () => {
 
     expect(result.status).toBe('error');
     expect(result.warnings[0]).toMatch(/missing credentials/);
+  });
+
+  it('Scenario: get_mailbox_status reports the connected Gmail provider', async () => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.provider = {} as never;
+    state.connectedMailbox = 'steven.obiajulu@gmail.com';
+    state.connectedProvider = 'gmail';
+    state.initPromise = Promise.resolve();
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, {}) as { provider: string; name: string; status: string };
+
+    expect(result.provider).toBe('gmail');
+    expect(result.name).toBe('steven.obiajulu@gmail.com');
+    expect(result.status).toBe('connected');
+  });
+
+  it('Scenario: custom search_emails routes to the requested mailbox provider', async () => {
+    const workSearch = vi.fn().mockResolvedValue([
+      {
+        id: 'work-1',
+        subject: 'Work result',
+        from: { email: 'boss@example.com' },
+        receivedAt: '2026-04-09T10:00:00.000Z',
+        isRead: false,
+        hasAttachments: false,
+      },
+    ]);
+    const personalSearch = vi.fn().mockResolvedValue([
+      {
+        id: 'personal-1',
+        subject: 'Personal result',
+        from: { email: 'friend@example.com' },
+        receivedAt: '2026-04-09T11:00:00.000Z',
+        isRead: true,
+        hasAttachments: true,
+      },
+    ]);
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { searchMessages: workSearch } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: { searchMessages: workSearch } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { searchMessages: personalSearch } as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const search = actions.find(a => a.name === 'search_emails')!;
+    const result = await search.run({}, { query: 'license', mailbox: 'personal' }) as {
+      emails: Array<{ id: string; subject: string; mailbox?: string }>;
+    };
+
+    expect(personalSearch).toHaveBeenCalledWith('license', undefined, 25, undefined);
+    expect(workSearch).not.toHaveBeenCalled();
+    expect(result.emails).toEqual([
+      {
+        id: 'personal-1',
+        subject: 'Personal result',
+        from: 'friend@example.com',
+        receivedAt: '2026-04-09T11:00:00.000Z',
+        isRead: true,
+        hasAttachments: true,
+        mailbox: 'personal',
+      },
+    ]);
+  });
+
+  it('Scenario: custom search_emails can fan out across all connected mailboxes', async () => {
+    const workSearch = vi.fn().mockResolvedValue([
+      {
+        id: 'work-1',
+        subject: 'Work result',
+        from: { email: 'boss@example.com' },
+        receivedAt: '2026-04-09T10:00:00.000Z',
+        isRead: false,
+        hasAttachments: false,
+      },
+    ]);
+    const personalSearch = vi.fn().mockResolvedValue([
+      {
+        id: 'personal-1',
+        subject: 'Personal result',
+        from: { email: 'friend@example.com' },
+        receivedAt: '2026-04-09T11:00:00.000Z',
+        isRead: true,
+        hasAttachments: true,
+      },
+    ]);
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { searchMessages: workSearch } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: { searchMessages: workSearch } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { searchMessages: personalSearch } as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const search = actions.find(a => a.name === 'search_emails')!;
+    const result = await search.run({}, { query: 'license', mailbox: null, limit: 10 }) as {
+      emails: Array<{ id: string; mailbox?: string }>;
+    };
+
+    expect(workSearch).toHaveBeenCalledWith('license', undefined);
+    expect(personalSearch).toHaveBeenCalledWith('license', undefined);
+    expect(result.emails).toEqual([
+      {
+        id: 'personal-1',
+        subject: 'Personal result',
+        from: 'friend@example.com',
+        receivedAt: '2026-04-09T11:00:00.000Z',
+        isRead: true,
+        hasAttachments: true,
+        mailbox: 'personal',
+      },
+      {
+        id: 'work-1',
+        subject: 'Work result',
+        from: 'boss@example.com',
+        receivedAt: '2026-04-09T10:00:00.000Z',
+        isRead: false,
+        hasAttachments: false,
+        mailbox: 'work',
+      },
+    ]);
+  });
+
+  it('Scenario: custom read_email surfaces attachment metadata from the provider', async () => {
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-attachment',
+      subject: 'Attachment message',
+      from: { email: 'sender@example.com', name: 'Sender' },
+      to: [{ email: 'recipient@example.com', name: 'Recipient' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      bodyHtml: '<p>See attached</p>',
+      attachments: [
+        {
+          id: 'att-1',
+          filename: 'license.jpeg',
+          mimeType: 'image/jpeg',
+          size: 692702,
+          isInline: false,
+        },
+      ],
+    });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'personal@example.com';
+    state.connectedProvider = 'gmail';
+    state.mailboxes = [
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { getMessage } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, { id: 'msg-attachment' }) as {
+      body: string;
+      attachments?: Array<{ filename: string; mimeType: string; size: number }>;
+    };
+
+    expect(result.body).toContain('See attached');
+    expect(result.attachments).toEqual([
+      {
+        id: 'att-1',
+        filename: 'license.jpeg',
+        mimeType: 'image/jpeg',
+        size: 692702,
+        contentId: undefined,
+        isInline: false,
+      },
+    ]);
+  });
+
+  it('Scenario: get_mailbox_status resolves the requested mailbox instead of the default', async () => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = {} as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: {} as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: {} as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, { mailbox: 'personal@example.com' }) as {
+      provider: string;
+      name: string;
+      status: string;
+      isDefault: boolean;
+    };
+
+    expect(result.provider).toBe('gmail');
+    expect(result.name).toBe('personal@example.com');
+    expect(result.status).toBe('connected');
+    expect(result.isDefault).toBe(false);
+  });
+
+  it('Scenario: get_mailbox_status reports a useful error for unknown requested mailboxes', async () => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = {} as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: {} as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: {} as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, { mailbox: 'unknown@example.com' }) as {
+      name: string;
+      status: string;
+      warnings: string[];
+    };
+
+    expect(result.name).toBe('unknown@example.com');
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toContain('Available mailboxes: work@example.com, personal@example.com');
+  });
+
+  it('Scenario: custom list_emails routes to the requested mailbox provider', async () => {
+    const workList = vi.fn().mockResolvedValue([]);
+    const personalList = vi.fn().mockResolvedValue([
+      {
+        id: 'personal-1',
+        subject: 'Personal result',
+        from: { email: 'friend@example.com' },
+        receivedAt: '2026-04-09T11:00:00.000Z',
+        isRead: true,
+        hasAttachments: true,
+      },
+    ]);
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { listMessages: workList } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: { listMessages: workList } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { listMessages: personalList } as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const listEmails = actions.find(a => a.name === 'list_emails')!;
+    const result = await listEmails.run({}, { mailbox: 'personal', limit: 10, unread: true, folder: 'inbox' }) as {
+      emails: Array<{ id: string; subject: string }>;
+    };
+
+    expect(personalList).toHaveBeenCalledWith({
+      unread: true,
+      limit: 10,
+      offset: undefined,
+      folder: 'inbox',
+    });
+    expect(workList).not.toHaveBeenCalled();
+    expect(result.emails).toEqual([
+      {
+        id: 'personal-1',
+        subject: 'Personal result',
+        from: 'friend@example.com',
+        receivedAt: '2026-04-09T11:00:00.000Z',
+        isRead: true,
+        hasAttachments: true,
+      },
+    ]);
+  });
+
+  it('Scenario: wrapped send_email uses the requested mailbox provider', async () => {
+    const workCreateDraft = vi.fn().mockResolvedValue({ success: true, draftId: 'draft-work' });
+    const personalCreateDraft = vi.fn().mockResolvedValue({ success: true, draftId: 'draft-personal' });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { createDraft: workCreateDraft } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: { createDraft: workCreateDraft } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { createDraft: personalCreateDraft } as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const sendEmail = actions.find(a => a.name === 'send_email')!;
+    const result = await sendEmail.run({}, {
+      mailbox: 'personal',
+      to: ['friend@example.com'],
+      subject: 'hello',
+      body: 'test body',
+      draft: true,
+    }) as { success: boolean; draftId?: string };
+
+    expect(result).toEqual({ success: true, draftId: 'draft-personal', error: undefined });
+    expect(personalCreateDraft).toHaveBeenCalledOnce();
+    expect(workCreateDraft).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: list_attachments uses the requested mailbox provider context', async () => {
+    const workGetMessage = vi.fn().mockResolvedValue({ attachments: [] });
+    const personalGetMessage = vi.fn().mockResolvedValue({
+      attachments: [
+        {
+          id: 'att-1',
+          filename: 'license.jpeg',
+          mimeType: 'image/jpeg',
+          size: 692702,
+          isInline: false,
+        },
+      ],
+    });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage: workGetMessage } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider: { getMessage: workGetMessage } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'personal',
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { getMessage: personalGetMessage } as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const listAttachments = actions.find(a => a.name === 'list_attachments')!;
+    const result = await listAttachments.run({}, {
+      mailbox: 'personal',
+      message_id: 'msg-attachment',
+    }) as { attachments: Array<{ filename: string }> };
+
+    expect(personalGetMessage).toHaveBeenCalledWith('msg-attachment');
+    expect(workGetMessage).not.toHaveBeenCalled();
+    expect(result.attachments).toEqual([
+      {
+        id: 'att-1',
+        filename: 'license.jpeg',
+        mimeType: 'image/jpeg',
+        size: 692702,
+        contentId: undefined,
+        isInline: false,
+      },
+    ]);
   });
 
   it('Scenario: waitForInit returns immediately once a terminal state is reached', async () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -12,6 +12,23 @@ export interface LazyProviderAuth {
   tryReconnect: () => Promise<boolean>;
 }
 
+export interface LazyMailboxState {
+  name: string;
+  emailAddress?: string;
+  displayName: string;
+  providerType: 'microsoft' | 'gmail';
+  provider: EmailProvider | null;
+  auth: LazyProviderAuth | null;
+  isDefault: boolean;
+  status: 'connected' | 'error';
+  error?: string;
+}
+
+interface ConnectedLazyMailboxState extends LazyMailboxState {
+  provider: EmailProvider;
+  status: 'connected';
+}
+
 export interface LazyProviderState {
   provider: EmailProvider | null;
   auth: LazyProviderAuth | null;
@@ -22,6 +39,8 @@ export interface LazyProviderState {
   status: 'pending' | 'connecting' | 'connected' | 'not_configured' | 'error';
   /** Human-readable display name of the connected mailbox, if any. */
   connectedMailbox: string | null;
+  connectedProvider: 'microsoft' | 'gmail' | null;
+  mailboxes: LazyMailboxState[];
 }
 
 /** Create a fresh lazy state. */
@@ -34,11 +53,18 @@ export function createLazyProviderState(): LazyProviderState {
     isDemo: false,
     status: 'pending',
     connectedMailbox: null,
+    connectedProvider: null,
+    mailboxes: [],
   };
 }
 
 const require = createRequire(import.meta.url);
 const { version: PACKAGE_VERSION } = require('../package.json') as { version: string };
+
+const MANUAL_GMAIL_SETUP_HINT =
+  'or add a Gmail mailbox JSON file under ~/.email-agent-mcp/tokens/. See packages/provider-gmail/README.md';
+const NO_MAILBOX_CONFIGURED_MESSAGE =
+  `No mailbox configured — run: email-agent-mcp configure --mailbox <name> --provider microsoft ${MANUAL_GMAIL_SETUP_HINT}`;
 
 // Re-export types for the action registry
 export interface McpTool {
@@ -257,12 +283,108 @@ export async function waitForInit(state: LazyProviderState): Promise<void> {
  */
 export async function ensureProvider(state: LazyProviderState): Promise<void> {
   await waitForInit(state);
-  if (!state.provider) {
+  if (!getDefaultMailbox(state)) {
+    throw new Error(state.error ?? NO_MAILBOX_CONFIGURED_MESSAGE);
+  }
+}
+
+interface ResolvedMailboxContext {
+  mailbox: ConnectedLazyMailboxState;
+  allMailboxes: Array<{
+    name: string;
+    emailAddress?: string;
+    provider: EmailProvider;
+    providerType: string;
+    isDefault: boolean;
+    status: 'connected';
+  }>;
+}
+
+function normalizeMailboxKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function fallbackConnectedMailbox(state: LazyProviderState): LazyMailboxState[] {
+  if (!state.provider) return [];
+  return [
+    {
+      name: state.connectedMailbox ?? 'default',
+      emailAddress: state.connectedMailbox ?? undefined,
+      displayName: state.connectedMailbox ?? 'default',
+      providerType: state.connectedProvider ?? 'microsoft',
+      provider: state.provider,
+      auth: state.auth,
+      isDefault: true,
+      status: 'connected',
+    },
+  ];
+}
+
+function getKnownMailboxes(state: LazyProviderState): LazyMailboxState[] {
+  return state.mailboxes.length > 0 ? state.mailboxes : fallbackConnectedMailbox(state);
+}
+
+function isConnectedMailbox(mailbox: LazyMailboxState): mailbox is ConnectedLazyMailboxState {
+  return mailbox.status === 'connected' && mailbox.provider !== null;
+}
+
+function getConnectedMailboxes(state: LazyProviderState): ConnectedLazyMailboxState[] {
+  return getKnownMailboxes(state).filter(isConnectedMailbox);
+}
+
+function getDefaultMailbox(state: LazyProviderState): ConnectedLazyMailboxState | null {
+  const connected = getConnectedMailboxes(state);
+  return connected.find(mailbox => mailbox.isDefault) ?? connected[0] ?? null;
+}
+
+function findKnownMailbox(state: LazyProviderState, mailboxName: string): LazyMailboxState | null {
+  const target = normalizeMailboxKey(mailboxName);
+  return (
+    getKnownMailboxes(state).find(mailbox =>
+      normalizeMailboxKey(mailbox.name) === target ||
+      normalizeMailboxKey(mailbox.displayName) === target ||
+      (mailbox.emailAddress ? normalizeMailboxKey(mailbox.emailAddress) === target : false),
+    ) ?? null
+  );
+}
+
+function describeConfiguredMailboxes(state: LazyProviderState): string {
+  const names = getKnownMailboxes(state).map(mailbox => mailbox.emailAddress ?? mailbox.name);
+  return names.length > 0 ? names.join(', ') : 'none';
+}
+
+function resolveMailboxContext(
+  state: LazyProviderState,
+  requestedMailbox?: string,
+): ResolvedMailboxContext {
+  const connectedMailboxes = getConnectedMailboxes(state);
+  if (connectedMailboxes.length === 0) {
+    throw new Error(state.error ?? NO_MAILBOX_CONFIGURED_MESSAGE);
+  }
+
+  const mailbox = requestedMailbox ? findKnownMailbox(state, requestedMailbox) : getDefaultMailbox(state);
+
+  if (!mailbox) {
     throw new Error(
-      state.error ??
-        'No mailbox configured — run: email-agent-mcp configure --mailbox <name> --provider microsoft',
+      `Mailbox "${requestedMailbox}" is not configured. Available mailboxes: ${describeConfiguredMailboxes(state)}`,
     );
   }
+
+  if (!isConnectedMailbox(mailbox)) {
+    throw new Error(mailbox.error ?? `Mailbox "${requestedMailbox ?? mailbox.name}" is not connected`);
+  }
+
+  return {
+    mailbox,
+    allMailboxes: connectedMailboxes.map(connected => ({
+      name: connected.name,
+      emailAddress: connected.emailAddress,
+      provider: connected.provider,
+      providerType: connected.providerType,
+      isDefault: connected.isDefault,
+      status: 'connected' as const,
+    })),
+  };
 }
 
 /**
@@ -272,19 +394,29 @@ export async function ensureProvider(state: LazyProviderState): Promise<void> {
  */
 export async function initProvider(state: LazyProviderState): Promise<void> {
   try {
-    const { listConfiguredMailboxesWithMetadata, DelegatedAuthManager, RealGraphApiClient, GraphEmailProvider } =
-      await import('@usejunior/provider-microsoft');
-    const allMailboxes = await listConfiguredMailboxesWithMetadata();
+    const [
+      { listConfiguredMailboxesWithMetadata, DelegatedAuthManager, RealGraphApiClient, GraphEmailProvider },
+      { listConfiguredGmailMailboxes, GmailAuthManager, GmailEmailProvider, GoogleapisGmailClient },
+    ] = await Promise.all([
+      import('@usejunior/provider-microsoft'),
+      import('@usejunior/provider-gmail'),
+    ]);
+    const microsoftMailboxes = await listConfiguredMailboxesWithMetadata();
+    const gmailMailboxes = await listConfiguredGmailMailboxes();
 
-    if (allMailboxes.length === 0) {
+    if (microsoftMailboxes.length === 0 && gmailMailboxes.length === 0) {
       state.isDemo = true;
       state.status = 'not_configured';
+      state.mailboxes = [];
       console.error('[email-agent-mcp] No configured mailboxes — running in demo mode');
-      console.error('[email-agent-mcp] Run: email-agent-mcp configure --mailbox <name> --provider microsoft');
+      console.error(`[email-agent-mcp] ${NO_MAILBOX_CONFIGURED_MESSAGE}`);
       return;
     }
 
-    for (const metadata of allMailboxes) {
+    const connectedMailboxes: LazyMailboxState[] = [];
+    const failedMailboxes: LazyMailboxState[] = [];
+
+    for (const metadata of microsoftMailboxes) {
       const displayName = metadata.emailAddress ?? metadata.mailboxName;
       try {
         const auth = new DelegatedAuthManager(
@@ -295,23 +427,99 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
         const client = new RealGraphApiClient(() => auth.getAccessToken(), () => auth.tryReconnect());
         const provider = new GraphEmailProvider(client);
 
-        state.provider = provider;
-        state.auth = {
+        const mailboxAuth = {
           getTokenHealthWarning: () => auth.getTokenHealthWarning(),
           tryReconnect: () => auth.tryReconnect(),
         };
-        state.connectedMailbox = displayName;
-        state.status = 'connected';
+
+        connectedMailboxes.push({
+          name: metadata.mailboxName,
+          emailAddress: metadata.emailAddress,
+          displayName,
+          providerType: 'microsoft',
+          provider,
+          auth: mailboxAuth,
+          isDefault: false,
+          status: 'connected',
+        });
+
         console.error(`[email-agent-mcp] Connected to mailbox "${displayName}" (${metadata.clientId})`);
-        return;
       } catch (err) {
+        failedMailboxes.push({
+          name: metadata.mailboxName,
+          emailAddress: metadata.emailAddress,
+          displayName,
+          providerType: 'microsoft',
+          provider: null,
+          auth: null,
+          isDefault: false,
+          status: 'error',
+          error: err instanceof Error ? err.message : String(err),
+        });
         console.error(
           `[email-agent-mcp] Skipping mailbox "${displayName}": ${err instanceof Error ? err.message : err}`,
         );
       }
     }
 
+    for (const metadata of gmailMailboxes) {
+      const displayName = metadata.emailAddress ?? metadata.mailboxName;
+      try {
+        const auth = new GmailAuthManager({
+          clientId: metadata.clientId,
+          clientSecret: metadata.clientSecret,
+          redirectUri: metadata.redirectUri,
+        });
+        await auth.connect({ refresh_token: metadata.refreshToken });
+        await auth.refresh();
+
+        const client = new GoogleapisGmailClient(auth);
+        const provider = new GmailEmailProvider(client);
+
+        connectedMailboxes.push({
+          name: metadata.mailboxName,
+          emailAddress: metadata.emailAddress,
+          displayName,
+          providerType: 'gmail',
+          provider,
+          auth: null,
+          isDefault: false,
+          status: 'connected',
+        });
+
+        console.error(`[email-agent-mcp] Connected to Gmail mailbox "${displayName}" (${metadata.clientId})`);
+      } catch (err) {
+        failedMailboxes.push({
+          name: metadata.mailboxName,
+          emailAddress: metadata.emailAddress,
+          displayName,
+          providerType: 'gmail',
+          provider: null,
+          auth: null,
+          isDefault: false,
+          status: 'error',
+          error: err instanceof Error ? err.message : String(err),
+        });
+        console.error(
+          `[email-agent-mcp] Skipping Gmail mailbox "${displayName}": ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
+    if (connectedMailboxes.length > 0) {
+      connectedMailboxes[0]!.isDefault = true;
+      state.mailboxes = [...connectedMailboxes, ...failedMailboxes];
+      state.provider = connectedMailboxes[0]!.provider;
+      state.auth = connectedMailboxes[0]!.auth;
+      state.connectedMailbox = connectedMailboxes[0]!.displayName;
+      state.connectedProvider = connectedMailboxes[0]!.providerType;
+      state.isDemo = false;
+      state.status = 'connected';
+      return;
+    }
+
     // All configured mailboxes failed to authenticate.
+    state.mailboxes = failedMailboxes;
     state.isDemo = true;
     state.status = 'error';
     state.error = 'All configured mailboxes failed to authenticate';
@@ -343,18 +551,13 @@ export async function buildLazyActions(
     sendDraftAction,
     updateDraftAction,
     getThreadAction,
+    listAttachmentsAction,
     labelEmailAction,
     flagEmailAction,
     markReadAction,
     moveToFolderAction,
     deleteEmailAction,
   } = await import('@usejunior/email-core');
-
-  // Shared context for email-core actions — provider is resolved at call time.
-  const actionCtx = {
-    get provider() { return state.provider as never; },
-    get sendAllowlist() { return getSendAllowlist(); },
-  };
 
   // Structured "provider unavailable" error — matches the shape of email-core errors.
   const providerUnavailableError = (err: unknown) => ({
@@ -376,10 +579,22 @@ export async function buildLazyActions(
     run: async (_ctx, input) => {
       try {
         await ensureProvider(state);
+        const requestedMailbox =
+          input && typeof input === 'object' && 'mailbox' in input &&
+          typeof (input as { mailbox?: unknown }).mailbox === 'string'
+            ? (input as { mailbox?: string }).mailbox
+            : undefined;
+        const resolved = resolveMailboxContext(state, requestedMailbox);
+        const actionCtx = {
+          provider: resolved.mailbox.provider,
+          mailboxName: resolved.mailbox.name,
+          allMailboxes: resolved.allMailboxes,
+          sendAllowlist: getSendAllowlist(),
+        };
+        return action.run(actionCtx as never, input as never);
       } catch (err) {
         return providerUnavailableError(err);
       }
-      return action.run(actionCtx as never, input as never);
     },
   });
 
@@ -401,7 +616,7 @@ export async function buildLazyActions(
     subject: 'Demo mode',
     from: 'system@email-agent-mcp.dev',
     to: ['user@example.com'],
-    body: 'No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft',
+    body: NO_MAILBOX_CONFIGURED_MESSAGE,
     receivedAt: new Date().toISOString(),
   });
 
@@ -414,9 +629,15 @@ export async function buildLazyActions(
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
-        if (!state.provider) return demoListEmails();
-        const inp = input as { unread?: boolean; limit?: number; offset?: number; folder?: string };
-        const messages = await state.provider.listMessages({ unread: inp.unread, limit: inp.limit ?? 25, offset: inp.offset, folder: inp.folder ?? 'inbox' });
+        if (!getDefaultMailbox(state)) return demoListEmails();
+        const inp = input as { mailbox?: string; unread?: boolean; limit?: number; offset?: number; folder?: string };
+        const { mailbox } = resolveMailboxContext(state, inp.mailbox);
+        const messages = await mailbox.provider.listMessages({
+          unread: inp.unread,
+          limit: inp.limit ?? 25,
+          offset: inp.offset,
+          folder: inp.folder ?? 'inbox',
+        });
         return {
           emails: (messages as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>).map(m => ({
             id: m.id,
@@ -433,24 +654,52 @@ export async function buildLazyActions(
       name: 'read_email',
       description: 'Read the full content of an email by ID, transformed to token-efficient markdown',
       input: z.object({ id: z.string(), mailbox: z.string().optional() }),
-      output: z.object({ id: z.string(), subject: z.string(), from: z.string(), to: z.array(z.string()), body: z.string(), receivedAt: z.string() }),
+      output: z.object({
+        id: z.string(),
+        subject: z.string(),
+        from: z.string(),
+        to: z.array(z.string()),
+        body: z.string(),
+        receivedAt: z.string(),
+        attachments: z.array(z.object({
+          id: z.string(),
+          filename: z.string(),
+          mimeType: z.string(),
+          size: z.number(),
+          contentId: z.string().optional(),
+          isInline: z.boolean(),
+        })).optional(),
+      }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
-        const inp = input as { id: string };
-        if (!state.provider) return demoReadEmail(inp.id);
-        const msg = await state.provider.getMessage(inp.id) as { id: string; subject: string; from: { email: string; name?: string }; to: Array<{ email: string; name?: string }>; receivedAt: string; body?: string; bodyHtml?: string };
+        const inp = input as { id: string; mailbox?: string };
+        if (!getDefaultMailbox(state)) return demoReadEmail(inp.id);
+        const { mailbox } = resolveMailboxContext(state, inp.mailbox);
+        const msg = await mailbox.provider.getMessage(inp.id) as {
+          id: string;
+          subject: string;
+          from: { email: string; name?: string };
+          to: Array<{ email: string; name?: string }>;
+          receivedAt: string;
+          body?: string;
+          bodyHtml?: string;
+          attachments?: Array<{
+            id: string;
+            filename: string;
+            mimeType: string;
+            size: number;
+            contentId?: string;
+            isInline: boolean;
+          }>;
+        };
 
         let emailBody = '';
-        if (msg.bodyHtml) {
-          try {
-            const { htmlToMarkdown } = await import('@usejunior/email-core');
-            emailBody = htmlToMarkdown(msg.bodyHtml);
-          } catch {
-            emailBody = msg.bodyHtml;
-          }
-        } else if (msg.body) {
-          emailBody = msg.body;
+        try {
+          const { transformEmailContent } = await import('@usejunior/email-core');
+          emailBody = transformEmailContent(msg.body, msg.bodyHtml, msg.attachments);
+        } catch {
+          emailBody = msg.bodyHtml ?? msg.body ?? '';
         }
 
         return {
@@ -460,20 +709,51 @@ export async function buildLazyActions(
           to: msg.to.map(a => a.name ? `${a.name} <${a.email}>` : a.email),
           body: emailBody,
           receivedAt: msg.receivedAt,
+          attachments: msg.attachments?.map(attachment => ({
+            id: attachment.id,
+            filename: attachment.filename,
+            mimeType: attachment.mimeType,
+            size: attachment.size,
+            contentId: attachment.contentId,
+            isInline: attachment.isInline,
+          })),
         };
       },
     },
     {
       name: 'search_emails',
       description: 'Search emails using full-text query across one or all mailboxes. Use offset for pagination.',
-      input: z.object({ query: z.string(), mailbox: z.string().optional(), limit: z.number().optional(), offset: z.number().optional() }),
-      output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
+      input: z.object({ query: z.string(), mailbox: z.string().nullable().optional(), limit: z.number().optional(), offset: z.number().optional() }),
+      output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean(), mailbox: z.string().optional() })) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
-        if (!state.provider) return { emails: [] };
-        const inp = input as { query: string; limit?: number; offset?: number };
-        const results = await state.provider.searchMessages(inp.query, undefined, inp.limit, inp.offset) as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>;
+        if (!getDefaultMailbox(state)) return { emails: [] };
+        const inp = input as { query: string; mailbox?: string | null; limit?: number; offset?: number };
+        const resolved = inp.mailbox === null ? null : resolveMailboxContext(state, inp.mailbox);
+        const results = resolved
+          ? (await resolved.mailbox.provider.searchMessages(
+            inp.query,
+            undefined,
+            inp.limit ?? 25,
+            inp.offset,
+          ) as Array<{
+            id: string;
+            subject: string;
+            from: { email: string; name?: string };
+            receivedAt: string;
+            isRead: boolean;
+            hasAttachments: boolean;
+          }>).map(result => ({ ...result, mailbox: resolved.mailbox.name }))
+          : (await Promise.all(
+            getConnectedMailboxes(state).map(async mailbox => {
+              const mailboxResults = await mailbox.provider.searchMessages(inp.query, undefined);
+              return mailboxResults.map(result => ({ ...result, mailbox: mailbox.name }));
+            }),
+          ))
+            .flat()
+            .sort((a, b) => new Date(b.receivedAt).getTime() - new Date(a.receivedAt).getTime())
+            .slice(inp.offset ?? 0, (inp.offset ?? 0) + (inp.limit ?? 25));
         return {
           emails: results.map(m => ({
             id: m.id,
@@ -482,6 +762,7 @@ export async function buildLazyActions(
             receivedAt: m.receivedAt,
             isRead: m.isRead,
             hasAttachments: m.hasAttachments,
+            mailbox: m.mailbox,
           })),
         };
       },
@@ -494,24 +775,54 @@ export async function buildLazyActions(
       annotations: { readOnlyHint: true, destructiveHint: false },
       // NON-BLOCKING — reports state directly without awaiting ensureProvider.
       // This is how callers check whether the server is still warming up.
-      run: async () => {
+      run: async (_ctx, input) => {
+        const inp = (input ?? {}) as { mailbox?: string };
         const warnings: string[] = [];
         switch (state.status) {
           case 'pending':
           case 'connecting':
             return { name: 'pending', provider: 'pending', status: 'connecting', isDefault: false, warnings: ['Authenticating — provider is warming up'] };
           case 'not_configured':
-            return { name: 'none', provider: 'none', status: 'not configured', isDefault: false, warnings: ['No mailbox configured. Run: email-agent-mcp configure --mailbox <name> --provider microsoft'] };
+            return { name: 'none', provider: 'none', status: 'not configured', isDefault: false, warnings: [NO_MAILBOX_CONFIGURED_MESSAGE] };
           case 'error':
             return { name: 'none', provider: 'none', status: 'error', isDefault: false, warnings: [state.error ?? 'Provider init failed'] };
           case 'connected': {
-            const healthWarning = state.auth?.getTokenHealthWarning();
+            const mailbox = inp.mailbox ? findKnownMailbox(state, inp.mailbox) : getDefaultMailbox(state);
+            if (!mailbox) {
+              return {
+                name: inp.mailbox ?? 'unknown',
+                provider: 'unknown',
+                status: 'error',
+                isDefault: false,
+                warnings: [
+                  `Mailbox "${inp.mailbox}" is not configured. Available mailboxes: ${describeConfiguredMailboxes(state)}`,
+                ],
+              };
+            }
+
+            if (mailbox.status !== 'connected') {
+              return {
+                name: mailbox.displayName,
+                provider: mailbox.providerType,
+                status: 'error',
+                isDefault: mailbox.isDefault,
+                warnings: [mailbox.error ?? `Mailbox "${mailbox.displayName}" is not connected`],
+              };
+            }
+
+            const healthWarning = mailbox.auth?.getTokenHealthWarning();
             if (healthWarning) warnings.push(healthWarning);
             const currentAllowlist = getSendAllowlist();
             if (!currentAllowlist || currentAllowlist.entries.length === 0) {
               warnings.push('Send allowlist not configured — all outbound email is disabled. Run: email-agent-mcp configure');
             }
-            return { name: state.connectedMailbox ?? 'default', provider: 'microsoft', status: 'connected', isDefault: true, warnings };
+            return {
+              name: mailbox.displayName,
+              provider: mailbox.providerType,
+              status: 'connected',
+              isDefault: mailbox.isDefault,
+              warnings,
+            };
           }
         }
       },
@@ -522,6 +833,7 @@ export async function buildLazyActions(
     wrapAction(sendDraftAction),
     wrapAction(updateDraftAction),
     wrapAction(getThreadAction),
+    wrapAction(listAttachmentsAction),
     wrapAction(labelEmailAction),
     wrapAction(flagEmailAction),
     wrapAction(markReadAction),

--- a/packages/email-mcp/src/wizard.ts
+++ b/packages/email-mcp/src/wizard.ts
@@ -3,8 +3,7 @@
 import * as p from '@clack/prompts';
 import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
-import type { CliOptions } from './cli.js';
-import type { MailboxMetadata } from '@usejunior/provider-microsoft';
+import type { CliOptions, ConfiguredMailboxSummary } from './cli.js';
 
 /**
  * First-run wizard — guides user through email setup.
@@ -15,7 +14,7 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
   p.intro('🦞 email-agent-mcp — Email connectivity for AI agents');
 
   p.note(
-    'Outlook: not configured\nGmail:   coming soon',
+    'Outlook: interactive setup\nGmail:   interactive setup (Google OAuth client required)',
     'Email Accounts',
   );
 
@@ -23,7 +22,7 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
     message: 'Select a provider',
     options: [
       { value: 'microsoft', label: 'Outlook (Microsoft 365 / Office 365)' },
-      { value: 'gmail', label: 'Gmail (coming soon)', hint: 'Not yet available' },
+      { value: 'gmail', label: 'Gmail' },
     ],
   });
 
@@ -34,29 +33,30 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
 
   if (provider === 'gmail') {
     p.note(
-      'Gmail support is coming soon.\nFor now, use Outlook (Microsoft 365 / Office 365).\nFollow: github.com/UseJunior/email-agent-mcp for updates.',
-      'Coming Soon',
+      'Gmail setup uses a Google OAuth client and a local browser callback on 127.0.0.1.\n' +
+      'Provide the client via --client-id / --client-secret or the env vars\n' +
+      'AGENT_EMAIL_GMAIL_CLIENT_ID and AGENT_EMAIL_GMAIL_CLIENT_SECRET.\n' +
+      `Credentials stored at ${getAgentEmailHome()}/tokens/`,
+      'How Gmail auth works',
     );
-    p.outro('Setup cancelled — Gmail not yet available.');
-    return 0;
+  } else {
+    p.note(
+      "You'll see a code to enter at https://login.microsoft.com/device\n" +
+      'This links your Outlook mailbox to email-agent-mcp.\n' +
+      `Credentials stored at ${getAgentEmailHome()}/tokens/\n` +
+      'Token refreshes automatically for ~90 days.',
+      'How email auth works',
+    );
   }
 
-  p.note(
-    "You'll see a code to enter at https://login.microsoft.com/device\n" +
-    'This links your Outlook mailbox to email-agent-mcp.\n' +
-    `Credentials stored at ${getAgentEmailHome()}/tokens/\n` +
-    'Token refreshes automatically for ~90 days.',
-    'How email auth works',
-  );
-
-  const confirmLink = await p.confirm({ message: 'Link Outlook now?' });
+  const confirmLink = await p.confirm({ message: provider === 'gmail' ? 'Link Gmail now?' : 'Link Outlook now?' });
   if (p.isCancel(confirmLink) || !confirmLink) {
     p.outro('Setup cancelled.');
     return 0;
   }
 
-  // Run the actual configure — this prints the device code to stderr
-  const configOpts: CliOptions = { ...opts, command: 'configure', provider: 'microsoft' };
+  // Run the actual configure — Microsoft prints a device code; Gmail prints a browser URL.
+  const configOpts: CliOptions = { ...opts, command: 'configure', provider };
   const exitCode = await runConfigure(configOpts);
   if (exitCode !== 0) {
     p.outro('Setup failed. Try again with: email-agent-mcp setup');
@@ -115,8 +115,9 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
   }
 
   // Summary
+  const providerLabel = provider === 'gmail' ? 'Gmail' : 'Outlook (Microsoft 365)';
   p.note(
-    `Provider: Outlook (Microsoft 365)\n` +
+    `Provider: ${providerLabel}\n` +
     `Tokens: ${getAgentEmailHome()}/tokens/\n` +
     `Config: ${getAgentEmailHome()}/config.json\n` +
     `Hooks: ${existingToken ? 'configured' : 'not configured'}`,
@@ -137,7 +138,7 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
 /**
  * Returning user menu — show status and offer actions.
  */
-export async function runWizardMenu(opts: CliOptions, mailboxes: MailboxMetadata[]): Promise<number> {
+export async function runWizardMenu(opts: CliOptions, mailboxes: ConfiguredMailboxSummary[]): Promise<number> {
   const { runWatch, runStatus, runConfigure, loadConfig, saveConfig } = await import('./cli.js');
   const { getAgentEmailHome } = await import('./cli.js');
 
@@ -149,7 +150,7 @@ export async function runWizardMenu(opts: CliOptions, mailboxes: MailboxMetadata
     const lastAuth = mb.lastInteractiveAuthAt
       ? new Date(mb.lastInteractiveAuthAt).toLocaleDateString()
       : 'unknown';
-    return `• ${email} (last auth: ${lastAuth})`;
+    return `• ${email} (${mb.provider}, last auth: ${lastAuth})`;
   }).join('\n');
 
   p.note(statusLines, 'Connected accounts');

--- a/packages/provider-gmail/README.md
+++ b/packages/provider-gmail/README.md
@@ -1,0 +1,105 @@
+# @usejunior/provider-gmail
+
+Gmail setup for `email-agent-mcp`.
+
+## Status
+
+The Gmail provider supports read/search/thread/draft/send flows through the MCP server. The recommended path is `email-agent-mcp configure --provider gmail`, which starts a local browser OAuth flow and writes the mailbox metadata for you. Manual token-file setup still works when you already have a refresh token.
+
+## 1. Create Google OAuth credentials
+
+Create an OAuth client in Google Cloud Console:
+
+1. Enable the Gmail API for your project.
+2. Create an OAuth client ID.
+3. Use a desktop-app client if you want the simplest local flow.
+4. Record the `client_id` and `client_secret`.
+
+## 2. Run the interactive CLI flow
+
+With your Google OAuth client ready, run:
+
+```bash
+npx tsx packages/email-mcp/src/cli.ts configure \
+  --provider gmail \
+  --mailbox personal \
+  --client-id YOUR_GOOGLE_CLIENT_ID \
+  --client-secret YOUR_GOOGLE_CLIENT_SECRET
+```
+
+You can also provide the OAuth client through environment variables:
+
+```bash
+export AGENT_EMAIL_GMAIL_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
+export AGENT_EMAIL_GMAIL_CLIENT_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+npx tsx packages/email-mcp/src/cli.ts configure --provider gmail --mailbox personal
+```
+
+The CLI prints a Google authorization URL, listens on a local `127.0.0.1` callback, saves the mailbox metadata under `~/.email-agent-mcp/tokens/`, and auto-adds the authenticated address to `send-allowlist.json`.
+
+## 3. Manual refresh-token path
+
+The simplest path is Google's OAuth 2.0 Playground using your own client credentials.
+
+1. Open `https://developers.google.com/oauthplayground/`.
+2. Click the gear icon and enable "Use your own OAuth credentials".
+3. Paste your Google `client_id` and `client_secret`.
+4. Authorize the Gmail scope `https://mail.google.com/`.
+5. Exchange the authorization code for tokens.
+6. Copy the returned `refresh_token`.
+
+`email-agent-mcp` only needs the refresh token on disk. Access tokens are refreshed automatically by `google-auth-library`.
+
+## 4. Write the mailbox metadata file
+
+Create `~/.email-agent-mcp/tokens/<safe-key>.json`, where `<safe-key>` is the lowercased email address with `@` replaced by `-at-`, `.` replaced by `-`, and other non-alphanumerics stripped.
+
+Example for `steven.obiajulu@gmail.com`:
+
+Path:
+
+```text
+~/.email-agent-mcp/tokens/steven-obiajulu-at-gmail-com.json
+```
+
+Contents:
+
+```json
+{
+  "provider": "gmail",
+  "mailboxName": "personal",
+  "emailAddress": "steven.obiajulu@gmail.com",
+  "clientId": "YOUR_GOOGLE_CLIENT_ID",
+  "clientSecret": "YOUR_GOOGLE_CLIENT_SECRET",
+  "refreshToken": "YOUR_GOOGLE_REFRESH_TOKEN",
+  "lastInteractiveAuthAt": "2026-04-08T12:00:00.000Z"
+}
+```
+
+`mailboxName` is an alias. `emailAddress` is the canonical mailbox identity.
+
+## 5. Start the server
+
+```bash
+npx tsx packages/email-mcp/src/cli.ts serve
+```
+
+Then call `get_mailbox_status`, `list_emails`, `read_email`, or `search_emails`.
+
+## Search example
+
+To search for an older driver's license email, start with Gmail's native query syntax via `search_emails`:
+
+```json
+{
+  "query": "\"driver license\" OR \"driver's license\" OR license has:attachment",
+  "limit": 25
+}
+```
+
+Then widen or narrow with Gmail filters such as `older_than:5y`, `from:dmv`, `filename:pdf`, or `in:anywhere`.
+
+## Current caveats
+
+- Gmail watcher / PubSub wiring is not implemented yet.
+- Gmail attachments on outgoing mail are not implemented yet.

--- a/packages/provider-gmail/src/auth.test.ts
+++ b/packages/provider-gmail/src/auth.test.ts
@@ -1,27 +1,45 @@
-import { describe, it, expect, vi } from 'vitest';
-import { GmailAuthManager } from './auth.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GMAIL_OAUTH_SCOPES, GmailAuthManager } from './auth.js';
 
-// Mock google-auth-library so tests don't make real HTTP calls
-vi.mock('google-auth-library', () => {
-  const setCredentialsFn = vi.fn();
-  const revokeTokenFn = vi.fn().mockResolvedValue({});
-  const generateAuthUrlFn = vi.fn().mockReturnValue('https://accounts.google.com/o/oauth2/v2/auth?test=1');
-  const getTokenFn = vi.fn().mockResolvedValue({
-    tokens: { access_token: 'exchanged-token', refresh_token: 'exchanged-refresh' },
-  });
-  const refreshAccessTokenFn = vi.fn().mockResolvedValue({
+const oauthMocks = vi.hoisted(() => ({
+  setCredentials: vi.fn(),
+  revokeToken: vi.fn().mockResolvedValue({}),
+  generateAuthUrl: vi.fn().mockReturnValue('https://accounts.google.com/o/oauth2/v2/auth?test=1'),
+  generateCodeVerifierAsync: vi.fn().mockResolvedValue({
+    codeVerifier: 'pkce-verifier',
+    codeChallenge: 'pkce-challenge',
+  }),
+  getToken: vi.fn().mockResolvedValue({
+    tokens: {
+      access_token: 'exchanged-token',
+      refresh_token: 'exchanged-refresh',
+      expiry_date: Date.now() + 3600000,
+    },
+  }),
+  refreshAccessToken: vi.fn().mockResolvedValue({
     credentials: { access_token: 'refreshed-token', expiry_date: Date.now() + 3600000 },
-  });
+  }),
+}));
 
+vi.mock('google-auth-library', () => {
   class MockOAuth2Client {
-    setCredentials = setCredentialsFn;
-    revokeToken = revokeTokenFn;
-    generateAuthUrl = generateAuthUrlFn;
-    getToken = getTokenFn;
-    refreshAccessToken = refreshAccessTokenFn;
+    setCredentials = oauthMocks.setCredentials;
+    revokeToken = oauthMocks.revokeToken;
+    generateAuthUrl = oauthMocks.generateAuthUrl;
+    generateCodeVerifierAsync = oauthMocks.generateCodeVerifierAsync;
+    getToken = oauthMocks.getToken;
+    refreshAccessToken = oauthMocks.refreshAccessToken;
   }
 
-  return { OAuth2Client: MockOAuth2Client };
+  return {
+    CodeChallengeMethod: { S256: 'S256' },
+    OAuth2Client: MockOAuth2Client,
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('provider-gmail/OAuth2 Authentication', () => {
@@ -31,20 +49,16 @@ describe('provider-gmail/OAuth2 Authentication', () => {
       clientSecret: 'test-secret',
     });
 
-    // Initiate OAuth2 flow and persist refresh tokens
     await auth.connect({ access_token: 'gmail-token', refresh_token: 'gmail-refresh' });
 
     expect(auth.getAccessToken()).toBe('gmail-token');
+    expect(auth.getRefreshToken()).toBe('gmail-refresh');
     expect(auth.isTokenExpired()).toBe(false);
-
-    // OAuth2Client.setCredentials was called with tokens
-    const oauthClient = auth.getOAuth2Client();
-    expect(oauthClient.setCredentials).toHaveBeenCalledWith({
+    expect(auth.getOAuth2Client().setCredentials).toHaveBeenCalledWith({
       access_token: 'gmail-token',
       refresh_token: 'gmail-refresh',
     });
 
-    // Refresh works via OAuth2Client
     await auth.refresh();
     expect(auth.getAccessToken()).toBe('refreshed-token');
     expect(auth.isTokenExpired()).toBe(false);
@@ -59,14 +73,84 @@ describe('provider-gmail/OAuth2 Authentication', () => {
     await expect(auth.connect({})).rejects.toThrow('access_token or refresh_token');
   });
 
-  it('Scenario: generateAuthUrl returns OAuth2 URL', () => {
+  it('Scenario: generateAuthUrl returns OAuth2 URL with Gmail scope and PKCE', async () => {
     const auth = new GmailAuthManager({
       clientId: 'test-client',
       clientSecret: 'test-secret',
     });
 
-    const url = auth.generateAuthUrl();
+    const pkce = await auth.generateCodeVerifierAsync();
+    const url = auth.generateAuthUrl({
+      scopes: GMAIL_OAUTH_SCOPES,
+      state: 'state-123',
+      redirectUri: 'http://127.0.0.1:4010/oauth2callback',
+      codeChallenge: pkce.codeChallenge,
+    });
+
     expect(url).toContain('accounts.google.com');
+    expect(auth.getOAuth2Client().generateAuthUrl).toHaveBeenCalledWith({
+      access_type: 'offline',
+      include_granted_scopes: true,
+      prompt: 'consent',
+      scope: GMAIL_OAUTH_SCOPES,
+      state: 'state-123',
+      login_hint: undefined,
+      redirect_uri: 'http://127.0.0.1:4010/oauth2callback',
+      code_challenge: 'pkce-challenge',
+      code_challenge_method: 'S256',
+    });
+  });
+
+  it('Scenario: exchangeCode uses code verifier and stores refresh token', async () => {
+    const auth = new GmailAuthManager({
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+
+    await auth.exchangeCode('auth-code', {
+      codeVerifier: 'pkce-verifier',
+      redirectUri: 'http://127.0.0.1:4010/oauth2callback',
+    });
+
+    expect(auth.getOAuth2Client().getToken).toHaveBeenCalledWith({
+      code: 'auth-code',
+      codeVerifier: 'pkce-verifier',
+      redirect_uri: 'http://127.0.0.1:4010/oauth2callback',
+    });
+    expect(auth.getOAuth2Client().setCredentials).toHaveBeenCalledWith({
+      access_token: 'exchanged-token',
+      refresh_token: 'exchanged-refresh',
+      expiry_date: expect.any(Number),
+    });
+    expect(auth.getRefreshToken()).toBe('exchanged-refresh');
+    expect(auth.getAccessToken()).toBe('exchanged-token');
+  });
+
+  it('Scenario: fetchProfile returns the authenticated Gmail address', async () => {
+    const auth = new GmailAuthManager({
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+    await auth.connect({ access_token: 'gmail-token', refresh_token: 'gmail-refresh' });
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        emailAddress: 'steven.obiajulu@gmail.com',
+        historyId: '12345',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const profile = await auth.fetchProfile();
+
+    expect(profile.emailAddress).toBe('steven.obiajulu@gmail.com');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gmail.googleapis.com/gmail/v1/users/me/profile',
+      {
+        headers: { Authorization: 'Bearer gmail-token' },
+      },
+    );
   });
 
   it('Scenario: disconnect revokes token', async () => {
@@ -79,6 +163,7 @@ describe('provider-gmail/OAuth2 Authentication', () => {
     await auth.disconnect();
 
     expect(auth.getAccessToken()).toBeUndefined();
+    expect(auth.getRefreshToken()).toBeUndefined();
     expect(auth.isTokenExpired()).toBe(true);
     expect(auth.getOAuth2Client().revokeToken).toHaveBeenCalledWith('gmail-token');
   });
@@ -89,7 +174,6 @@ describe('provider-gmail/OAuth2 Authentication', () => {
       clientSecret: 'test-secret',
     });
 
-    // Connect with only access_token, no refresh_token
     await auth.connect({ access_token: 'gmail-token' });
     await expect(auth.refresh()).rejects.toThrow('No refresh token');
   });

--- a/packages/provider-gmail/src/auth.ts
+++ b/packages/provider-gmail/src/auth.ts
@@ -1,12 +1,35 @@
 // Gmail OAuth2 authentication
-import { OAuth2Client } from 'google-auth-library';
+import { CodeChallengeMethod, OAuth2Client } from 'google-auth-library';
 import type { AuthManager } from '@usejunior/email-core';
 
 export interface GmailAuthConfig {
   clientId: string;
-  clientSecret: string;
+  clientSecret?: string;
   redirectUri?: string;
 }
+
+export interface GmailAuthUrlOptions {
+  scopes?: string[];
+  state?: string;
+  loginHint?: string;
+  redirectUri?: string;
+  codeChallenge?: string;
+  prompt?: string;
+}
+
+export interface GmailExchangeCodeOptions {
+  codeVerifier?: string;
+  redirectUri?: string;
+}
+
+export interface GmailProfile {
+  emailAddress: string;
+  historyId?: string;
+  messagesTotal?: number;
+  threadsTotal?: number;
+}
+
+export const GMAIL_OAUTH_SCOPES = ['https://mail.google.com/'];
 
 export class GmailAuthManager implements AuthManager {
   private oauth2Client: OAuth2Client;
@@ -26,6 +49,10 @@ export class GmailAuthManager implements AuthManager {
 
   /** Returns the underlying OAuth2Client for use with Gmail API. */
   getOAuth2Client(): OAuth2Client { return this.oauth2Client; }
+
+  async generateCodeVerifierAsync(): Promise<{ codeVerifier: string; codeChallenge?: string }> {
+    return await this.oauth2Client.generateCodeVerifierAsync();
+  }
 
   /**
    * Connect using OAuth2 credentials.
@@ -60,10 +87,17 @@ export class GmailAuthManager implements AuthManager {
    * The user visits this URL, grants access, and receives an authorization code
    * which can be exchanged via `exchangeCode()`.
    */
-  generateAuthUrl(scopes: string[] = ['https://www.googleapis.com/auth/gmail.modify']): string {
+  generateAuthUrl(options: GmailAuthUrlOptions = {}): string {
     return this.oauth2Client.generateAuthUrl({
       access_type: 'offline',
-      scope: scopes,
+      include_granted_scopes: true,
+      prompt: options.prompt ?? 'consent',
+      scope: options.scopes ?? GMAIL_OAUTH_SCOPES,
+      state: options.state,
+      login_hint: options.loginHint,
+      redirect_uri: options.redirectUri ?? this._config.redirectUri,
+      code_challenge: options.codeChallenge,
+      code_challenge_method: options.codeChallenge ? CodeChallengeMethod.S256 : undefined,
     });
   }
 
@@ -71,12 +105,17 @@ export class GmailAuthManager implements AuthManager {
    * Exchange an authorization code (from the consent flow) for tokens.
    * Calls `connect()` internally with the resulting tokens.
    */
-  async exchangeCode(code: string): Promise<void> {
-    const { tokens } = await this.oauth2Client.getToken(code);
-    await this.connect({
-      access_token: tokens.access_token ?? '',
-      refresh_token: tokens.refresh_token ?? '',
+  async exchangeCode(code: string, options: GmailExchangeCodeOptions = {}): Promise<void> {
+    const { tokens } = await this.oauth2Client.getToken({
+      code,
+      codeVerifier: options.codeVerifier,
+      redirect_uri: options.redirectUri ?? this._config.redirectUri,
     });
+
+    this.oauth2Client.setCredentials(tokens);
+    this.accessToken = tokens.access_token ?? undefined;
+    this.refreshToken = tokens.refresh_token ?? this.refreshToken;
+    this.expiresAt = tokens.expiry_date ?? Date.now() + 3600000;
   }
 
   async refresh(): Promise<void> {
@@ -109,5 +148,33 @@ export class GmailAuthManager implements AuthManager {
 
   getAccessToken(): string | undefined {
     return this.accessToken;
+  }
+
+  getRefreshToken(): string | undefined {
+    return this.refreshToken;
+  }
+
+  async fetchProfile(): Promise<GmailProfile> {
+    let accessToken = this.getAccessToken();
+    if (!accessToken) {
+      await this.refresh();
+      accessToken = this.getAccessToken();
+    }
+
+    if (!accessToken) {
+      throw new Error('No Gmail access token available');
+    }
+
+    const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/profile', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Gmail profile fetch failed (${response.status})`);
+    }
+
+    return await response.json() as GmailProfile;
   }
 }

--- a/packages/provider-gmail/src/config.test.ts
+++ b/packages/provider-gmail/src/config.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  listConfiguredGmailMailboxes,
+  loadGmailMailboxMetadata,
+  saveGmailMailboxMetadata,
+  toFilesystemSafeKey,
+  type GmailMailboxMetadata,
+} from './config.js';
+
+let tempHome: string;
+
+function gmailMailbox(overrides: Partial<GmailMailboxMetadata> = {}): GmailMailboxMetadata {
+  return {
+    provider: 'gmail',
+    mailboxName: 'personal',
+    emailAddress: 'steven.obiajulu@gmail.com',
+    clientId: 'gmail-client',
+    clientSecret: 'gmail-secret',
+    refreshToken: 'gmail-refresh',
+    lastInteractiveAuthAt: '2026-04-08T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  tempHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-gmail-config-'));
+  process.env['EMAIL_AGENT_MCP_HOME'] = tempHome;
+  await mkdir(join(tempHome, 'tokens'), { recursive: true });
+});
+
+afterEach(async () => {
+  delete process.env['EMAIL_AGENT_MCP_HOME'];
+  await rm(tempHome, { recursive: true, force: true });
+});
+
+describe('provider-gmail/Config Discovery', () => {
+  it('Scenario: listConfiguredGmailMailboxes ignores Microsoft token files', async () => {
+    const tokensDir = join(tempHome, 'tokens');
+
+    await writeFile(
+      join(tokensDir, 'steven-obiajulu-at-gmail-com.json'),
+      JSON.stringify(gmailMailbox(), null, 2),
+      'utf-8',
+    );
+    await writeFile(
+      join(tokensDir, 'work.json'),
+      JSON.stringify({
+        provider: 'microsoft',
+        mailboxName: 'work',
+        emailAddress: 'steven@usejunior.com',
+        clientId: 'graph-client',
+        authenticationRecord: { tenantId: 'tenant', clientId: 'graph-client' },
+        lastInteractiveAuthAt: '2026-04-08T10:00:00.000Z',
+      }, null, 2),
+      'utf-8',
+    );
+
+    const results = await listConfiguredGmailMailboxes();
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.provider).toBe('gmail');
+    expect(results[0]!.emailAddress).toBe('steven.obiajulu@gmail.com');
+  });
+
+  it('Scenario: loadGmailMailboxMetadata resolves by alias and email', async () => {
+    await saveGmailMailboxMetadata(gmailMailbox());
+
+    const byAlias = await loadGmailMailboxMetadata('personal');
+    const byEmail = await loadGmailMailboxMetadata('steven.obiajulu@gmail.com');
+
+    expect(byAlias?.emailAddress).toBe('steven.obiajulu@gmail.com');
+    expect(byEmail?.mailboxName).toBe('personal');
+  });
+
+  it('Scenario: saveGmailMailboxMetadata uses the filesystem-safe email key', async () => {
+    const metadata = gmailMailbox({
+      emailAddress: 'Steven.Obiajulu+mail@gmail.com',
+    });
+    await saveGmailMailboxMetadata(metadata);
+
+    const path = join(
+      tempHome,
+      'tokens',
+      `${toFilesystemSafeKey('Steven.Obiajulu+mail@gmail.com')}.json`,
+    );
+    const saved = JSON.parse(await readFile(path, 'utf-8')) as GmailMailboxMetadata;
+
+    expect(saved.provider).toBe('gmail');
+    expect(saved.emailAddress).toBe('Steven.Obiajulu+mail@gmail.com');
+  });
+});

--- a/packages/provider-gmail/src/config.ts
+++ b/packages/provider-gmail/src/config.ts
@@ -1,0 +1,158 @@
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+export interface GmailMailboxMetadata {
+  provider: 'gmail';
+  mailboxName: string;
+  emailAddress: string;
+  clientId: string;
+  clientSecret: string;
+  refreshToken: string;
+  redirectUri?: string;
+  lastInteractiveAuthAt?: string;
+}
+
+export function getConfigDir(): string {
+  const base = process.env['EMAIL_AGENT_MCP_HOME'] ?? join(homedir(), '.email-agent-mcp');
+  return join(base, 'tokens');
+}
+
+export function toFilesystemSafeKey(email: string): string {
+  return email
+    .toLowerCase()
+    .replace(/@/g, '-at-')
+    .replace(/\./g, '-')
+    .replace(/[^a-z0-9-]/g, '');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isGmailMailboxMetadata(value: unknown): value is GmailMailboxMetadata {
+  if (!isRecord(value)) return false;
+
+  const provider = value['provider'];
+  if (provider !== undefined && provider !== 'gmail') return false;
+
+  return (
+    typeof value['mailboxName'] === 'string' &&
+    typeof value['emailAddress'] === 'string' &&
+    typeof value['clientId'] === 'string' &&
+    typeof value['clientSecret'] === 'string' &&
+    typeof value['refreshToken'] === 'string' &&
+    !('authenticationRecord' in value)
+  );
+}
+
+function sortByRecency(
+  a: { metadata: GmailMailboxMetadata },
+  b: { metadata: GmailMailboxMetadata },
+): number {
+  const dateA = new Date(a.metadata.lastInteractiveAuthAt ?? '1970-01-01').getTime();
+  const dateB = new Date(b.metadata.lastInteractiveAuthAt ?? '1970-01-01').getTime();
+  return dateB - dateA;
+}
+
+export async function listConfiguredGmailMailboxes(): Promise<GmailMailboxMetadata[]> {
+  let files: string[];
+  try {
+    files = (await readdir(getConfigDir())).filter(file => file.endsWith('.json'));
+  } catch {
+    return [];
+  }
+
+  const entries: Array<{ filename: string; metadata: GmailMailboxMetadata }> = [];
+  for (const file of files) {
+    try {
+      const raw = await readFile(join(getConfigDir(), file), 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (isGmailMailboxMetadata(parsed)) {
+        entries.push({
+          filename: file,
+          metadata: {
+            ...parsed,
+            provider: 'gmail',
+          },
+        });
+      }
+    } catch {
+      // Skip unreadable or invalid files.
+    }
+  }
+
+  const byEmail = new Map<string, Array<{ filename: string; metadata: GmailMailboxMetadata }>>();
+  for (const entry of entries) {
+    const email = entry.metadata.emailAddress.toLowerCase();
+    const group = byEmail.get(email) ?? [];
+    group.push(entry);
+    byEmail.set(email, group);
+  }
+
+  const results: GmailMailboxMetadata[] = [];
+  for (const [, group] of byEmail) {
+    group.sort(sortByRecency);
+    results.push(group[0]!.metadata);
+  }
+
+  return results;
+}
+
+export async function loadGmailMailboxMetadata(identifier: string): Promise<GmailMailboxMetadata | null> {
+  const candidatePaths = [`${identifier}.json`];
+  if (identifier.includes('@')) {
+    candidatePaths.push(`${toFilesystemSafeKey(identifier)}.json`);
+  }
+
+  for (const candidate of candidatePaths) {
+    try {
+      const raw = await readFile(join(getConfigDir(), candidate), 'utf-8');
+      const parsed = JSON.parse(raw) as unknown;
+      if (isGmailMailboxMetadata(parsed)) {
+        return {
+          ...parsed,
+          provider: 'gmail',
+        };
+      }
+    } catch {
+      // Try the next path.
+    }
+  }
+
+  try {
+    const files = (await readdir(getConfigDir())).filter(file => file.endsWith('.json'));
+    for (const file of files) {
+      try {
+        const raw = await readFile(join(getConfigDir(), file), 'utf-8');
+        const parsed = JSON.parse(raw) as unknown;
+        if (
+          isGmailMailboxMetadata(parsed) &&
+          (parsed.mailboxName === identifier || parsed.emailAddress === identifier)
+        ) {
+          return {
+            ...parsed,
+            provider: 'gmail',
+          };
+        }
+      } catch {
+        // Skip unreadable or invalid files.
+      }
+    }
+  } catch {
+    // Config dir does not exist.
+  }
+
+  return null;
+}
+
+export async function saveGmailMailboxMetadata(metadata: GmailMailboxMetadata): Promise<void> {
+  const filename = `${toFilesystemSafeKey(metadata.emailAddress)}.json`;
+  const path = join(getConfigDir(), filename);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(
+    path,
+    JSON.stringify({ ...metadata, provider: 'gmail' }, null, 2) + '\n',
+    'utf-8',
+  );
+}

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -19,6 +19,10 @@ function createMockGmailClient(overrides: Partial<GmailApiClient> = {}): GmailAp
       },
       internalDate: String(new Date('2024-03-15T10:00:00Z').getTime()),
     }),
+    getAttachment: vi.fn().mockResolvedValue({
+      data: Buffer.from('attachment bytes').toString('base64url'),
+      size: 16,
+    }),
     sendMessage: vi.fn().mockResolvedValue({ id: 'sent-1', threadId: 'thread-1' }),
     modifyMessage: vi.fn().mockResolvedValue(undefined),
     getThread: vi.fn().mockResolvedValue({ id: 'thread-1', messages: [] }),
@@ -43,6 +47,119 @@ describe('provider-gmail/Message Mapping', () => {
     expect(msg.from.name).toBe('Alice');
     expect(msg.labels).toContain('INBOX');
     expect(msg.isRead).toBe(false); // Has UNREAD label
+  });
+
+  it('Scenario: multipart Gmail messages expose attachment metadata and inline content ids', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-attachments',
+        threadId: 'thread-attachments',
+        labelIds: ['INBOX'],
+        payload: {
+          headers: [
+            { name: 'From', value: 'sender@example.com' },
+            { name: 'To', value: 'recipient@example.com' },
+            { name: 'Subject', value: 'Attachments' },
+            { name: 'Date', value: '2026-04-09T12:00:00Z' },
+          ],
+          mimeType: 'multipart/mixed',
+          parts: [
+            {
+              mimeType: 'multipart/alternative',
+              parts: [
+                {
+                  mimeType: 'text/plain',
+                  body: { data: Buffer.from('Plain body').toString('base64url') },
+                },
+                {
+                  mimeType: 'text/html',
+                  body: { data: Buffer.from('<p>HTML body</p>').toString('base64url') },
+                },
+              ],
+            },
+            {
+              mimeType: 'application/pdf',
+              filename: 'contract.pdf',
+              body: { attachmentId: 'att-pdf', size: 245000 },
+              headers: [{ name: 'Content-Disposition', value: 'attachment; filename="contract.pdf"' }],
+            },
+            {
+              mimeType: 'image/png',
+              filename: 'inline.png',
+              body: { attachmentId: 'att-inline', size: 1024 },
+              headers: [
+                { name: 'Content-Disposition', value: 'inline; filename="inline.png"' },
+                { name: 'Content-ID', value: '<image001>' },
+              ],
+            },
+          ],
+        },
+        internalDate: String(new Date('2026-04-09T12:00:00Z').getTime()),
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-attachments');
+
+    expect(msg.body).toBe('Plain body');
+    expect(msg.bodyHtml).toBe('<p>HTML body</p>');
+    expect(msg.hasAttachments).toBe(true);
+    expect(msg.attachments).toEqual([
+      {
+        id: 'att-pdf',
+        filename: 'contract.pdf',
+        mimeType: 'application/pdf',
+        size: 245000,
+        contentId: undefined,
+        isInline: false,
+      },
+      {
+        id: 'att-inline',
+        filename: 'inline.png',
+        mimeType: 'image/png',
+        size: 1024,
+        contentId: 'image001',
+        isInline: true,
+      },
+    ]);
+  });
+
+  it('Scenario: inline body-only attachment parts get synthetic ids for later download', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-inline-body',
+        threadId: 'thread-inline-body',
+        labelIds: ['INBOX'],
+        payload: {
+          headers: [
+            { name: 'From', value: 'sender@example.com' },
+            { name: 'To', value: 'recipient@example.com' },
+            { name: 'Subject', value: 'Inline image' },
+          ],
+          parts: [
+            {
+              mimeType: 'image/png',
+              body: { data: Buffer.from('tiny-image').toString('base64url') },
+              headers: [{ name: 'Content-ID', value: '<image002>' }],
+            },
+          ],
+        },
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-inline-body');
+
+    expect(msg.attachments).toEqual([
+      {
+        id: 'part:0',
+        filename: 'image002',
+        mimeType: 'image/png',
+        size: Buffer.from('tiny-image').byteLength,
+        contentId: 'image002',
+        isInline: true,
+      },
+    ]);
   });
 });
 
@@ -113,6 +230,47 @@ describe('provider-gmail/NemoClaw Compatibility', () => {
     expect(domains).toContain('gmail.googleapis.com');
     expect(domains).toContain('oauth2.googleapis.com');
     expect(domains).toContain('pubsub.googleapis.com');
+  });
+});
+
+describe('provider-gmail/Attachment Retrieval', () => {
+  it('Scenario: downloadAttachment fetches Gmail attachment bytes by attachment id', async () => {
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    const bytes = await provider.downloadAttachment('msg-1', 'att-1');
+
+    expect(client.getAttachment).toHaveBeenCalledWith('msg-1', 'att-1');
+    expect(bytes.toString('utf-8')).toBe('attachment bytes');
+  });
+
+  it('Scenario: downloadAttachment falls back to inline part data for synthetic ids', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-inline-body',
+        threadId: 'thread-inline-body',
+        payload: {
+          headers: [
+            { name: 'From', value: 'sender@example.com' },
+            { name: 'To', value: 'recipient@example.com' },
+            { name: 'Subject', value: 'Inline image' },
+          ],
+          parts: [
+            {
+              mimeType: 'image/png',
+              body: { data: Buffer.from('tiny-image').toString('base64url') },
+              headers: [{ name: 'Content-ID', value: '<image002>' }],
+            },
+          ],
+        },
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const bytes = await provider.downloadAttachment('msg-inline-body', 'part:0');
+
+    expect(client.getAttachment).not.toHaveBeenCalled();
+    expect(bytes.toString('utf-8')).toBe('tiny-image');
   });
 });
 

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -2,6 +2,7 @@
 import { randomBytes } from 'node:crypto';
 import type {
   EmailAddress,
+  EmailAttachment,
   EmailMessage,
   EmailThread,
   ComposeMessage,
@@ -29,6 +30,7 @@ const SUBJECT_MAX_LENGTH = 255;
 export interface GmailApiClient {
   listMessages(opts: { labelIds?: string[]; maxResults?: number; q?: string }): Promise<{ messages?: Array<{ id: string; threadId: string }>; resultSizeEstimate?: number }>;
   getMessage(id: string): Promise<GmailMessage>;
+  getAttachment(messageId: string, attachmentId: string): Promise<{ data?: string; size?: number }>;
   /**
    * Send a raw RFC 2822 message. Optional `threadId` routes the send into
    * an existing thread (used by reply flows). Existing implementations can
@@ -53,6 +55,14 @@ export interface GmailApiClient {
   updateDraft?(draftId: string, raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }>;
 }
 
+interface GmailMessagePart {
+  mimeType?: string;
+  body?: { data?: string; attachmentId?: string; size?: number };
+  filename?: string;
+  headers?: Array<{ name: string; value: string }>;
+  parts?: GmailMessagePart[];
+}
+
 export interface GmailMessage {
   id: string;
   threadId: string;
@@ -61,12 +71,7 @@ export interface GmailMessage {
     headers?: Array<{ name: string; value: string }>;
     body?: { data?: string };
     mimeType?: string;
-    parts?: Array<{
-      mimeType?: string;
-      body?: { data?: string; attachmentId?: string; size?: number };
-      filename?: string;
-      headers?: Array<{ name: string; value: string }>;
-    }>;
+    parts?: GmailMessagePart[];
   };
   internalDate?: string;
 }
@@ -126,6 +131,28 @@ export class GmailEmailProvider {
       messageCount: thread.messages.length,
       isTruncated: thread.messages.length >= 100,
     };
+  }
+
+  async listAttachments(messageId: string): Promise<EmailAttachment[]> {
+    const message = await this.getMessage(messageId);
+    return message.attachments ?? [];
+  }
+
+  async downloadAttachment(messageId: string, attachmentId: string): Promise<Buffer> {
+    if (attachmentId.startsWith('part:')) {
+      const message = await this.client.getMessage(messageId);
+      const part = findPartByPath(message.payload?.parts, attachmentId.slice('part:'.length));
+      if (!part?.body?.data) {
+        throw new Error(`Gmail attachment ${attachmentId} is missing inline body data`);
+      }
+      return Buffer.from(part.body.data, 'base64url');
+    }
+
+    const attachment = await this.client.getAttachment(messageId, attachmentId);
+    if (!attachment.data) {
+      throw new Error(`Gmail attachment ${attachmentId} returned no data`);
+    }
+    return Buffer.from(attachment.data, 'base64url');
   }
 
   async sendMessage(msg: ComposeMessage): Promise<SendResult> {
@@ -266,6 +293,71 @@ function getHeader(msg: GmailMessage, name: string): string | undefined {
   return msg.payload?.headers?.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
 }
 
+function getPartHeader(part: GmailMessagePart, name: string): string | undefined {
+  return part.headers?.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function decodeBase64Url(value: string): string {
+  return Buffer.from(value, 'base64url').toString('utf-8');
+}
+
+function stripAngleBrackets(value: string): string {
+  const match = value.trim().match(/^<(.+)>$/);
+  return match ? match[1]! : value.trim();
+}
+
+function collectPayloadContent(msg: GmailMessage): {
+  body?: string;
+  bodyHtml?: string;
+  attachments: EmailAttachment[];
+} {
+  let body =
+    msg.payload?.body?.data && msg.payload.mimeType !== 'text/html'
+      ? decodeBase64Url(msg.payload.body.data)
+      : undefined;
+  let bodyHtml =
+    msg.payload?.body?.data && msg.payload.mimeType === 'text/html'
+      ? decodeBase64Url(msg.payload.body.data)
+      : undefined;
+  const attachments: EmailAttachment[] = [];
+
+  const visitPart = (part: GmailMessagePart, path: string): void => {
+    const contentId = getPartHeader(part, 'Content-ID');
+    const contentDisposition = getPartHeader(part, 'Content-Disposition')?.toLowerCase();
+    const hasAttachmentIdentity = Boolean(part.filename) || Boolean(part.body?.attachmentId);
+    const isInline = Boolean(contentId) || Boolean(contentDisposition?.includes('inline'));
+
+    if (!hasAttachmentIdentity && !isInline) {
+      if (!body && part.mimeType === 'text/plain' && part.body?.data) {
+        body = decodeBase64Url(part.body.data);
+      } else if (!bodyHtml && part.mimeType === 'text/html' && part.body?.data) {
+        bodyHtml = decodeBase64Url(part.body.data);
+      }
+    } else if (part.body?.attachmentId || part.body?.data) {
+      const attachmentId = part.body?.attachmentId ?? `part:${path}`;
+      const decodedSize = part.body?.data ? Buffer.from(part.body.data, 'base64url').byteLength : 0;
+      attachments.push({
+        id: attachmentId,
+        filename: part.filename || stripAngleBrackets(contentId ?? '') || `attachment-${path.replace(/\./g, '-')}`,
+        mimeType: part.mimeType ?? 'application/octet-stream',
+        size: part.body?.size ?? decodedSize,
+        contentId: contentId ? stripAngleBrackets(contentId) : undefined,
+        isInline,
+      });
+    }
+
+    for (const [index, child] of (part.parts ?? []).entries()) {
+      visitPart(child, `${path}.${index}`);
+    }
+  };
+
+  for (const [index, part] of (msg.payload?.parts ?? []).entries()) {
+    visitPart(part, String(index));
+  }
+
+  return { body, bodyHtml, attachments };
+}
+
 function mapGmailMessage(msg: GmailMessage): EmailMessage {
   const from = parseEmailAddress(getHeader(msg, 'From') ?? '');
   const to = (getHeader(msg, 'To') ?? '').split(',').map(a => parseEmailAddress(a.trim())).filter(a => a.email);
@@ -284,21 +376,7 @@ function mapGmailMessage(msg: GmailMessage): EmailMessage {
     ? referencesRaw.split(/\s+/).filter(r => r.length > 0)
     : undefined;
 
-  // Get body content
-  let body: string | undefined;
-  let bodyHtml: string | undefined;
-  if (msg.payload?.body?.data) {
-    body = Buffer.from(msg.payload.body.data, 'base64url').toString('utf-8');
-  }
-  if (msg.payload?.parts) {
-    for (const part of msg.payload.parts) {
-      if (part.mimeType === 'text/plain' && part.body?.data) {
-        body = Buffer.from(part.body.data, 'base64url').toString('utf-8');
-      } else if (part.mimeType === 'text/html' && part.body?.data) {
-        bodyHtml = Buffer.from(part.body.data, 'base64url').toString('utf-8');
-      }
-    }
-  }
+  const { body, bodyHtml, attachments } = collectPayloadContent(msg);
 
   const labels = msg.labelIds ?? [];
 
@@ -310,7 +388,7 @@ function mapGmailMessage(msg: GmailMessage): EmailMessage {
     cc,
     receivedAt: date,
     isRead: !labels.includes('UNREAD'),
-    hasAttachments: msg.payload?.parts?.some(p => !!p.filename) ?? false,
+    hasAttachments: attachments.length > 0,
     body,
     bodyHtml,
     threadId: msg.threadId,
@@ -319,7 +397,21 @@ function mapGmailMessage(msg: GmailMessage): EmailMessage {
     references,
     labels,
     folder: labels.includes('INBOX') ? 'inbox' : labels.includes('SENT') ? 'sent' : undefined,
+    attachments: attachments.length > 0 ? attachments : undefined,
   };
+}
+
+function findPartByPath(parts: GmailMessagePart[] | undefined, path: string): GmailMessagePart | null {
+  if (!parts) return null;
+  const indices = path.split('.').map(segment => Number.parseInt(segment, 10));
+  let current: GmailMessagePart | undefined;
+  let currentParts = parts;
+  for (const index of indices) {
+    current = currentParts[index];
+    if (!current) return null;
+    currentParts = current.parts ?? [];
+  }
+  return current ?? null;
 }
 
 function parseEmailAddress(raw: string): { email: string; name?: string } {

--- a/packages/provider-gmail/src/googleapis-client.test.ts
+++ b/packages/provider-gmail/src/googleapis-client.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GmailMessage } from './email-gmail-provider.js';
+import { GoogleapisGmailClient } from './googleapis-client.js';
+
+function message(id: string, threadId: string): GmailMessage {
+  return {
+    id,
+    threadId,
+    payload: {
+      headers: [
+        { name: 'From', value: 'Sender <sender@example.com>' },
+        { name: 'To', value: 'recipient@example.com' },
+        { name: 'Subject', value: 'Hello' },
+      ],
+    },
+  };
+}
+
+function createMockApi() {
+  return {
+    users: {
+      messages: {
+        list: vi.fn().mockResolvedValue({ data: { messages: [{ id: 'm-1', threadId: 't-1' }], resultSizeEstimate: 1 } }),
+        get: vi.fn().mockResolvedValue({ data: message('m-1', 't-1') }),
+        attachments: {
+          get: vi.fn().mockResolvedValue({ data: { data: Buffer.from('attachment-bytes').toString('base64url'), size: 16 } }),
+        },
+        send: vi.fn().mockResolvedValue({ data: { id: 'm-sent', threadId: 't-sent' } }),
+        modify: vi.fn().mockResolvedValue({}),
+      },
+      drafts: {
+        create: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: { id: 'm-draft', threadId: 't-draft' } } }),
+        get: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: message('m-draft', 't-draft') } }),
+        send: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: { id: 'm-sent-draft', threadId: 't-draft' } } }),
+        update: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: { id: 'm-updated-draft', threadId: 't-draft' } } }),
+      },
+      threads: {
+        get: vi.fn().mockResolvedValue({ data: { id: 't-1', messages: [message('m-1', 't-1')] } }),
+      },
+    },
+  };
+}
+
+function createClient(api = createMockApi()): GoogleapisGmailClient {
+  return new GoogleapisGmailClient(
+    { getOAuth2Client: () => ({}) } as never,
+    api as never,
+  );
+}
+
+describe('provider-gmail/GoogleapisGmailClient', () => {
+  it('Scenario: listMessages forwards Gmail list request shape', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.listMessages({
+      labelIds: ['INBOX'],
+      maxResults: 10,
+      q: 'driver license',
+    });
+
+    expect(api.users.messages.list).toHaveBeenCalledWith({
+      userId: 'me',
+      labelIds: ['INBOX'],
+      maxResults: 10,
+      q: 'driver license',
+    });
+    expect(result).toEqual({
+      messages: [{ id: 'm-1', threadId: 't-1' }],
+      resultSizeEstimate: 1,
+    });
+  });
+
+  it('Scenario: getMessage requests full Gmail payload', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.getMessage('m-1');
+
+    expect(api.users.messages.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'm-1',
+      format: 'full',
+    });
+    expect(result.id).toBe('m-1');
+    expect(result.threadId).toBe('t-1');
+  });
+
+  it('Scenario: getMessage falls back to drafts.get for draft ids', async () => {
+    const api = createMockApi();
+    api.users.messages.get.mockRejectedValueOnce({ code: 404 });
+    const client = createClient(api);
+
+    const result = await client.getMessage('d-1');
+
+    expect(api.users.messages.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'd-1',
+      format: 'full',
+    });
+    expect(api.users.drafts.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'd-1',
+      format: 'full',
+    });
+    expect(result.id).toBe('m-draft');
+    expect(result.threadId).toBe('t-draft');
+  });
+
+  it('Scenario: getMessage also falls back to drafts.get for response-status 404 errors', async () => {
+    const api = createMockApi();
+    api.users.messages.get.mockRejectedValueOnce({ response: { status: 404 } });
+    const client = createClient(api);
+
+    const result = await client.getMessage('d-1');
+
+    expect(api.users.drafts.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'd-1',
+      format: 'full',
+    });
+    expect(result.id).toBe('m-draft');
+  });
+
+  it('Scenario: getMessage rethrows non-404 Gmail API errors', async () => {
+    const api = createMockApi();
+    api.users.messages.get.mockRejectedValueOnce(new Error('boom'));
+    const client = createClient(api);
+
+    await expect(client.getMessage('m-1')).rejects.toThrow('boom');
+    expect(api.users.drafts.get).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: getMessage rejects incomplete Gmail API payloads', async () => {
+    const api = createMockApi();
+    api.users.messages.get.mockResolvedValueOnce({ data: { id: 'm-1' } });
+    const client = createClient(api);
+
+    await expect(client.getMessage('m-1')).rejects.toThrow('incomplete message payload');
+  });
+
+  it('Scenario: getAttachment requests Gmail attachment bytes', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.getAttachment('m-1', 'att-1');
+
+    expect(api.users.messages.attachments.get).toHaveBeenCalledWith({
+      userId: 'me',
+      messageId: 'm-1',
+      id: 'att-1',
+    });
+    expect(result).toEqual({
+      data: Buffer.from('attachment-bytes').toString('base64url'),
+      size: 16,
+    });
+  });
+
+  it('Scenario: sendMessage routes optional thread ids', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.sendMessage('raw-rfc822', 't-reply');
+
+    expect(api.users.messages.send).toHaveBeenCalledWith({
+      userId: 'me',
+      requestBody: { raw: 'raw-rfc822', threadId: 't-reply' },
+    });
+    expect(result).toEqual({ id: 'm-sent', threadId: 't-sent' });
+  });
+
+  it('Scenario: sendMessage rejects incomplete Gmail send responses', async () => {
+    const api = createMockApi();
+    api.users.messages.send.mockResolvedValueOnce({ data: { id: 'm-sent' } });
+    const client = createClient(api);
+
+    await expect(client.sendMessage('raw-rfc822')).rejects.toThrow('incomplete message summary');
+  });
+
+  it('Scenario: createDraft preserves thread association', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.createDraft('raw-rfc822', 't-draft');
+
+    expect(api.users.drafts.create).toHaveBeenCalledWith({
+      userId: 'me',
+      requestBody: { message: { raw: 'raw-rfc822', threadId: 't-draft' } },
+    });
+    expect(result).toEqual({
+      id: 'd-1',
+      message: { id: 'm-draft', threadId: 't-draft' },
+    });
+  });
+
+  it('Scenario: createDraft rejects incomplete draft payloads', async () => {
+    const api = createMockApi();
+    api.users.drafts.create.mockResolvedValueOnce({ data: { id: 'd-1' } });
+    const client = createClient(api);
+
+    await expect(client.createDraft('raw-rfc822')).rejects.toThrow('incomplete draft payload');
+  });
+
+  it('Scenario: sendDraft uses Gmail drafts.send', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.sendDraft('d-1');
+
+    expect(api.users.drafts.send).toHaveBeenCalledWith({
+      userId: 'me',
+      requestBody: { id: 'd-1' },
+    });
+    expect(result).toEqual({
+      id: 'd-1',
+      message: { id: 'm-sent-draft', threadId: 't-draft' },
+    });
+  });
+
+  it('Scenario: updateDraft replaces the draft body with thread context intact', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.updateDraft('d-1', 'updated-rfc822', 't-draft');
+
+    expect(api.users.drafts.update).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'd-1',
+      requestBody: { message: { raw: 'updated-rfc822', threadId: 't-draft' } },
+    });
+    expect(result).toEqual({
+      id: 'd-1',
+      message: { id: 'm-updated-draft', threadId: 't-draft' },
+    });
+  });
+
+  it('Scenario: modifyMessage forwards label mutations', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    await client.modifyMessage('m-1', {
+      addLabelIds: ['STARRED'],
+      removeLabelIds: ['UNREAD'],
+    });
+
+    expect(api.users.messages.modify).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'm-1',
+      requestBody: {
+        addLabelIds: ['STARRED'],
+        removeLabelIds: ['UNREAD'],
+      },
+    });
+  });
+
+  it('Scenario: getThread requests full thread payload', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.getThread('t-1');
+
+    expect(api.users.threads.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 't-1',
+      format: 'full',
+    });
+    expect(result).toEqual({
+      id: 't-1',
+      messages: [message('m-1', 't-1')],
+    });
+  });
+
+  it('Scenario: getThread rejects incomplete thread payloads', async () => {
+    const api = createMockApi();
+    api.users.threads.get.mockResolvedValueOnce({ data: { id: 't-1' } });
+    const client = createClient(api);
+
+    await expect(client.getThread('t-1')).rejects.toThrow('incomplete thread payload');
+  });
+});

--- a/packages/provider-gmail/src/googleapis-client.ts
+++ b/packages/provider-gmail/src/googleapis-client.ts
@@ -1,0 +1,257 @@
+import { gmail } from '@googleapis/gmail';
+import type { GmailAuthManager } from './auth.js';
+import type { GmailApiClient, GmailMessage } from './email-gmail-provider.js';
+
+interface MessageSummary {
+  id?: string | null;
+  threadId?: string | null;
+}
+
+interface GmailMessagesApi {
+  list(args: {
+    userId: string;
+    labelIds?: string[];
+    maxResults?: number;
+    q?: string;
+  }): Promise<{ data?: { messages?: MessageSummary[]; resultSizeEstimate?: number | null } }>;
+  get(args: {
+    userId: string;
+    id: string;
+    format: 'full';
+  }): Promise<{ data?: GmailMessage }>;
+  attachments: {
+    get(args: {
+      userId: string;
+      messageId: string;
+      id: string;
+    }): Promise<{ data?: { data?: string | null; size?: number | null } }>;
+  };
+  send(args: {
+    userId: string;
+    requestBody: { raw: string; threadId?: string };
+  }): Promise<{ data?: MessageSummary }>;
+  modify(args: {
+    userId: string;
+    id: string;
+    requestBody: { addLabelIds?: string[]; removeLabelIds?: string[] };
+  }): Promise<unknown>;
+}
+
+interface GmailDraft {
+  id?: string | null;
+  message?: GmailMessage;
+}
+
+interface GmailDraftsApi {
+  create(args: {
+    userId: string;
+    requestBody: { message: { raw: string; threadId?: string } };
+  }): Promise<{ data?: GmailDraft }>;
+  get(args: {
+    userId: string;
+    id: string;
+    format: 'full';
+  }): Promise<{ data?: GmailDraft }>;
+  send(args: {
+    userId: string;
+    requestBody: { id: string };
+  }): Promise<{ data?: GmailDraft }>;
+  update(args: {
+    userId: string;
+    id: string;
+    requestBody: { message: { raw: string; threadId?: string } };
+  }): Promise<{ data?: GmailDraft }>;
+}
+
+interface GmailThreadsApi {
+  get(args: {
+    userId: string;
+    id: string;
+    format: 'full';
+  }): Promise<{ data?: { id?: string | null; messages?: GmailMessage[] } }>;
+}
+
+interface GmailApiInstance {
+  users: {
+    messages: GmailMessagesApi;
+    drafts: GmailDraftsApi;
+    threads: GmailThreadsApi;
+  };
+}
+
+function buildRawRequest(raw: string, threadId?: string): { raw: string; threadId?: string } {
+  return threadId ? { raw, threadId } : { raw };
+}
+
+function requireMessageSummary(summary: MessageSummary | undefined, op: string): { id: string; threadId: string } {
+  if (!summary?.id || !summary.threadId) {
+    throw new Error(`Gmail API ${op} returned an incomplete message summary`);
+  }
+  return { id: summary.id, threadId: summary.threadId };
+}
+
+function requireDraft(draft: GmailDraft | undefined, op: string): { id: string; message: { id: string; threadId: string } } {
+  if (!draft?.id || !draft.message?.id || !draft.message.threadId) {
+    throw new Error(`Gmail API ${op} returned an incomplete draft payload`);
+  }
+
+  return {
+    id: draft.id,
+    message: {
+      id: draft.message.id,
+      threadId: draft.message.threadId,
+    },
+  };
+}
+
+function getErrorStatus(err: unknown): number | undefined {
+  const record = err as { code?: unknown; response?: { status?: unknown } } | null;
+  if (!record || typeof record !== 'object') return undefined;
+  if (typeof record.code === 'number') return record.code;
+  if (typeof record.response?.status === 'number') return record.response.status;
+  return undefined;
+}
+
+export class GoogleapisGmailClient implements GmailApiClient {
+  private readonly api: GmailApiInstance;
+
+  constructor(
+    auth: GmailAuthManager,
+    api: GmailApiInstance = gmail({
+      version: 'v1',
+      auth: auth.getOAuth2Client(),
+    }) as unknown as GmailApiInstance,
+  ) {
+    this.api = api;
+  }
+
+  async listMessages(opts: {
+    labelIds?: string[];
+    maxResults?: number;
+    q?: string;
+  }): Promise<{ messages?: Array<{ id: string; threadId: string }>; resultSizeEstimate?: number }> {
+    const response = await this.api.users.messages.list({
+      userId: 'me',
+      labelIds: opts.labelIds,
+      maxResults: opts.maxResults,
+      q: opts.q,
+    });
+
+    return {
+      messages: response.data?.messages
+        ?.filter((message): message is { id: string; threadId: string } => !!message.id && !!message.threadId)
+        .map(message => ({ id: message.id, threadId: message.threadId })),
+      resultSizeEstimate: response.data?.resultSizeEstimate ?? undefined,
+    };
+  }
+
+  async getMessage(id: string): Promise<GmailMessage> {
+    try {
+      const response = await this.api.users.messages.get({
+        userId: 'me',
+        id,
+        format: 'full',
+      });
+
+      if (!response.data?.id || !response.data.threadId) {
+        throw new Error('Gmail API messages.get returned an incomplete message payload');
+      }
+
+      return response.data;
+    } catch (err) {
+      if (getErrorStatus(err) !== 404) throw err;
+
+      const draft = await this.api.users.drafts.get({
+        userId: 'me',
+        id,
+        format: 'full',
+      });
+      if (!draft.data?.message?.id || !draft.data.message.threadId) {
+        throw new Error('Gmail API drafts.get returned an incomplete message payload');
+      }
+      return draft.data.message;
+    }
+  }
+
+  async getAttachment(messageId: string, attachmentId: string): Promise<{ data?: string; size?: number }> {
+    const response = await this.api.users.messages.attachments.get({
+      userId: 'me',
+      messageId,
+      id: attachmentId,
+    });
+
+    return {
+      data: response.data?.data ?? undefined,
+      size: response.data?.size ?? undefined,
+    };
+  }
+
+  async sendMessage(raw: string, threadId?: string): Promise<{ id: string; threadId: string }> {
+    const response = await this.api.users.messages.send({
+      userId: 'me',
+      requestBody: buildRawRequest(raw, threadId),
+    });
+
+    return requireMessageSummary(response.data, 'messages.send');
+  }
+
+  async modifyMessage(id: string, opts: { addLabelIds?: string[]; removeLabelIds?: string[] }): Promise<void> {
+    await this.api.users.messages.modify({
+      userId: 'me',
+      id,
+      requestBody: {
+        addLabelIds: opts.addLabelIds,
+        removeLabelIds: opts.removeLabelIds,
+      },
+    });
+  }
+
+  async getThread(threadId: string): Promise<{ id: string; messages: GmailMessage[] }> {
+    const response = await this.api.users.threads.get({
+      userId: 'me',
+      id: threadId,
+      format: 'full',
+    });
+
+    if (!response.data?.id || !response.data.messages) {
+      throw new Error('Gmail API threads.get returned an incomplete thread payload');
+    }
+
+    return {
+      id: response.data.id,
+      messages: response.data.messages,
+    };
+  }
+
+  async createDraft(raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }> {
+    const response = await this.api.users.drafts.create({
+      userId: 'me',
+      requestBody: {
+        message: buildRawRequest(raw, threadId),
+      },
+    });
+
+    return requireDraft(response.data, 'drafts.create');
+  }
+
+  async sendDraft(draftId: string): Promise<{ id: string; message: { id: string; threadId: string } }> {
+    const response = await this.api.users.drafts.send({
+      userId: 'me',
+      requestBody: { id: draftId },
+    });
+
+    return requireDraft(response.data, 'drafts.send');
+  }
+
+  async updateDraft(draftId: string, raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }> {
+    const response = await this.api.users.drafts.update({
+      userId: 'me',
+      id: draftId,
+      requestBody: {
+        message: buildRawRequest(raw, threadId),
+      },
+    });
+
+    return requireDraft(response.data, 'drafts.update');
+  }
+}

--- a/packages/provider-gmail/src/index.ts
+++ b/packages/provider-gmail/src/index.ts
@@ -1,4 +1,13 @@
 // @usejunior/provider-gmail — Gmail API email provider
 export { GmailEmailProvider } from './email-gmail-provider.js';
-export { GmailAuthManager } from './auth.js';
+export { GMAIL_OAUTH_SCOPES, GmailAuthManager } from './auth.js';
+export {
+  listConfiguredGmailMailboxes,
+  loadGmailMailboxMetadata,
+  saveGmailMailboxMetadata,
+  toFilesystemSafeKey,
+  getConfigDir,
+} from './config.js';
+export type { GmailMailboxMetadata } from './config.js';
+export { GoogleapisGmailClient } from './googleapis-client.js';
 export { registerWatch, needsRenewal, pollHistory } from './push.js';

--- a/packages/provider-microsoft/src/auth-dedup.test.ts
+++ b/packages/provider-microsoft/src/auth-dedup.test.ts
@@ -193,6 +193,23 @@ describe('provider-microsoft/Mailbox Deduplication', () => {
     expect(remainingFiles[0]).toBe('test-user-at-example-com.json');
   });
 
+  it('Scenario: Gmail metadata files are ignored by Microsoft mailbox discovery', async () => {
+    await writeFile(
+      join(tokensDir, 'steven-obiajulu-at-gmail-com.json'),
+      JSON.stringify({
+        provider: 'gmail',
+        mailboxName: 'personal',
+        emailAddress: 'steven.obiajulu@gmail.com',
+        clientId: 'gmail-client',
+        clientSecret: 'gmail-secret',
+        refreshToken: 'gmail-refresh',
+      }),
+    );
+
+    const results = await listConfiguredMailboxesWithMetadata();
+    expect(results).toEqual([]);
+  });
+
   it('Scenario: Empty tokens directory returns empty array', async () => {
     const results = await listConfiguredMailboxesWithMetadata();
     expect(results).toEqual([]);

--- a/packages/provider-microsoft/src/auth.ts
+++ b/packages/provider-microsoft/src/auth.ts
@@ -39,6 +39,7 @@ export interface MicrosoftAuthConfig {
 }
 
 export interface MailboxMetadata {
+  provider?: string;
   authenticationRecord: AuthenticationRecord;
   cacheName?: string;
   lastInteractiveAuthAt: string;
@@ -290,6 +291,7 @@ export class DelegatedAuthManager implements AuthManager {
     const path = this.getMetadataPath();
     await mkdir(dirname(path), { recursive: true });
     const metadata: MailboxMetadata = {
+      provider: 'microsoft',
       authenticationRecord: this.authRecord!,
       cacheName: this.cacheName ?? undefined,
       lastInteractiveAuthAt: this._lastInteractiveAuthAt!,
@@ -437,7 +439,10 @@ export async function listConfiguredMailboxesWithMetadata(): Promise<MailboxMeta
   for (const file of files) {
     try {
       const content = await readFile(join(getConfigDir(), file), 'utf-8');
-      const metadata = JSON.parse(content) as MailboxMetadata;
+      const metadata = JSON.parse(content) as MailboxMetadata & { provider?: string };
+      if (metadata.provider === 'gmail') {
+        continue;
+      }
       entries.push({ filename: file, metadata });
     } catch {
       // Skip unreadable files
@@ -515,7 +520,10 @@ export async function loadMailboxMetadata(identifier: string): Promise<MailboxMe
   // Try direct filename match first (e.g., "work" → "work.json", or safe key → safe key.json)
   try {
     const content = await readFile(join(getConfigDir(), `${identifier}.json`), 'utf-8');
-    return JSON.parse(content) as MailboxMetadata;
+    const metadata = JSON.parse(content) as MailboxMetadata & { provider?: string };
+    if (metadata.provider !== 'gmail') {
+      return metadata;
+    }
   } catch {
     // Not found by direct name
   }
@@ -525,7 +533,10 @@ export async function loadMailboxMetadata(identifier: string): Promise<MailboxMe
     try {
       const safeKey = toFilesystemSafeKey(identifier);
       const content = await readFile(join(getConfigDir(), `${safeKey}.json`), 'utf-8');
-      return JSON.parse(content) as MailboxMetadata;
+      const metadata = JSON.parse(content) as MailboxMetadata & { provider?: string };
+      if (metadata.provider !== 'gmail') {
+        return metadata;
+      }
     } catch {
       // Not found
     }
@@ -538,8 +549,11 @@ export async function loadMailboxMetadata(identifier: string): Promise<MailboxMe
     for (const file of files.filter(f => f.endsWith('.json'))) {
       try {
         const content = await readFile(join(getConfigDir(), file), 'utf-8');
-        const metadata = JSON.parse(content) as MailboxMetadata;
-        if (metadata.mailboxName === identifier || metadata.emailAddress === identifier) {
+        const metadata = JSON.parse(content) as MailboxMetadata & { provider?: string };
+        if (
+          metadata.provider !== 'gmail' &&
+          (metadata.mailboxName === identifier || metadata.emailAddress === identifier)
+        ) {
           return metadata;
         }
       } catch {


### PR DESCRIPTION
## Summary
This PR completes the Gmail configure flow and fixes the mailbox-selection and attachment gaps found during live validation.

It includes:
- Gmail OAuth configure support in the CLI and wizard
- mailbox-aware MCP routing instead of binding the transport to the first connected mailbox
- Gmail attachment metadata surfacing in `read_email` and `list_attachments`
- shared send-allowlist path resolution between CLI and runtime
- fail-closed Gmail account-intent checks during configure
- graceful degradation when allowlist watch acquisition or runtime watch events fail

## Root Cause
The MCP server kept a single live provider in process state and reused it for all tool calls, even when multiple mailboxes were configured. At the same time, Gmail message mapping did not populate attachment metadata, the CLI and runtime could write/read different allowlist files, and the Gmail configure flow trusted whichever Google account completed OAuth without checking operator intent.

## Impact
- Explicit `mailbox` selection now reaches the requested provider for both custom MCP tools and wrapped email-core actions.
- Gmail reads now surface attachment metadata through normal MCP paths.
- Configure-time send allowlist edits now land in the same file the runtime watches.
- Gmail configure is safer in multi-account browser sessions.
- Allowlist watch failures now degrade to static config instead of noisy repeated failures.

Closes #26
Closes #27
Closes #28
Closes #29
Closes #30

## Validation
- `npm run test:run -w @usejunior/email-core`
- `npm run test:run -w @usejunior/provider-gmail`
- `npm run test:run -w @usejunior/email-mcp`
- `npm run build`

## Manual Testing
Ran a live end-to-end Gmail smoke test against a real configured Gmail token in a multi-mailbox setup:
- authenticated both configured Gmail mailboxes during lazy init
- `search_emails` with an explicit mailbox returned the expected target message from the intended mailbox
- `get_mailbox_status` reported the requested non-default Gmail mailbox as connected
- `read_email` surfaced Gmail attachment metadata in the normal MCP response
- `list_attachments` returned the attachment summary for that same message
- `create_draft` with an explicit mailbox succeeded, confirming wrapped-action routing on the real mailbox path
