### PR TITLE
chore(email-mcp): drop bin field from core package

### DIFF
--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -5,9 +5,6 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": {
-    "email-agent-mcp": "./dist/cli.js"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Follow-up to #39. The `@usejunior/email-mcp` package and the `email-agent-mcp` wrapper both declared a `bin` named `email-agent-mcp` pointing at different files. When both are installed, npm can only create one symlink — the core package wins and the wrapper's bin becomes unreachable. That's what caused the silent-exit bug fixed in #39 (v0.1.6).
- #39 made the direct-run detection robust to the symlinked path, so the bug is already gone. This PR removes the duplicate bin declaration entirely so the two packages stop fighting over the same bin name at install time — belt-and-suspenders.
- The `@usejunior/email-mcp` package is a library consumed by the `email-agent-mcp` wrapper; end users are not expected to invoke its CLI directly. Anyone who was doing so via the bin symlink can still run `node node_modules/@usejunior/email-mcp/dist/cli.js`.
- No version bump — rides the next release cycle.

## Test plan

- [x] `npm run build` (all workspaces)
- [x] `npm run test:run` → 492 tests passed across 38 files