### PR TITLE
[codex] keep direct CLI serve alive for Claude MCP

### DIFF
--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   runCli,
+  runCliDirect,
   parseCliArgs,
   getNemoClawEgressDomains,
   getAgentEmailHome,
@@ -288,6 +289,31 @@ describe('cli/Serve Subcommand', () => {
   it('Scenario: Start MCP server', async () => {
     const exitCode = await runCli(['serve']);
     expect(exitCode).toBe(0);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('MCP server started'),
+    );
+  });
+});
+
+describe('cli/Direct entrypoint lifecycle', () => {
+  let originalExitCode: number | undefined;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+  });
+
+  it('Scenario: Direct serve entrypoint does not force process exit after transport startup', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await runCliDirect(['serve']);
+
+    expect(process.exitCode).toBe(0);
+    expect(exitSpy).not.toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('MCP server started'),
     );

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -1065,8 +1065,8 @@ async function runToken(opts: CliOptions): Promise<number> {
     await auth.reconnect();
     const token = await auth.getAccessToken();
 
-    // Await stdout flush — the CLI wrapper calls process.exit() after runCli()
-    // resolves, which can truncate piped output if the write hasn't drained.
+    // Await stdout flush so short-lived invocations can exit naturally only
+    // after the token has fully reached stdout.
     await new Promise<void>((resolve, reject) => {
       process.stdout.write(token, (err) => err ? reject(err) : resolve());
     });
@@ -1118,13 +1118,25 @@ export function getNemoClawEgressDomains(): string[] {
   return [...NEMOCLAW_EGRESS_DOMAINS];
 }
 
+/**
+ * Direct entrypoint adapter used by `node dist/cli.js ...`.
+ *
+ * Important: successful runs must not force `process.exit()`. `serve` resolves
+ * once stdio transport is connected, but the MCP process must stay alive for
+ * the client handshake and subsequent tool calls.
+ */
+export async function runCliDirect(args: string[]): Promise<void> {
+  try {
+    const code = await runCli(args);
+    process.exitCode = code;
+  } catch (err) {
+    console.error('Fatal:', err);
+    process.exit(1);
+  }
+}
+
 // Auto-execute when run directly (not imported as a module in tests)
 const isDirectRun = process.argv[1]?.endsWith('cli.ts') || process.argv[1]?.endsWith('cli.js');
 if (isDirectRun) {
-  runCli(process.argv.slice(2)).then(code => {
-    process.exit(code);
-  }).catch(err => {
-    console.error('Fatal:', err);
-    process.exit(1);
-  });
+  void runCliDirect(process.argv.slice(2));
 }


### PR DESCRIPTION
## What changed
The direct `node .../dist/cli.js serve` entrypoint now routes through a small `runCliDirect()` adapter that sets `process.exitCode` on success instead of calling `process.exit(code)` immediately.

A regression test was added to verify the direct `serve` path does not force-process-exit after the MCP stdio transport starts.

## Why
Claude MCP health checks were failing when pointed directly at `packages/email-mcp/dist/cli.js serve` from the main checkout.

Root cause: the direct CLI auto-run path awaited `runCli()` and then unconditionally called `process.exit(code)`. For `serve`, `runCli()` resolves after stdio transport setup, so the process exited right after startup and before Claude could complete its handshake.

## Impact
This makes the main checkout usable as a direct Claude MCP runtime target without relying on a separate wrapper or alternate runtime worktree.

## Validation
- `npm run test:run -w @usejunior/email-mcp`
- `npm run build -w @usejunior/email-mcp`
- `claude mcp get email-agent-mcp-worktree-test` -> `Status: ✓ Connected`
- manual runtime check: `node packages/email-mcp/dist/cli.js serve` stayed alive after startup