### PR TITLE
fix(email-mcp): surface Gmail reauth-required state

### DIFF
--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -48,11 +48,14 @@ const watcherMockState = vi.hoisted(() => ({
 
 const gmailMockState = vi.hoisted(() => ({
   enableConfigureMock: false,
+  enableAuthMock: false,
   authUrlOptions: null as null | Record<string, unknown>,
   exchangeCodeArgs: null as null | Record<string, unknown>,
   savedMetadata: null as null | Record<string, unknown>,
   profileEmail: 'steven.obiajulu@gmail.com',
   refreshToken: 'mock-refresh-token' as string | undefined,
+  refreshError: null as Error | Record<string, unknown> | null,
+  tokenHealthWarning: undefined as string | undefined,
 }));
 
 const promptMockState = vi.hoisted(() => ({
@@ -217,6 +220,7 @@ vi.mock('@usejunior/provider-gmail', async (importOriginal) => {
 
   class MockGmailAuthManager {
     constructor(_config: Record<string, unknown>) {}
+    async connect() {}
     async generateCodeVerifierAsync() {
       return { codeVerifier: 'mock-code-verifier', codeChallenge: 'mock-code-challenge' };
     }
@@ -230,6 +234,17 @@ vi.mock('@usejunior/provider-gmail', async (importOriginal) => {
     getRefreshToken() {
       return gmailMockState.refreshToken;
     }
+    async refresh() {
+      if (gmailMockState.refreshError) {
+        throw gmailMockState.refreshError;
+      }
+    }
+    getTokenHealthWarning() {
+      return gmailMockState.tokenHealthWarning;
+    }
+    async tryReconnect() {
+      return !gmailMockState.refreshError;
+    }
     async fetchProfile() {
       return { emailAddress: gmailMockState.profileEmail };
     }
@@ -237,12 +252,18 @@ vi.mock('@usejunior/provider-gmail', async (importOriginal) => {
 
   const actualSave = actual.saveGmailMailboxMetadata as (metadata: Record<string, unknown>) => Promise<void>;
   const actualToSafeKey = actual.toFilesystemSafeKey as (email: string) => string;
+  const mockIsGmailReauthError = (err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    return message.toLowerCase().includes('invalid_grant');
+  };
+  const mockFormatGmailAuthError = (_err: unknown, mailboxName: string) =>
+    `Authentication expired for Gmail mailbox "${mailboxName}". Run: email-agent-mcp configure --provider gmail --mailbox ${mailboxName}`;
 
   return {
     ...actual,
     GmailAuthManager: new Proxy(MockGmailAuthManager, {
       construct(target, args) {
-        if (gmailMockState.enableConfigureMock) return new target(...args);
+        if (gmailMockState.enableConfigureMock || gmailMockState.enableAuthMock) return new target(...args);
         const RealAuth = actual.GmailAuthManager as new (...realArgs: unknown[]) => unknown;
         return new RealAuth(...args);
       },
@@ -255,17 +276,22 @@ vi.mock('@usejunior/provider-gmail', async (importOriginal) => {
       await actualSave(metadata);
     }),
     toFilesystemSafeKey: vi.fn((email: string) => actualToSafeKey(email)),
+    isGmailReauthError: vi.fn((err: unknown) => mockIsGmailReauthError(err)),
+    formatGmailAuthError: vi.fn((err: unknown, mailboxName: string) => mockFormatGmailAuthError(err, mailboxName)),
   };
 });
 
 beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
   gmailMockState.enableConfigureMock = false;
+  gmailMockState.enableAuthMock = false;
   gmailMockState.authUrlOptions = null;
   gmailMockState.exchangeCodeArgs = null;
   gmailMockState.savedMetadata = null;
   gmailMockState.profileEmail = 'steven.obiajulu@gmail.com';
   gmailMockState.refreshToken = 'mock-refresh-token';
+  gmailMockState.refreshError = null;
+  gmailMockState.tokenHealthWarning = undefined;
   promptMockState.confirmResult = true;
   promptMockState.textResult = '';
   promptMockState.passwordResult = '';
@@ -731,19 +757,31 @@ describe('cli/Interactive Wizard', () => {
 
 describe('cli/Status Subcommand', () => {
   it('Scenario: Status output', async () => {
-    // WHEN email-agent-mcp status is run
-    // THEN the system displays account info, token age, and allowlist summary
-    const exitCode = await runCli(['status']);
-    expect(exitCode).toBe(0);
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining('status'),
-    );
+    const tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-status-header-'));
+    const savedHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+
+    try {
+      const exitCode = await runCli(['status']);
+      expect(exitCode).toBe(0);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('status'),
+      );
+    } finally {
+      if (savedHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = savedHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
   });
 
   it('Status includes Gmail-only mailboxes', async () => {
     const tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-gmail-status-test-'));
     const savedHome = process.env['EMAIL_AGENT_MCP_HOME'];
     process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+    gmailMockState.enableAuthMock = true;
 
     try {
       const { mkdir, writeFile } = await import('node:fs/promises');
@@ -763,6 +801,42 @@ describe('cli/Status Subcommand', () => {
       expect(exitCode).toBe(0);
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('Provider: gmail'),
+      );
+    } finally {
+      if (savedHome === undefined) {
+        delete process.env['EMAIL_AGENT_MCP_HOME'];
+      } else {
+        process.env['EMAIL_AGENT_MCP_HOME'] = savedHome;
+      }
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('Status surfaces Gmail reauth-required warnings', async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-gmail-reauth-status-'));
+    const savedHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+    gmailMockState.enableAuthMock = true;
+    gmailMockState.refreshError = new Error('invalid_grant');
+
+    try {
+      const { mkdir, writeFile } = await import('node:fs/promises');
+      const tokensDir = join(tmpHome, 'tokens');
+      await mkdir(tokensDir, { recursive: true });
+      await writeFile(join(tokensDir, 'steven-obiajulu-at-gmail-com.json'), JSON.stringify({
+        provider: 'gmail',
+        mailboxName: 'personal',
+        emailAddress: 'steven.obiajulu@gmail.com',
+        clientId: 'gmail-client-id',
+        clientSecret: 'gmail-client-secret',
+        refreshToken: 'gmail-refresh-token',
+        lastInteractiveAuthAt: '2026-04-08T12:00:00.000Z',
+      }, null, 2) + '\n');
+
+      const exitCode = await runCli(['status']);
+      expect(exitCode).toBe(0);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Authentication expired for Gmail mailbox "steven.obiajulu@gmail.com"'),
       );
     } finally {
       if (savedHome === undefined) {

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -130,6 +130,36 @@ async function listConfiguredMailboxSummaries(): Promise<ConfiguredMailboxSummar
   return summaries;
 }
 
+async function getGmailReauthWarning(summary: ConfiguredMailboxSummary): Promise<string | undefined> {
+  if (summary.provider !== 'gmail') return undefined;
+
+  const gmail = await import('@usejunior/provider-gmail');
+
+  try {
+    const metadata = await gmail.loadGmailMailboxMetadata(summary.emailAddress ?? summary.mailboxName);
+    if (!metadata) return undefined;
+
+    const mailboxRef = metadata.emailAddress ?? metadata.mailboxName;
+    const auth = new gmail.GmailAuthManager({
+      clientId: metadata.clientId,
+      clientSecret: metadata.clientSecret,
+      redirectUri: metadata.redirectUri,
+      mailboxName: mailboxRef,
+      lastInteractiveAuthAt: metadata.lastInteractiveAuthAt,
+    });
+
+    await auth.connect({ refresh_token: metadata.refreshToken });
+    await auth.refresh();
+
+    return auth.getTokenHealthWarning();
+  } catch (err) {
+    if (!gmail.isGmailReauthError(err)) {
+      return undefined;
+    }
+    return gmail.formatGmailAuthError(err, summary.emailAddress ?? summary.mailboxName);
+  }
+}
+
 export async function getEffectiveSendAllowlistPath(): Promise<string> {
   const { getSendAllowlistPath } = await import('@usejunior/email-core');
   return getSendAllowlistPath();
@@ -1000,6 +1030,12 @@ export async function runStatus(): Promise<number> {
         console.error(`    Token age: ${daysSinceAuth} days (healthy)`);
       }
     }
+
+    const gmailWarning = await getGmailReauthWarning(mb);
+    if (gmailWarning) {
+      console.error(`    \u26A0\uFE0F  ${gmailWarning}`);
+    }
+
     console.error('');
   }
 

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -316,6 +316,76 @@ describe('mcp-transport/Lazy Provider State', () => {
     expect(result.warnings[0]).toMatch(/missing credentials/);
   });
 
+  it('Scenario: get_mailbox_status returns the requested failed Gmail mailbox when all auth attempts failed', async () => {
+    const state = createLazyProviderState();
+    state.status = 'error';
+    state.isDemo = true;
+    state.error = 'All configured mailboxes failed to authenticate';
+    state.initPromise = Promise.resolve();
+    state.mailboxes = [
+      {
+        name: 'personal',
+        emailAddress: 'steven.obiajulu@gmail.com',
+        displayName: 'steven.obiajulu@gmail.com',
+        providerType: 'gmail',
+        provider: null,
+        auth: null,
+        isDefault: false,
+        status: 'error',
+        error: 'Authentication expired for Gmail mailbox "steven.obiajulu@gmail.com". Run: email-agent-mcp configure --provider gmail --mailbox steven.obiajulu@gmail.com',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, { mailbox: 'personal' }) as {
+      name: string;
+      provider: string;
+      status: string;
+      warnings: string[];
+    };
+
+    expect(result.name).toBe('steven.obiajulu@gmail.com');
+    expect(result.provider).toBe('gmail');
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toContain('configure --provider gmail --mailbox steven.obiajulu@gmail.com');
+  });
+
+  it('Scenario: get_mailbox_status returns the only failed mailbox by default when all auth attempts failed', async () => {
+    const state = createLazyProviderState();
+    state.status = 'error';
+    state.isDemo = true;
+    state.error = 'Authentication expired for Gmail mailbox "steven.obiajulu@gmail.com". Run: email-agent-mcp configure --provider gmail --mailbox steven.obiajulu@gmail.com';
+    state.initPromise = Promise.resolve();
+    state.mailboxes = [
+      {
+        name: 'personal',
+        emailAddress: 'steven.obiajulu@gmail.com',
+        displayName: 'steven.obiajulu@gmail.com',
+        providerType: 'gmail',
+        provider: null,
+        auth: null,
+        isDefault: false,
+        status: 'error',
+        error: 'Authentication expired for Gmail mailbox "steven.obiajulu@gmail.com". Run: email-agent-mcp configure --provider gmail --mailbox steven.obiajulu@gmail.com',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, {}) as {
+      name: string;
+      provider: string;
+      status: string;
+      warnings: string[];
+    };
+
+    expect(result.name).toBe('steven.obiajulu@gmail.com');
+    expect(result.provider).toBe('gmail');
+    expect(result.status).toBe('error');
+    expect(result.warnings[0]).toContain('configure --provider gmail --mailbox steven.obiajulu@gmail.com');
+  });
+
   it('Scenario: get_mailbox_status reports the connected Gmail provider', async () => {
     const state = createLazyProviderState();
     state.status = 'connected';

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -406,7 +406,13 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
   try {
     const [
       { listConfiguredMailboxesWithMetadata, DelegatedAuthManager, RealGraphApiClient, GraphEmailProvider },
-      { listConfiguredGmailMailboxes, GmailAuthManager, GmailEmailProvider, GoogleapisGmailClient },
+      {
+        listConfiguredGmailMailboxes,
+        GmailAuthManager,
+        GmailEmailProvider,
+        GoogleapisGmailClient,
+        formatGmailAuthError,
+      },
     ] = await Promise.all([
       import('@usejunior/provider-microsoft'),
       import('@usejunior/provider-gmail'),
@@ -474,17 +480,24 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
 
     for (const metadata of gmailMailboxes) {
       const displayName = metadata.emailAddress ?? metadata.mailboxName;
+      const mailboxRef = metadata.emailAddress ?? metadata.mailboxName;
       try {
         const auth = new GmailAuthManager({
           clientId: metadata.clientId,
           clientSecret: metadata.clientSecret,
           redirectUri: metadata.redirectUri,
+          mailboxName: mailboxRef,
+          lastInteractiveAuthAt: metadata.lastInteractiveAuthAt,
         });
         await auth.connect({ refresh_token: metadata.refreshToken });
         await auth.refresh();
 
         const client = new GoogleapisGmailClient(auth);
         const provider = new GmailEmailProvider(client);
+        const mailboxAuth = {
+          getTokenHealthWarning: () => auth.getTokenHealthWarning(),
+          tryReconnect: () => auth.tryReconnect(),
+        };
 
         connectedMailboxes.push({
           name: metadata.mailboxName,
@@ -492,7 +505,7 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
           displayName,
           providerType: 'gmail',
           provider,
-          auth: null,
+          auth: mailboxAuth,
           isDefault: false,
           status: 'connected',
         });
@@ -508,10 +521,10 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
           auth: null,
           isDefault: false,
           status: 'error',
-          error: err instanceof Error ? err.message : String(err),
+          error: formatGmailAuthError(err, mailboxRef),
         });
         console.error(
-          `[email-agent-mcp] Skipping Gmail mailbox "${displayName}": ${err instanceof Error ? err.message : err}`,
+          `[email-agent-mcp] Skipping Gmail mailbox "${displayName}": ${formatGmailAuthError(err, mailboxRef)}`,
         );
       }
     }
@@ -532,7 +545,9 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
     state.mailboxes = failedMailboxes;
     state.isDemo = true;
     state.status = 'error';
-    state.error = 'All configured mailboxes failed to authenticate';
+    state.error = failedMailboxes.length === 1
+      ? (failedMailboxes[0]!.error ?? 'Mailbox authentication failed')
+      : `All configured mailboxes failed to authenticate. Use get_mailbox_status with a mailbox name for details. Configured mailboxes: ${failedMailboxes.map(mailbox => mailbox.displayName).join(', ')}`;
     console.error(
       '[email-agent-mcp] WARNING: All configured mailboxes failed to authenticate — running in demo mode. Run: email-agent-mcp configure',
     );
@@ -794,8 +809,25 @@ export async function buildLazyActions(
             return { name: 'pending', provider: 'pending', status: 'connecting', isDefault: false, warnings: ['Authenticating — provider is warming up'] };
           case 'not_configured':
             return { name: 'none', provider: 'none', status: 'not configured', isDefault: false, warnings: [NO_MAILBOX_CONFIGURED_MESSAGE] };
-          case 'error':
+          case 'error': {
+            const mailbox = inp.mailbox
+              ? findKnownMailbox(state, inp.mailbox)
+              : state.mailboxes.length === 1
+                ? state.mailboxes[0] ?? null
+                : null;
+
+            if (mailbox) {
+              return {
+                name: mailbox.displayName,
+                provider: mailbox.providerType,
+                status: 'error',
+                isDefault: mailbox.isDefault,
+                warnings: [mailbox.error ?? state.error ?? 'Provider init failed'],
+              };
+            }
+
             return { name: 'none', provider: 'none', status: 'error', isDefault: false, warnings: [state.error ?? 'Provider init failed'] };
+          }
           case 'connected': {
             const mailbox = inp.mailbox ? findKnownMailbox(state, inp.mailbox) : getDefaultMailbox(state);
             if (!mailbox) {

--- a/packages/provider-gmail/src/auth.test.ts
+++ b/packages/provider-gmail/src/auth.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { GMAIL_OAUTH_SCOPES, GmailAuthManager } from './auth.js';
+import { GMAIL_OAUTH_SCOPES, GmailAuthManager, isGmailReauthError } from './auth.js';
 
 const oauthMocks = vi.hoisted(() => ({
   setCredentials: vi.fn(),
@@ -176,5 +176,61 @@ describe('provider-gmail/OAuth2 Authentication', () => {
 
     await auth.connect({ access_token: 'gmail-token' });
     await expect(auth.refresh()).rejects.toThrow('No refresh token');
+  });
+
+  it('Scenario: detects Gmail invalid_grant responses as reauth-required', () => {
+    expect(isGmailReauthError(new Error('invalid_grant'))).toBe(true);
+    expect(isGmailReauthError({
+      response: {
+        data: {
+          error: 'invalid_grant',
+          error_description: 'Token has been expired or revoked.',
+        },
+      },
+    })).toBe(true);
+    expect(isGmailReauthError(new Error('network timeout'))).toBe(false);
+  });
+
+  it('Scenario: refresh marks Gmail auth as expired when Google rejects the refresh token', async () => {
+    oauthMocks.refreshAccessToken.mockRejectedValueOnce({
+      response: {
+        data: {
+          error: 'invalid_grant',
+          error_description: 'Token has been expired or revoked.',
+        },
+      },
+    });
+
+    const auth = new GmailAuthManager({
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+      mailboxName: 'personal',
+    });
+
+    await auth.connect({ refresh_token: 'gmail-refresh' });
+    await expect(auth.refresh()).rejects.toMatchObject({
+      response: {
+        data: {
+          error: 'invalid_grant',
+        },
+      },
+    });
+    expect(auth.isTokenExpired()).toBe(true);
+    expect(auth.getTokenHealthWarning()).toContain('configure --provider gmail --mailbox personal');
+  });
+
+  it('Scenario: getTokenHealthWarning warns about 7-day Testing refresh-token expiry for older Gmail auth', async () => {
+    const sixDaysAgo = new Date(Date.now() - (6 * 24 * 60 * 60 * 1000)).toISOString();
+    const auth = new GmailAuthManager({
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+      mailboxName: 'personal',
+      lastInteractiveAuthAt: sixDaysAgo,
+    });
+
+    await auth.connect({ refresh_token: 'gmail-refresh' });
+
+    expect(auth.getTokenHealthWarning()).toContain('still in Testing');
+    expect(auth.getTokenHealthWarning()).toContain('Last authenticated');
   });
 });

--- a/packages/provider-gmail/src/auth.ts
+++ b/packages/provider-gmail/src/auth.ts
@@ -6,6 +6,8 @@ export interface GmailAuthConfig {
   clientId: string;
   clientSecret?: string;
   redirectUri?: string;
+  mailboxName?: string;
+  lastInteractiveAuthAt?: string;
 }
 
 export interface GmailAuthUrlOptions {
@@ -31,11 +33,90 @@ export interface GmailProfile {
 
 export const GMAIL_OAUTH_SCOPES = ['https://mail.google.com/'];
 
+function collectAuthErrorStrings(err: unknown): string[] {
+  const values = new Set<string>();
+
+  const add = (value: unknown) => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    values.add(trimmed);
+  };
+
+  if (err instanceof Error) {
+    add(err.message);
+  }
+
+  const record = err as {
+    message?: unknown;
+    error?: unknown;
+    error_description?: unknown;
+    response?: {
+      data?: {
+        error?: unknown;
+        error_description?: unknown;
+      };
+    };
+  } | null;
+
+  if (record && typeof record === 'object') {
+    add(record.message);
+    add(record.error_description);
+
+    if (typeof record.error === 'string') {
+      add(record.error);
+    } else if (record.error && typeof record.error === 'object') {
+      const nestedError = record.error as { message?: unknown; code?: unknown };
+      add(nestedError.message);
+      add(nestedError.code);
+    }
+
+    const responseData = record.response?.data;
+    if (responseData && typeof responseData === 'object') {
+      add(responseData.error_description);
+      if (typeof responseData.error === 'string') {
+        add(responseData.error);
+      } else if (responseData.error && typeof responseData.error === 'object') {
+        const nestedError = responseData.error as { message?: unknown; status?: unknown };
+        add(nestedError.message);
+        add(nestedError.status);
+      }
+    }
+  }
+
+  return [...values];
+}
+
+export function isGmailReauthError(err: unknown): boolean {
+  return collectAuthErrorStrings(err).some(value => {
+    const lower = value.toLowerCase();
+    return (
+      lower.includes('invalid_grant') ||
+      lower.includes('token has been expired or revoked') ||
+      lower.includes('token has been revoked') ||
+      lower.includes('invalid_rapt') ||
+      lower.includes('no refresh token')
+    );
+  });
+}
+
+export function formatGmailAuthError(err: unknown, mailboxName: string): string {
+  if (isGmailReauthError(err)) {
+    return `Authentication expired for Gmail mailbox "${mailboxName}". Run: email-agent-mcp configure --provider gmail --mailbox ${mailboxName}`;
+  }
+
+  return collectAuthErrorStrings(err)[0] ?? (err instanceof Error ? err.message : String(err));
+}
+
 export class GmailAuthManager implements AuthManager {
   private oauth2Client: OAuth2Client;
   private accessToken?: string;
   private refreshToken?: string;
   private expiresAt?: number;
+  private readonly mailboxName: string;
+  private readonly lastInteractiveAuthAt?: string;
+  private needsReauth = false;
+  private reconnectPromise: Promise<boolean> | null = null;
 
   constructor(private readonly _config: GmailAuthConfig) {
     this.oauth2Client = new OAuth2Client(
@@ -43,6 +124,8 @@ export class GmailAuthManager implements AuthManager {
       this._config.clientSecret,
       this._config.redirectUri ?? 'urn:ietf:wg:oauth:2.0:oob',
     );
+    this.mailboxName = this._config.mailboxName ?? 'gmail';
+    this.lastInteractiveAuthAt = this._config.lastInteractiveAuthAt;
   }
 
   get clientId(): string { return this._config.clientId; }
@@ -80,6 +163,7 @@ export class GmailAuthManager implements AuthManager {
     this.accessToken = accessToken;
     this.refreshToken = refreshTokenVal;
     this.expiresAt = Date.now() + 3600000; // 1 hour default
+    this.needsReauth = false;
   }
 
   /**
@@ -116,15 +200,27 @@ export class GmailAuthManager implements AuthManager {
     this.accessToken = tokens.access_token ?? undefined;
     this.refreshToken = tokens.refresh_token ?? this.refreshToken;
     this.expiresAt = tokens.expiry_date ?? Date.now() + 3600000;
+    this.needsReauth = false;
   }
 
   async refresh(): Promise<void> {
-    if (!this.refreshToken) throw new Error('No refresh token');
+    if (!this.refreshToken) {
+      this.needsReauth = true;
+      throw new Error('No refresh token');
+    }
 
-    // Use the OAuth2Client's built-in refresh mechanism
-    const { credentials } = await this.oauth2Client.refreshAccessToken();
-    this.accessToken = credentials.access_token ?? undefined;
-    this.expiresAt = credentials.expiry_date ?? Date.now() + 3600000;
+    try {
+      // Use the OAuth2Client's built-in refresh mechanism
+      const { credentials } = await this.oauth2Client.refreshAccessToken();
+      this.accessToken = credentials.access_token ?? undefined;
+      this.expiresAt = credentials.expiry_date ?? Date.now() + 3600000;
+      this.needsReauth = false;
+    } catch (err) {
+      if (isGmailReauthError(err)) {
+        this.needsReauth = true;
+      }
+      throw err;
+    }
   }
 
   async disconnect(): Promise<void> {
@@ -139,9 +235,12 @@ export class GmailAuthManager implements AuthManager {
     this.accessToken = undefined;
     this.refreshToken = undefined;
     this.expiresAt = undefined;
+    this.needsReauth = false;
+    this.reconnectPromise = null;
   }
 
   isTokenExpired(): boolean {
+    if (this.needsReauth) return true;
     if (!this.expiresAt) return true;
     return Date.now() >= this.expiresAt;
   }
@@ -152,6 +251,36 @@ export class GmailAuthManager implements AuthManager {
 
   getRefreshToken(): string | undefined {
     return this.refreshToken;
+  }
+
+  async tryReconnect(): Promise<boolean> {
+    if (this.reconnectPromise) return this.reconnectPromise;
+    this.reconnectPromise = (async () => {
+      try {
+        await this.refresh();
+        return true;
+      } catch {
+        return false;
+      } finally {
+        this.reconnectPromise = null;
+      }
+    })();
+    return this.reconnectPromise;
+  }
+
+  getTokenHealthWarning(): string | undefined {
+    if (this.needsReauth) {
+      return formatGmailAuthError(new Error('invalid_grant'), this.mailboxName);
+    }
+
+    if (this.lastInteractiveAuthAt) {
+      const daysSinceAuth = (Date.now() - new Date(this.lastInteractiveAuthAt).getTime()) / (1000 * 60 * 60 * 24);
+      if (daysSinceAuth > 5) {
+        return `If the Google OAuth app is still in Testing, Gmail may require reauthentication after 7 days. Last authenticated ${Math.round(daysSinceAuth)} days ago.`;
+      }
+    }
+
+    return undefined;
   }
 
   async fetchProfile(): Promise<GmailProfile> {

--- a/packages/provider-gmail/src/index.ts
+++ b/packages/provider-gmail/src/index.ts
@@ -1,6 +1,11 @@
 // @usejunior/provider-gmail — Gmail API email provider
 export { GmailEmailProvider } from './email-gmail-provider.js';
-export { GMAIL_OAUTH_SCOPES, GmailAuthManager } from './auth.js';
+export {
+  GMAIL_OAUTH_SCOPES,
+  GmailAuthManager,
+  isGmailReauthError,
+  formatGmailAuthError,
+} from './auth.js';
 export {
   listConfiguredGmailMailboxes,
   loadGmailMailboxMetadata,


### PR DESCRIPTION
## Summary
- classify Gmail refresh failures that require user reauthentication
- surface mailbox-specific Gmail auth failures through server status and CLI status output
- add Gmail auth and MCP status coverage for invalid refresh-token paths

## Testing
- npm run test:run -w @usejunior/provider-gmail
- npm run test:run -w @usejunior/email-mcp
- npm run build -w @usejunior/provider-gmail
- npm run build -w @usejunior/email-mcp
- manual smoke: `npx tsx packages/email-mcp/src/cli.ts status` against configured Gmail mailboxes, confirming live warning output for older Gmail auth metadata
