### PR TITLE
fix(wizard): pick mailbox on reconnect instead of defaulting to microsoft/default

### DIFF
--- a/packages/email-mcp/src/wizard.test.ts
+++ b/packages/email-mcp/src/wizard.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ConfiguredMailboxSummary } from './cli.js';
+
+// Linux CI runners do not provide libsecret; match cli.test.ts pattern.
+vi.mock('@azure/identity-cache-persistence', () => ({
+  cachePersistencePlugin: vi.fn(),
+}));
+
+const CANCEL_TOKEN = Symbol.for('email-agent-mcp/test-cancel');
+
+const promptMockState = vi.hoisted(() => ({
+  selectResults: [] as unknown[],
+  confirmResult: false as boolean,
+  textResult: '' as string,
+}));
+
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const CANCEL = Symbol.for('email-agent-mcp/test-cancel');
+  return {
+    ...actual,
+    intro: vi.fn(),
+    outro: vi.fn(),
+    note: vi.fn(),
+    log: {
+      success: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      message: vi.fn(),
+      step: vi.fn(),
+    },
+    select: vi.fn(async () => {
+      if (promptMockState.selectResults.length === 0) {
+        throw new Error('select() called more times than test primed');
+      }
+      return promptMockState.selectResults.shift();
+    }),
+    confirm: vi.fn(async () => promptMockState.confirmResult),
+    text: vi.fn(async () => promptMockState.textResult),
+    isCancel: vi.fn((v: unknown) => v === CANCEL),
+  };
+});
+
+const cliMockState = vi.hoisted(() => ({
+  runConfigureCalls: [] as unknown[],
+  runConfigureResult: 0,
+}));
+
+vi.mock('./cli.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./cli.js')>();
+  return {
+    ...actual,
+    runConfigure: vi.fn(async (opts: unknown) => {
+      cliMockState.runConfigureCalls.push(opts);
+      return cliMockState.runConfigureResult;
+    }),
+    runWatch: vi.fn(async () => 0),
+    runStatus: vi.fn(async () => 0),
+    loadConfig: vi.fn(async () => ({})),
+    saveConfig: vi.fn(async () => {}),
+    getAgentEmailHome: vi.fn(() => '/tmp/email-agent-mcp-wizard-test-home'),
+  };
+});
+
+describe('wizard/Reconnect Picker', () => {
+  beforeEach(() => {
+    promptMockState.selectResults = [];
+    promptMockState.confirmResult = false;
+    promptMockState.textResult = '';
+    cliMockState.runConfigureCalls = [];
+    cliMockState.runConfigureResult = 0;
+  });
+
+  it('Scenario: Multiple mailboxes — picker dispatches runConfigure with selected provider/mailbox', async () => {
+    const msft: ConfiguredMailboxSummary = {
+      provider: 'microsoft',
+      mailboxName: 'default',
+      emailAddress: 'user@contoso.com',
+    };
+    const gmail: ConfiguredMailboxSummary = {
+      provider: 'gmail',
+      mailboxName: 'user@gmail.com',
+      emailAddress: 'user@gmail.com',
+    };
+
+    // Two select calls in sequence: top-level menu choice, then the mailbox picker.
+    promptMockState.selectResults = ['reconnect', gmail];
+
+    const { runWizardMenu } = await import('./wizard.js');
+    const exit = await runWizardMenu({}, [msft, gmail]);
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(1);
+    expect(cliMockState.runConfigureCalls[0]).toMatchObject({
+      provider: 'gmail',
+      mailbox: 'user@gmail.com',
+    });
+  });
+
+  it('Scenario: Single mailbox — picker skipped, runConfigure called directly', async () => {
+    const gmail: ConfiguredMailboxSummary = {
+      provider: 'gmail',
+      mailboxName: 'user@gmail.com',
+      emailAddress: 'user@gmail.com',
+    };
+    // Only the top-level menu choice — picker should not be called.
+    promptMockState.selectResults = ['reconnect'];
+
+    const { runWizardMenu } = await import('./wizard.js');
+    const exit = await runWizardMenu({}, [gmail]);
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(1);
+    expect(cliMockState.runConfigureCalls[0]).toMatchObject({
+      provider: 'gmail',
+      mailbox: 'user@gmail.com',
+    });
+  });
+
+  it('Scenario: Picker cancelled — exits 0 without calling runConfigure', async () => {
+    const msft: ConfiguredMailboxSummary = {
+      provider: 'microsoft',
+      mailboxName: 'default',
+      emailAddress: 'user@contoso.com',
+    };
+    const gmail: ConfiguredMailboxSummary = {
+      provider: 'gmail',
+      mailboxName: 'user@gmail.com',
+      emailAddress: 'user@gmail.com',
+    };
+
+    promptMockState.selectResults = ['reconnect', CANCEL_TOKEN];
+
+    const { runWizardMenu } = await import('./wizard.js');
+    const exit = await runWizardMenu({}, [msft, gmail]);
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(0);
+  });
+
+  it('Scenario: Uses emailAddress when available, falls back to mailboxName', async () => {
+    // Mailbox with no emailAddress — verify mailboxName is used as the --mailbox arg.
+    const msftDefault: ConfiguredMailboxSummary = {
+      provider: 'microsoft',
+      mailboxName: 'default',
+    };
+    promptMockState.selectResults = ['reconnect'];
+
+    const { runWizardMenu } = await import('./wizard.js');
+    const exit = await runWizardMenu({}, [msftDefault]);
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls[0]).toMatchObject({
+      provider: 'microsoft',
+      mailbox: 'default',
+    });
+  });
+});

--- a/packages/email-mcp/src/wizard.ts
+++ b/packages/email-mcp/src/wizard.ts
@@ -212,8 +212,42 @@ export async function runWizardMenu(opts: CliOptions, mailboxes: ConfiguredMailb
     case 'add':
       return await runWizardSetup(opts);
 
-    case 'reconnect':
-      return await runConfigure(opts);
+    case 'reconnect': {
+      if (mailboxes.length === 0) {
+        p.outro('No configured mailboxes to reconnect. Run: email-agent-mcp setup');
+        return 0;
+      }
+
+      let target: ConfiguredMailboxSummary;
+      if (mailboxes.length === 1) {
+        target = mailboxes[0]!;
+      } else {
+        const picked = await p.select<ConfiguredMailboxSummary>({
+          message: 'Which mailbox do you want to reconnect?',
+          options: mailboxes.map(mb => {
+            const email = mb.emailAddress ?? mb.mailboxName;
+            const lastAuth = mb.lastInteractiveAuthAt
+              ? new Date(mb.lastInteractiveAuthAt).toLocaleDateString()
+              : 'unknown';
+            return {
+              value: mb,
+              label: `${email} (${mb.provider}, last auth: ${lastAuth})`,
+            };
+          }),
+        });
+        if (p.isCancel(picked)) {
+          p.outro('Goodbye!');
+          return 0;
+        }
+        target = picked;
+      }
+
+      return await runConfigure({
+        ...opts,
+        provider: target.provider,
+        mailbox: target.emailAddress ?? target.mailboxName,
+      });
+    }
 
     case 'hooks': {
       const config = await loadConfig();


### PR DESCRIPTION
## Summary

Fixes #43.

`runWizardMenu`'s "Reconnect a disconnected mailbox" option dispatched `runConfigure(opts)` with the original (usually empty) CLI opts. With both Microsoft and Gmail mailboxes configured, `runConfigure` silently defaulted to `provider=microsoft` / `mailbox=default`, re-authing the healthy Outlook account and leaving the expired Gmail one still expired. On the next run, the cleanup path then logged `Removing superseded token file: default.json`.

## Fix

Use the `mailboxes: ConfiguredMailboxSummary[]` that `runWizardMenu` already receives (and already renders in the "Connected accounts" note) to drive the reconnect selection:

- **Multiple configured mailboxes** → `p.select` picker with labels matching the existing `email (provider, last auth: date)` format; cancel returns 0.
- **Single configured mailbox** → skip the picker, reconnect directly.
- **Zero mailboxes** (defensive, since this path is only reached with existing config) → print a friendly message and exit 0. Notably, do **not** fall through to `runConfigure(opts)` — that's the bug being fixed.
- Dispatches `runConfigure({ ...opts, provider: target.provider, mailbox: target.emailAddress ?? target.mailboxName })` so the correct provider + mailbox flow always runs.

No changes to `cli.ts` — `runConfigure` already honors explicit `provider` + `mailbox`.

## Tests

New `packages/email-mcp/src/wizard.test.ts` (first wizard test file in the repo) with 4 scenarios:

- **Multi-mailbox regression**: microsoft + gmail configured, user picks gmail → `runConfigure` receives `{ provider: 'gmail', mailbox: 'user@gmail.com' }`. This is the exact case #43 describes.
- **Single-mailbox short-circuit**: picker not invoked, `runConfigure` called with that mailbox's provider+mailbox.
- **Picker cancel**: exit 0, `runConfigure` not called.
- **emailAddress vs mailboxName fallback**: when `emailAddress` is absent, `mailboxName` is passed as `--mailbox`.

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:run -w @usejunior/email-mcp` — 154/154 tests pass (4 new)
- [x] `npm run lint` clean
- [ ] Manual TTY smoke: run the built CLI with two configured providers, pick "Reconnect", confirm the picker appears and the correct provider reauth is triggered (to be verified by maintainer; device-code and OAuth flows are interactive)

## Out of scope

- Live disconnected-state detection. #43 explicitly scopes this out — each provider would need a live status check. The explicit picker is the minimum-viable fix.
- `--mailbox` typo handling.
- Version bumps / release tags (batched separately).