### PR TITLE
fix(provider-gmail): handle Gmail draft ids in getMessage

### DIFF
--- a/packages/provider-gmail/src/googleapis-client.test.ts
+++ b/packages/provider-gmail/src/googleapis-client.test.ts
@@ -122,12 +122,64 @@ describe('provider-gmail/GoogleapisGmailClient', () => {
     expect(result.id).toBe('m-draft');
   });
 
+  it('Scenario: getMessage falls back to drafts.get for Gmail draft ids rejected as invalid message ids', async () => {
+    const api = createMockApi();
+    api.users.messages.get.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: {
+          error: {
+            message: 'Invalid id value',
+          },
+        },
+      },
+    });
+    const client = createClient(api);
+
+    const result = await client.getMessage('r1234567890');
+
+    expect(api.users.messages.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'r1234567890',
+      format: 'full',
+    });
+    expect(api.users.drafts.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'r1234567890',
+      format: 'full',
+    });
+    expect(result.id).toBe('m-draft');
+    expect(result.threadId).toBe('t-draft');
+  });
+
   it('Scenario: getMessage rethrows non-404 Gmail API errors', async () => {
     const api = createMockApi();
     api.users.messages.get.mockRejectedValueOnce(new Error('boom'));
     const client = createClient(api);
 
     await expect(client.getMessage('m-1')).rejects.toThrow('boom');
+    expect(api.users.drafts.get).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: getMessage rethrows unrelated 400 errors instead of treating them as drafts', async () => {
+    const api = createMockApi();
+    api.users.messages.get.mockRejectedValueOnce({
+      response: {
+        status: 400,
+        data: {
+          error: {
+            message: 'Bad Request',
+          },
+        },
+      },
+    });
+    const client = createClient(api);
+
+    await expect(client.getMessage('m-1')).rejects.toMatchObject({
+      response: {
+        status: 400,
+      },
+    });
     expect(api.users.drafts.get).not.toHaveBeenCalled();
   });
 

--- a/packages/provider-gmail/src/googleapis-client.ts
+++ b/packages/provider-gmail/src/googleapis-client.ts
@@ -112,6 +112,26 @@ function getErrorStatus(err: unknown): number | undefined {
   return undefined;
 }
 
+function getErrorMessage(err: unknown): string | undefined {
+  const record = err as {
+    message?: unknown;
+    response?: { data?: { error?: { message?: unknown } } };
+  } | null;
+  if (!record || typeof record !== 'object') return undefined;
+  if (typeof record.response?.data?.error?.message === 'string') return record.response.data.error.message;
+  if (typeof record.message === 'string') return record.message;
+  return undefined;
+}
+
+function shouldFallbackToDraftLookup(err: unknown): boolean {
+  const status = getErrorStatus(err);
+  if (status === 404) return true;
+  if (status !== 400) return false;
+
+  const message = getErrorMessage(err);
+  return typeof message === 'string' && /invalid id value/i.test(message);
+}
+
 export class GoogleapisGmailClient implements GmailApiClient {
   private readonly api: GmailApiInstance;
 
@@ -159,7 +179,7 @@ export class GoogleapisGmailClient implements GmailApiClient {
 
       return response.data;
     } catch (err) {
-      if (getErrorStatus(err) !== 404) throw err;
+      if (!shouldFallbackToDraftLookup(err)) throw err;
 
       const draft = await this.api.users.drafts.get({
         userId: 'me',


### PR DESCRIPTION
## Summary
- fall back to `drafts.get` when Gmail rejects a draft id with `400 Invalid id value`
- keep the existing behavior for true message ids and unrelated 400s
- add focused regression tests for the draft-id fallback path

## Why
Gmail draft ids like `r...` are not valid `messages.get` ids. In practice Gmail can reject them with `400 Invalid id value`, not just `404`, which broke draft readback and `updateDraft(...)` flows after a draft was created.

## Validation
- `npm run build -w @usejunior/provider-gmail`
- `npm run test:run -w @usejunior/provider-gmail`
- installed-package smoke test against a real Gmail mailbox using the configured token:
  - created a new draft, then verified `getMessage(draftId)` and `updateDraft(draftId, ...)`
  - created a reply draft, then verified `getMessage(draftId)` and `updateDraft(draftId, ...)`
  - confirmed the reply draft stayed on the original Gmail thread before and after the update

## Manual test notes
- new draft smoke test returned a Gmail draft id in the `r...` format and read/update succeeded
- reply draft smoke test returned a Gmail draft id in the `r...` format and read/update succeeded while preserving thread association