### PR TITLE
chore(skills): sync 4 SKILL.md files to match ClawHub published versions

### DIFF
--- a/skills/email-cleanup/SKILL.md
+++ b/skills/email-cleanup/SKILL.md
@@ -50,7 +50,7 @@ requires:
       - permanentDelete
 metadata:
   author: UseJunior
-  version: "0.1.3"
+  version: "0.1.4"
 ---
 
 # Inbox Cleanup & Rules (Outlook)
@@ -62,6 +62,28 @@ This skill covers both one-time inbox cleanup and ongoing rule automation for Mi
 Use when the user's inbox has become noisy — automated notifications drowning out human conversations, newsletters mixed with client emails, or hundreds of unread messages that make it hard to find what matters.
 
 **Real trigger example**: A user's partner email went unread for 9 days because it was buried under GitHub and npm notifications. This is the exact problem server-side rules solve.
+
+## Trust Boundary: What This Skill Can and Cannot Enforce
+
+Before you install or grant OAuth consent, understand where the safety boundary lies.
+
+**This skill is instruction-only.** It ships no code, executes nothing by itself, and cannot enforce any of the safety protections described below. Everything in the "Rule Security Model" and "Authentication & Required Scopes" sections is enforced (or not enforced) by whichever runtime actually executes the Microsoft Graph API calls. The skill file is a set of instructions, not a sandbox.
+
+### What that means in practice
+
+- The blocked-actions list (`forwardTo`, `redirectTo`, `delete`, etc.) describes what a trusted runtime SHOULD reject. Whether those actions are actually rejected depends on the runtime. If you use [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), rejection is built into the action handler ([`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39)). If you use a raw Graph API client or a custom MCP without equivalent guards, the protections do not automatically apply.
+- `MailboxSettings.ReadWrite` is a high-risk scope because it controls inbox rules — and inbox rules can be configured to forward or redirect mail externally. Granting the scope without a runtime that enforces the blocked-actions list gives up the primary mitigation.
+- Autonomous invocation (where the agent runs this skill without per-call approval) is a platform-level setting, not something the skill controls. Combined with write scopes, it increases the surface area of any runtime weakness.
+
+### Before installing or granting consent
+
+This skill requests a high-risk mailbox-rule permission (`MailboxSettings.ReadWrite`). Review the five items below before you grant consent. They are the exact things to check; the skill cannot enforce any of them for you.
+
+1. **Only grant `MailboxSettings.ReadWrite` if you trust the runtime** that will execute these instructions. The skill itself cannot enforce the blocked-actions list (`forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete`). Verify your runtime does.
+2. **Prefer audit-only scopes** (`MailboxSettings.Read`) — or omit rule creation entirely — if you do not need automated rule management. Folder operations and batch moves work with just `Mail.ReadWrite`.
+3. **If you must grant full scopes, use a vetted runtime** that enforces blocking of forward/redirect/delete actions at the action handler. The reference runtime `email-agent-mcp` does this at [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39) — inspect the code yourself. Alternatively, add network-level protections (for example, NemoClaw) to block Graph endpoints that create dangerous rules.
+4. **Test on a non-production account first.** Be prepared to revoke OAuth consent and invalidate refresh tokens at https://myaccount.microsoft.com/consent if anything looks wrong or misconfigured.
+5. **Avoid enabling autonomous invocation** for this skill unless you understand and trust the runtime's guardrails. Autonomous invocation combined with `MailboxSettings.ReadWrite` gives the agent the ability to create inbox rules without per-call user approval — only safe if the runtime enforces the blocked-actions list.
 
 ## Authentication & Required Scopes
 

--- a/skills/email-drafting/SKILL.md
+++ b/skills/email-drafting/SKILL.md
@@ -13,7 +13,7 @@ compatibility: >-
   and thread detection.
 metadata:
   author: UseJunior
-  version: "0.1.0"
+  version: "0.1.1"
 ---
 
 # Email Response Drafting

--- a/skills/nemoclaw-email-policy/SKILL.md
+++ b/skills/nemoclaw-email-policy/SKILL.md
@@ -12,7 +12,7 @@ compatibility: >-
   including email-agent-mcp and direct Graph API clients.
 metadata:
   author: UseJunior
-  version: "0.1.0"
+  version: "0.1.1"
 ---
 
 # NemoClaw Email Policy

--- a/skills/outlook-email/SKILL.md
+++ b/skills/outlook-email/SKILL.md
@@ -63,7 +63,7 @@ requires:
     - calendar_integration
 metadata:
   author: UseJunior
-  version: "0.1.6"
+  version: "0.1.7"
 ---
 
 # Outlook Email Management
@@ -93,6 +93,30 @@ Why this matters: a single wrong send — wrong recipient, wrong attachment, con
 - **`delete_email` disabled by default** unless the caller explicitly opts in with `user_explicitly_requested_deletion: true` ([label.ts](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts))
 
 **NemoClaw** can enforce it at the network policy level — see the [NemoClaw Email Policy skill](#related-skills).
+
+## Trust Boundary: What This Skill Can and Cannot Enforce
+
+Before you install or grant OAuth consent, understand where the safety boundary lies.
+
+**This skill is instruction-only.** It ships no code, executes nothing by itself, and cannot enforce any of the safety protections described in the Safety Model above or the Authentication section below. Everything is enforced (or not enforced) by whichever runtime actually executes the Microsoft Graph API calls. The skill file is a set of instructions; the runtime is the sandbox.
+
+### What that means in practice
+
+- The draft-first workflow, send allowlist, and inbox-rule action blocks are properties of the reference runtime [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), not of this skill. If you use a different runtime, those protections are not automatically present.
+- `Mail.Send` and `Mail.ReadWrite` are high-impact OAuth scopes. Granting them without a runtime that enforces draft-first and send-allowlist gives up the primary mitigations.
+- `MailboxSettings.ReadWrite` controls inbox rules, and inbox rules can forward or redirect mail externally. The reference runtime blocks dangerous rule actions at the action handler level, but that protection is runtime-specific.
+- Autonomous invocation (where the agent runs this skill without per-call approval) is a platform-level setting, not something the skill controls. Combined with write scopes, it increases the surface area of any runtime weakness.
+
+### Before installing or granting consent
+
+This skill requests high-impact Microsoft Graph scopes (`Mail.ReadWrite`, `MailboxSettings.ReadWrite`, optionally `Mail.Send`). Review the items below before you grant consent. They are the exact things to check; the skill cannot enforce any of them for you.
+
+1. **Only grant `Mail.Send` if you trust the runtime** to honor draft-first. The skill itself cannot enforce "draft first, send second" — that's a runtime property. Verify your runtime either (a) blocks direct send by default, or (b) is `email-agent-mcp` which ships with an empty send allowlist by default.
+2. **Only grant `MailboxSettings.ReadWrite` if you trust the runtime** to block dangerous rule actions (`forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete`). The reference runtime does this at [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39) — inspect the code yourself. Alternatively, prefer `MailboxSettings.Read` if rule auditing is all you need.
+3. **Prefer least-privilege consent.** Start with `Mail.Read` + `offline_access` for read-only triage. Escalate to write scopes only as specific workflows require them. Skip `Mail.Send` entirely if draft-first (user sends manually from Outlook) is acceptable.
+4. **Review the client app identity.** Whatever `AGENT_EMAIL_CLIENT_ID` resolves to is the Azure AD application you are consenting to. Check the consent screen, verify the app name and publisher, and make sure the requested scopes match what you see in this document.
+5. **Test on a non-production account first.** Be prepared to revoke OAuth consent and invalidate refresh tokens at https://myaccount.microsoft.com/consent if anything looks wrong or misconfigured.
+6. **Avoid enabling autonomous invocation** for this skill unless you understand and trust the runtime's guardrails. Autonomous invocation combined with `Mail.Send` or `MailboxSettings.ReadWrite` gives the agent the ability to send mail or create inbox rules without per-call user approval — only safe if the runtime enforces the mitigations described above.
 
 ## Authentication & Required Scopes
 > 身份验证与所需权限


### PR DESCRIPTION
## Summary
- Syncs 4 SKILL.md files to match their ClawHub-published versions. These skills were iterated against the ClawHub scanner feedback loop without committing back to git.
- Closes version drift between git, Smithery, and ClawHub for the email-agent-mcp skills.

## Changes per skill
| Skill | git (before) | ClawHub/target | What changed |
|---|---|---|---|
| email-cleanup | 0.1.3 | 0.1.4 | Adds Trust Boundary section (scanner flip to Benign) |
| email-drafting | 0.1.0 | 0.1.1 | Fixes ClawHub star slug reference |
| nemoclaw-email-policy | 0.1.0 | 0.1.1 | Fixes ClawHub star slug reference |
| outlook-email | 0.1.6 | 0.1.7 | Adds Trust Boundary section (scanner flip to Benign) |

## Test plan
- [x] All 4 SKILL.md files parse as valid YAML frontmatter + markdown
- [x] Frontmatter versions match ClawHub published versions
- [ ] After merge, re-dispatch Smithery publish to sync Smithery listings