### PR TITLE
feat(cli): infer --provider from mailbox domain

### DIFF
--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -7,6 +7,7 @@ import {
   getAgentEmailHome,
   ensureGmailProfileMatchesIntent,
   getEffectiveSendAllowlistPath,
+  inferProviderFromMailbox,
   loadConfig,
   saveConfig,
   isDirectCliRun,
@@ -422,6 +423,47 @@ describe('cli/Configure Subcommand', () => {
   });
 });
 
+describe('cli/Provider Inference', () => {
+  it('infers gmail from gmail.com', () => {
+    expect(inferProviderFromMailbox('steven@gmail.com')).toBe('gmail');
+  });
+
+  it('infers gmail case-insensitively', () => {
+    expect(inferProviderFromMailbox('Steven@GMAIL.COM')).toBe('gmail');
+    expect(inferProviderFromMailbox('Steven@Gmail.com')).toBe('gmail');
+  });
+
+  it('infers gmail from googlemail.com (legacy variant)', () => {
+    expect(inferProviderFromMailbox('user@googlemail.com')).toBe('gmail');
+  });
+
+  it('infers gmail despite surrounding whitespace', () => {
+    expect(inferProviderFromMailbox('  steven@gmail.com  ')).toBe('gmail');
+  });
+
+  it('infers microsoft from each consumer domain', () => {
+    expect(inferProviderFromMailbox('user@outlook.com')).toBe('microsoft');
+    expect(inferProviderFromMailbox('user@hotmail.com')).toBe('microsoft');
+    expect(inferProviderFromMailbox('user@live.com')).toBe('microsoft');
+    expect(inferProviderFromMailbox('user@msn.com')).toBe('microsoft');
+  });
+
+  it('returns undefined for custom business domains', () => {
+    expect(inferProviderFromMailbox('steven@usejunior.com')).toBeUndefined();
+  });
+
+  it('returns undefined for inputs that are not an email address', () => {
+    expect(inferProviderFromMailbox('')).toBeUndefined();
+    expect(inferProviderFromMailbox('not-an-email')).toBeUndefined();
+    expect(inferProviderFromMailbox(undefined)).toBeUndefined();
+  });
+
+  it('does not pattern-match regional variants (hotmail.co.uk, outlook.fr) — exact match only', () => {
+    expect(inferProviderFromMailbox('user@hotmail.co.uk')).toBeUndefined();
+    expect(inferProviderFromMailbox('user@outlook.fr')).toBeUndefined();
+  });
+});
+
 describe('cli/Gmail Account Intent Checks', () => {
   let tmpHome: string;
   let originalHome: string | undefined;
@@ -662,6 +704,27 @@ describe('cli/Gmail Configure', () => {
       clientId: 'env-client-id',
       clientSecret: 'env-client-secret',
     });
+  });
+
+  it('Scenario: Configure without --provider infers gmail from a gmail.com mailbox', async () => {
+    process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'] = 'env-client-id';
+    process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'] = 'env-client-secret';
+
+    const exitCode = await runCli([
+      'configure',
+      '--mailbox',
+      'steven.obiajulu@gmail.com',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(gmailMockState.savedMetadata).toMatchObject({
+      provider: 'gmail',
+      mailboxName: 'steven.obiajulu@gmail.com',
+      emailAddress: 'steven.obiajulu@gmail.com',
+    });
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Inferred provider "gmail" from mailbox domain "gmail.com"'),
+    );
   });
 });
 

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -876,6 +876,28 @@ async function runGmailConfigure(opts: CliOptions): Promise<number> {
   return 0;
 }
 
+export function inferProviderFromMailbox(
+  mailbox: string | undefined,
+): 'gmail' | 'microsoft' | undefined {
+  if (!mailbox) return undefined;
+  const normalized = normalizeMailboxValue(mailbox);
+  if (!normalized.includes('@')) return undefined;
+  const domain = normalized.split('@').pop();
+  if (!domain) return undefined;
+
+  const GMAIL_DOMAINS = new Set(['gmail.com', 'googlemail.com']);
+  const MICROSOFT_CONSUMER_DOMAINS = new Set([
+    'outlook.com',
+    'hotmail.com',
+    'live.com',
+    'msn.com',
+  ]);
+
+  if (GMAIL_DOMAINS.has(domain)) return 'gmail';
+  if (MICROSOFT_CONSUMER_DOMAINS.has(domain)) return 'microsoft';
+  return undefined;
+}
+
 export async function runConfigure(opts: CliOptions): Promise<number> {
   if (opts.nemoclaw) {
     console.error('[email-agent-mcp] NemoClaw bootstrap — adding egress domains:');
@@ -886,7 +908,15 @@ export async function runConfigure(opts: CliOptions): Promise<number> {
   }
 
   const mailboxName = opts.mailbox ?? 'default';
-  const provider = opts.provider ?? 'microsoft';
+  const inferredProvider = opts.provider ? undefined : inferProviderFromMailbox(opts.mailbox);
+  const provider = opts.provider ?? inferredProvider ?? 'microsoft';
+
+  if (inferredProvider && !opts.provider) {
+    const domain = normalizeMailboxValue(opts.mailbox ?? '').split('@').pop();
+    console.error(
+      `[email-agent-mcp] Inferred provider "${inferredProvider}" from mailbox domain "${domain}". Pass --provider to override.`,
+    );
+  }
 
   if (provider === 'gmail') {
     try {


### PR DESCRIPTION
## Summary

Closes #41. When `--provider` is not passed, `setup` / `configure` now infers the provider from the `--mailbox` domain instead of silently defaulting to Microsoft for Gmail addresses.

**Priority order:**
1. Explicit `--provider` — always wins.
2. Inferred from `--mailbox` domain (exact match).
3. Falls back to existing `'microsoft'` default (preserves behavior for corporate/custom domains).

**Domain map (exact match only, case-insensitive):**
- `gmail.com`, `googlemail.com` → `gmail`
- `outlook.com`, `hotmail.com`, `live.com`, `msn.com` → `microsoft`
  ([Microsoft Support groups these four as Outlook.com-family consumer domains](https://support.microsoft.com/en-us/office/do-you-support-hotmail-msn-and-live-1571e197-4670-4a84-9f2c-eaca689d1d84))
- anything else → `undefined` (falls through to `microsoft` default)

When inference fires, we log once to stderr (matching the existing `[email-agent-mcp] Configuring mailbox …` pattern) with the matched domain so the behavior is transparent:

```
[email-agent-mcp] Inferred provider "gmail" from mailbox domain "gmail.com". Pass --provider to override.
```

Pattern matching (e.g., `hotmail.*`) was intentionally rejected — false-positive risk for corporate domains is not worth the marginal coverage of regional variants.

## Diff scope

- `packages/email-mcp/src/cli.ts` — new exported helper `inferProviderFromMailbox` (reuses the existing `normalizeMailboxValue` so whitespace-padded inputs still infer); two-line change to provider resolution in `runConfigure`; one new stderr log line.
- `packages/email-mcp/src/cli.test.ts` — new `describe('cli/Provider Inference')` with 8 unit tests covering the domain map, case-insensitivity, whitespace, non-matching domains, and explicit non-pattern-matching (`hotmail.co.uk` → undefined); one new integration scenario inside the existing `cli/Gmail Configure` block that runs `configure --mailbox test@gmail.com` with no `--provider` and asserts both the Gmail path was taken and the inference log was emitted.

No other files touched. No package-version bump (release is batched separately).

Peer-reviewed by Gemini CLI and Codex CLI before implementation. Codex caught two issues that shaped the final plan: (1) the helper reuses `normalizeMailboxValue` for input trimming, and (2) the "explicit Microsoft wins" runtime test was intentionally omitted — the Microsoft mock in `cli.test.ts` only activates for watcher tests (via `watcherMockState.mailboxes.length > 0`), not configure. The precedence logic is still covered by the unit `??` chain.

## Test plan

- [x] `npm run build`
- [x] `npm run test:run -w @usejunior/email-mcp` — 150/150 passing (9 new tests)
- [x] `npm run lint`