### PR TITLE
fix(graph): preserve auto-quoted thread history in reply_to_email

### DIFF
--- a/openspec/specs/provider-microsoft/spec.md
+++ b/openspec/specs/provider-microsoft/spec.md
@@ -29,12 +29,17 @@ The system SHALL support client credentials (app-only) authentication for daemon
 
 ### Requirement: Draft-Then-Send via createReplyAll
 
-The system SHALL use `createReplyAll` (not `sendMail`) for replies. `createReplyAll` preserves embedded images, CID references, and thread metadata. `sendMail` is fallback only when the original message is deleted (404).
+The system SHALL use `createReplyAll` (not `sendMail`) for replies. `createReplyAll` preserves embedded images, CID references, and thread metadata. The system merges Graph's auto-quoted body with caller content rather than overwriting it. `sendMail` is fallback only when the original message is deleted (404).
 
-#### Scenario: Reply preserves embedded images
-- **WHEN** the original email contains embedded images with CID references
+#### Scenario: Reply preserves Graph auto-quoted thread (plain text)
+- **WHEN** the original email has prior thread history
+- **AND** the system replies via `createReplyAll` with plain-text content
+- **THEN** the resulting draft preserves Graph's auto-generated quoted thread divider and prior-message header block alongside the caller content
+
+#### Scenario: cid: references survive the merge unchanged
+- **WHEN** the original email contains embedded images referenced via `cid:` URLs in Graph's quoted body
 - **AND** the system replies via `createReplyAll`
-- **THEN** the quoted content includes the embedded images intact
+- **THEN** the merged draft body retains every `cid:` reference intact
 
 #### Scenario: Fallback to sendMail on 404
 - **WHEN** `createReplyAll` returns 404 (original message deleted)

--- a/packages/email-core/src/providers/provider.test.ts
+++ b/packages/email-core/src/providers/provider.test.ts
@@ -43,6 +43,22 @@ describe('provider-interface/Capability Interfaces', () => {
     expect(partialProvider.subscribe).toBeUndefined();
     expect(partialProvider.unsubscribe).toBeUndefined();
   });
+
+  it('Scenario: Provider honors ReplyOptions.bodyHtml', async () => {
+    const provider = new MockEmailProvider();
+    provider.addMessage({ id: 'msg1', subject: 'Hello', from: { email: 'sender@example.com' } });
+
+    // replyToMessage with opts.bodyHtml — provider should preserve the HTML
+    // body alongside the plain-text fallback.
+    await provider.replyToMessage('msg1', 'plain fallback', {
+      bodyHtml: '<p>rendered reply</p>',
+    });
+
+    const sent = provider.getSentMessages();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.bodyHtml).toBe('<p>rendered reply</p>');
+    expect(sent[0]!.body).toBe('plain fallback');
+  });
 });
 
 describe('provider-interface/Provider Registration', () => {

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -16,34 +16,275 @@ function createMockClient(overrides: Partial<GraphApiClient> = {}): GraphApiClie
   };
 }
 
+// Realistic Graph createReplyAll response body — captured from a real probe.
+// Note: Graph returns contentType lowercased ("html") and prepends `<hr>` immediately
+// after `<body>`, so caller content inserted right after `<body>` lands above Graph's divider.
+const QUOTED_REPLY_BODY = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
+  + '<body style="font-size:10pt; font-family:Verdana,Geneva,sans-serif">'
+  + '<hr tabindex="-1" style="display:inline-block; width:98%">'
+  + '<div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" color="#000000" style="font-size:11pt">'
+  + '<b>From:</b> Alice &lt;alice@corp.com&gt;<br>'
+  + '<b>Sent:</b> Saturday, 25 April 2026 16:08:46<br>'
+  + '<b>To:</b> Steven &lt;steven@corp.com&gt;<br>'
+  + '<b>Subject:</b> Re: Quarterly Report</font><div>&nbsp;</div></div>'
+  + '<div><p>Original message content</p></div>'
+  + '</body></html>';
+
+function quotedReplyResponse(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'draft-123',
+    body: { contentType: 'html', content: QUOTED_REPLY_BODY },
+    ccRecipients: [],
+    bccRecipients: [],
+    toRecipients: [{ emailAddress: { address: 'alice@corp.com' } }],
+    ...overrides,
+  };
+}
+
 describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
-  it('Scenario: Reply preserves embedded images', async () => {
+  it('Scenario: Reply preserves Graph auto-quoted thread (plain text)', async () => {
     const client = createMockClient({
       post: vi.fn()
-        .mockResolvedValueOnce({ id: 'draft-123' }) // createReplyAll
+        .mockResolvedValueOnce(quotedReplyResponse())
         .mockResolvedValueOnce({}), // send
-      get: vi.fn().mockResolvedValue({
-        id: 'msg-1',
-        subject: 'Test',
-        from: { emailAddress: { address: 'alice@corp.com' } },
-        receivedDateTime: '2024-03-15T10:00:00Z',
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.replyToMessage('msg-1', 'Hi — short reply.');
+
+    expect(result.success).toBe(true);
+    // createReplyAll is called with empty body (we no longer use the `comment` field)
+    expect(client.post).toHaveBeenNthCalledWith(1, expect.stringContaining('createReplyAll'), {});
+    // Draft body PATCH preserves Graph's auto-quoted thread alongside caller content
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
+    expect(patchBody.contentType).toBe('HTML');
+    expect(patchBody.content).toContain('Hi — short reply.');
+    expect(patchBody.content).toContain('From:</b> Alice');
+    // Send POST follows the PATCH
+    expect(client.post).toHaveBeenNthCalledWith(2, expect.stringContaining('draft-123/send'), {});
+  });
+
+  it('Scenario: HTML reply merges fragment before quoted block', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse())
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'plain fallback', {
+      bodyHtml: '<p>rendered reply</p>',
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    const renderedAt = content.indexOf('<p>rendered reply</p>');
+    const fromHeaderAt = content.indexOf('From:</b> Alice');
+    expect(renderedAt).toBeGreaterThanOrEqual(0);
+    expect(fromHeaderAt).toBeGreaterThan(renderedAt);
+  });
+
+  it('Scenario: Caller-supplied full HTML document has wrappers stripped', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'plain', {
+      bodyHtml: '<html><body><p>rendered</p></body></html>',
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    // Outer <html>/<body> from caller fragment must be stripped — exactly one <html> and <body>
+    // (the outer ones from Graph's quoted document).
+    expect(content.match(/<html[\s>]/gi)?.length ?? 0).toBe(1);
+    expect(content.match(/<body[\s>]/gi)?.length ?? 0).toBe(1);
+    expect(content).toContain('<p>rendered</p>');
+  });
+
+  it('Scenario: Fallback GET when POST response is missing body', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce({ id: 'draft-456', ccRecipients: [], bccRecipients: [] }) // no body
+        .mockResolvedValueOnce({}),
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'draft-456',
+        body: { contentType: 'html', content: QUOTED_REPLY_BODY },
+        ccRecipients: [],
+        bccRecipients: [],
       }),
     });
     const provider = new GraphEmailProvider(client);
 
-    const result = await provider.replyToMessage('msg-1', '<p>Thanks!</p>');
+    await provider.replyToMessage('msg-1', 'reply');
 
-    expect(result.success).toBe(true);
-    // Verify createReplyAll was called (preserves embedded images)
-    expect(client.post).toHaveBeenCalledWith(
-      expect.stringContaining('createReplyAll'),
-      expect.anything(),
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('draft-456'));
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    expect(content).toContain('From:</b> Alice');
+    expect(content).toContain('reply');
+  });
+
+  it('Scenario: Fallback GET when POST response contentType is Text', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce({
+          id: 'draft-789',
+          body: { contentType: 'text', content: 'plain content from Graph' },
+          ccRecipients: [],
+          bccRecipients: [],
+        })
+        .mockResolvedValueOnce({}),
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'draft-789',
+        body: { contentType: 'html', content: QUOTED_REPLY_BODY },
+        ccRecipients: [],
+        bccRecipients: [],
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply');
+
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('draft-789'));
+  });
+
+  it('Scenario: CC merge — Graph-populated + caller-supplied', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse({
+          ccRecipients: [{ emailAddress: { address: 'alice@corp.com', name: 'Alice' } }],
+        }))
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply', {
+      cc: [{ email: 'bob@corp.com', name: 'Bob' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const cc = (patchArgs[1] as { ccRecipients: Array<{ emailAddress: { address: string } }> }).ccRecipients;
+    const addresses = cc.map(r => r.emailAddress.address.toLowerCase()).sort();
+    expect(addresses).toEqual(['alice@corp.com', 'bob@corp.com']);
+  });
+
+  it('Scenario: CC dedupe is case-insensitive', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse({
+          ccRecipients: [{ emailAddress: { address: 'Alice@corp.com', name: 'Alice' } }],
+        }))
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply', {
+      cc: [{ email: 'alice@CORP.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const cc = (patchArgs[1] as { ccRecipients: unknown[] }).ccRecipients;
+    expect(cc).toHaveLength(1);
+  });
+
+  it('Scenario: replyToMessage honors opts.cc (regression — previously dropped)', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse())
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply', {
+      cc: [{ email: 'new@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const cc = (patchArgs[1] as { ccRecipients: Array<{ emailAddress: { address: string } }> }).ccRecipients;
+    expect(cc.map(r => r.emailAddress.address)).toContain('new@corp.com');
+  });
+
+  it('Scenario: BCC merge', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse())
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply', {
+      bcc: [{ email: 'audit@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as { bccRecipients?: Array<{ emailAddress: { address: string } }> };
+    expect(patch.bccRecipients?.map(r => r.emailAddress.address)).toContain('audit@corp.com');
+  });
+
+  it('Scenario: cid: references survive the merge unchanged', async () => {
+    const bodyWithCid = QUOTED_REPLY_BODY.replace(
+      '<div><p>Original message content</p></div>',
+      '<div><p>Original</p><img src="cid:image001.jpg@01D8E4F2"></div>',
     );
-    // Verify draft body was updated
-    expect(client.patch).toHaveBeenCalledWith(
-      expect.stringContaining('draft-123'),
-      expect.objectContaining({ body: expect.anything() }),
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse({
+          body: { contentType: 'html', content: bodyWithCid },
+        }))
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'thanks', { bodyHtml: '<p>thanks</p>' });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    expect(content).toContain('cid:image001.jpg@01D8E4F2');
+  });
+
+  it('Scenario: Truncation preserves caller content at the top', async () => {
+    const huge = '<div>' + 'x'.repeat(4 * 1024 * 1024) + '</div>';
+    const bigBody = QUOTED_REPLY_BODY.replace(
+      '<div><p>Original message content</p></div>',
+      huge,
     );
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse({
+          body: { contentType: 'html', content: bigBody },
+        }))
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'caller content here', { bodyHtml: '<p>my reply</p>' });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    expect(content).toContain('<p>my reply</p>');
+    // Truncation keeps the caller content even though the quoted body was huge
+    expect(Buffer.byteLength(content, 'utf-8')).toBeLessThanOrEqual(3.5 * 1024 * 1024 + 200);
+  });
+
+  it('Scenario: <body>-tag-missing defensive fallback', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse({
+          body: { contentType: 'html', content: '<p>just a fragment, no body tag</p>' },
+        }))
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply', { bodyHtml: '<p>rendered</p>' });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    // Caller fragment ends up before the original (concat fallback)
+    expect(content.indexOf('<p>rendered</p>')).toBeLessThan(content.indexOf('just a fragment'));
   });
 
   it('Scenario: Fallback to sendMail on 404', async () => {
@@ -68,6 +309,33 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
       expect.stringContaining('sendMail'),
       expect.anything(),
     );
+  });
+
+  it('Scenario: createReplyDraft parity — merges quoted body and CCs without sending', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse({
+        ccRecipients: [{ emailAddress: { address: 'alice@corp.com' } }],
+      })),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.createReplyDraft('msg-1', 'reply', {
+      bodyHtml: '<p>rendered</p>',
+      cc: [{ email: 'bob@corp.com' }],
+    });
+
+    expect(result).toEqual({ success: true, draftId: 'draft-123' });
+    // Only one POST (createReplyAll) — no /send
+    expect(client.post).toHaveBeenCalledTimes(1);
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as {
+      body: { content: string };
+      ccRecipients: Array<{ emailAddress: { address: string } }>;
+    };
+    expect(patch.body.content).toContain('<p>rendered</p>');
+    expect(patch.body.content).toContain('From:</b> Alice');
+    const addresses = patch.ccRecipients.map(r => r.emailAddress.address.toLowerCase()).sort();
+    expect(addresses).toEqual(['alice@corp.com', 'bob@corp.com']);
   });
 });
 
@@ -127,24 +395,6 @@ describe('provider-interface/Capability Interfaces', () => {
     // Graph → contentType: Text when only body is set; newlines preserved verbatim
     expect(body.contentType).toBe('Text');
     expect(body.content).toBe('line one\nline two');
-  });
-
-  it('Scenario: Provider honors ReplyOptions.bodyHtml', async () => {
-    const client = createMockClient({
-      post: vi.fn()
-        .mockResolvedValueOnce({ id: 'draft-xyz' }) // createReplyAll
-        .mockResolvedValueOnce({}), // send
-    });
-    const provider = new GraphEmailProvider(client);
-
-    await provider.replyToMessage('msg-1', 'plain reply', {
-      bodyHtml: '<p>rendered reply</p>',
-    });
-
-    const patchCall = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    const body = (patchCall[1] as { body: { contentType: string; content: string } }).body;
-    expect(body.contentType).toBe('HTML');
-    expect(body.content).toBe('<p>rendered reply</p>');
   });
 
   it('Scenario: createDraft and updateDraft honor bodyHtml', async () => {

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -289,25 +289,13 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async replyToMessage(messageId: string, body: string, opts?: ReplyOptions): Promise<SendResult> {
-    // Use createReplyAll to preserve embedded images and CID references
+    // Use createReplyAll to preserve embedded images, CID references, and Graph's auto-quoted thread.
     try {
-      const draft = await this.client.post(
-        `${this.basePath}/messages/${messageId}/createReplyAll`,
-        {},
-      );
-
-      if (draft.id) {
-        // Update draft body — pick HTML if caller rendered it, else plain text
-        await this.client.patch(`${this.basePath}/messages/${draft.id}`, {
-          body: buildGraphBody(opts?.bodyHtml, body),
-        });
-
-        // Send the draft
-        await this.client.post(`${this.basePath}/messages/${draft.id}/send`, {});
-        return { success: true, messageId: draft.id };
-      }
+      const draftId = await this.prepareReplyDraft(messageId, body, opts);
+      await this.client.post(`${this.basePath}/messages/${draftId}/send`, {});
+      return { success: true, messageId: draftId };
     } catch {
-      // Fallback to sendMail on 404 (original deleted)
+      // Fallback to sendMail on 404 (original deleted) or other createReplyAll failures
     }
 
     // Fallback: construct reply manually via sendMail
@@ -336,25 +324,65 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
-    // Use createReplyAll to preserve embedded images and CID references
+    // Use createReplyAll to preserve embedded images, CID references, and Graph's auto-quoted thread.
+    try {
+      const draftId = await this.prepareReplyDraft(messageId, body, opts);
+      return { success: true, draftId };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to create reply draft';
+      return { success: false, error: { code: 'DRAFT_FAILED', message, recoverable: false } };
+    }
+  }
+
+  /**
+   * Shared helper for both reply paths. Calls createReplyAll, then merges Graph's
+   * auto-quoted body with the caller's content and merges Graph's auto-populated
+   * recipients with caller-supplied additions before PATCHing the draft.
+   *
+   * Returns the draft id. Throws if createReplyAll fails or returns no id.
+   */
+  private async prepareReplyDraft(
+    messageId: string,
+    body: string,
+    opts?: ReplyOptions,
+  ): Promise<string> {
     const draft = await this.client.post(
       `${this.basePath}/messages/${messageId}/createReplyAll`,
       {},
     );
+    if (!draft.id) throw new Error('createReplyAll did not return a draft id');
 
-    if (draft.id) {
-      // Update draft body — HTML if caller rendered it, else plain text
-      const patch: Record<string, unknown> = {
-        body: buildGraphBody(opts?.bodyHtml, body),
-      };
-      if (opts?.cc?.length) {
-        patch.ccRecipients = opts.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
-      }
-      await this.client.patch(`${this.basePath}/messages/${draft.id}`, patch);
-      return { success: true, draftId: draft.id };
+    let draftBody = draft.body as { contentType?: string; content?: string } | undefined;
+    let draftCc = (draft.ccRecipients as GraphRecipient[] | undefined) ?? [];
+    let draftBcc = (draft.bccRecipients as GraphRecipient[] | undefined) ?? [];
+
+    // Fallback GET when the POST response lacks a usable HTML body. Graph defaults
+    // to HTML on `Get message` so no Prefer header is needed.
+    if (typeof draftBody?.content !== 'string' || draftBody.contentType?.toLowerCase() !== 'html') {
+      const fetched = await this.client.get(`${this.basePath}/messages/${draft.id}`);
+      draftBody = fetched.body as { contentType?: string; content?: string } | undefined;
+      draftCc = (fetched.ccRecipients as GraphRecipient[] | undefined) ?? [];
+      draftBcc = (fetched.bccRecipients as GraphRecipient[] | undefined) ?? [];
     }
 
-    return { success: false, error: { code: 'DRAFT_FAILED', message: 'Failed to create reply draft', recoverable: false } };
+    const draftContent = typeof draftBody?.content === 'string' ? draftBody.content : '';
+    const callerFragment = opts?.bodyHtml !== undefined
+      ? stripHtmlBodyWrappers(opts.bodyHtml)
+      : wrapPlainTextAsHtml(body);
+    const merged = mergeQuotedReplyHtml(draftContent, callerFragment);
+
+    const patch: Record<string, unknown> = {
+      body: { contentType: 'HTML', content: truncateBody(merged) },
+    };
+
+    const ccMerged = mergeRecipients(draftCc, opts?.cc ?? []);
+    if (ccMerged.length > 0) patch.ccRecipients = ccMerged;
+
+    const bccMerged = mergeRecipients(draftBcc, opts?.bcc ?? []);
+    if (bccMerged.length > 0) patch.bccRecipients = bccMerged;
+
+    await this.client.patch(`${this.basePath}/messages/${draft.id}`, patch);
+    return draft.id;
   }
 
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {
@@ -543,4 +571,90 @@ function buildGraphBody(
     return { contentType: 'HTML', content: truncateBody(bodyHtml) };
   }
   return { contentType: 'Text', content: truncateBody(body) };
+}
+
+interface GraphRecipient {
+  emailAddress: { address: string; name?: string };
+}
+
+/**
+ * Strip outer `<html>` / `<body>` wrappers from caller-supplied HTML so it can be
+ * inserted as a fragment into Graph's auto-quoted reply document. `format: 'html'`
+ * is a passthrough in body-renderer.ts, so callers may send full documents.
+ */
+function stripHtmlBodyWrappers(html: string): string {
+  let out = html;
+  const headStart = out.search(/<html[^>]*>/i);
+  if (headStart >= 0) {
+    const bodyOpen = out.search(/<body[^>]*>/i);
+    if (bodyOpen >= 0) {
+      const tagMatch = out.slice(bodyOpen).match(/<body[^>]*>/i);
+      if (tagMatch) out = out.slice(bodyOpen + tagMatch[0].length);
+    } else {
+      const htmlTagMatch = out.match(/<html[^>]*>/i);
+      if (htmlTagMatch && htmlTagMatch.index !== undefined) {
+        out = out.slice(htmlTagMatch.index + htmlTagMatch[0].length);
+      }
+    }
+    out = out.replace(/<\/body\s*>[\s\S]*?<\/html\s*>\s*$/i, '');
+    out = out.replace(/<\/html\s*>\s*$/i, '');
+    out = out.replace(/<\/body\s*>\s*$/i, '');
+  }
+  return out;
+}
+
+/**
+ * Wrap plain text as a minimal HTML fragment suitable for merging into Graph's
+ * auto-quoted reply document. HTML-escapes the input and converts newlines to `<br>`.
+ */
+function wrapPlainTextAsHtml(text: string): string {
+  const escaped = text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+  return `<div>${escaped.replace(/\n/g, '<br>')}</div>`;
+}
+
+/**
+ * Merge a caller-supplied HTML fragment into Graph's auto-quoted reply document so
+ * that Graph's `From:/Sent:/To:/Subject:` divider and the prior thread are preserved.
+ *
+ * Insertion strategy: place the fragment immediately after the `<body>` opening tag.
+ * Graph's response begins with an `<hr>` right after `<body>`, so the caller's content
+ * naturally appears above that divider — no need to add our own.
+ *
+ * Defensive fallback (no `<body>` tag): concatenate fragment + content.
+ */
+function mergeQuotedReplyHtml(draftContent: string, callerFragment: string): string {
+  const bodyTagMatch = draftContent.match(/<body[^>]*>/i);
+  if (!bodyTagMatch || bodyTagMatch.index === undefined) {
+    return callerFragment + draftContent;
+  }
+  const insertAt = bodyTagMatch.index + bodyTagMatch[0].length;
+  return draftContent.slice(0, insertAt) + callerFragment + draftContent.slice(insertAt);
+}
+
+/**
+ * Merge two recipient lists, deduplicating by email address case-insensitively.
+ * Used to combine Graph's auto-populated reply-all recipients with caller-supplied
+ * additions without dropping either set.
+ */
+function mergeRecipients(
+  existing: GraphRecipient[],
+  additions: { email: string; name?: string }[],
+): GraphRecipient[] {
+  const byEmail = new Map<string, GraphRecipient>();
+  for (const r of existing) {
+    const email = r.emailAddress?.address?.toLowerCase();
+    if (email) byEmail.set(email, r);
+  }
+  for (const a of additions) {
+    const email = a.email.toLowerCase();
+    if (!byEmail.has(email)) {
+      byEmail.set(email, { emailAddress: { address: a.email, name: a.name } });
+    }
+  }
+  return Array.from(byEmail.values());
 }

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -581,25 +581,49 @@ interface GraphRecipient {
  * Strip outer `<html>` / `<body>` wrappers from caller-supplied HTML so it can be
  * inserted as a fragment into Graph's auto-quoted reply document. `format: 'html'`
  * is a passthrough in body-renderer.ts, so callers may send full documents.
+ *
+ * Uses indexOf-based parsing rather than regex to avoid backtracking on
+ * adversarial input (caller-supplied HTML may be untrusted).
  */
 function stripHtmlBodyWrappers(html: string): string {
+  const lower = html.toLowerCase();
+
+  // Bail early if there's no <html> tag — input is already a fragment.
+  const htmlOpenIdx = lower.indexOf('<html');
+  if (htmlOpenIdx < 0) return html;
+
   let out = html;
-  const headStart = out.search(/<html[^>]*>/i);
-  if (headStart >= 0) {
-    const bodyOpen = out.search(/<body[^>]*>/i);
-    if (bodyOpen >= 0) {
-      const tagMatch = out.slice(bodyOpen).match(/<body[^>]*>/i);
-      if (tagMatch) out = out.slice(bodyOpen + tagMatch[0].length);
-    } else {
-      const htmlTagMatch = out.match(/<html[^>]*>/i);
-      if (htmlTagMatch && htmlTagMatch.index !== undefined) {
-        out = out.slice(htmlTagMatch.index + htmlTagMatch[0].length);
-      }
-    }
-    out = out.replace(/<\/body\s*>[\s\S]*?<\/html\s*>\s*$/i, '');
-    out = out.replace(/<\/html\s*>\s*$/i, '');
-    out = out.replace(/<\/body\s*>\s*$/i, '');
+  let outLower = lower;
+
+  // Strip everything up to and including the opening <body...> tag, falling
+  // back to the opening <html...> tag when no body is present.
+  const bodyOpenIdx = outLower.indexOf('<body');
+  const openTagIdx = bodyOpenIdx >= 0 ? bodyOpenIdx : htmlOpenIdx;
+  const openTagEnd = outLower.indexOf('>', openTagIdx);
+  if (openTagEnd >= 0) {
+    out = out.slice(openTagEnd + 1);
+    outLower = out.toLowerCase();
   }
+
+  // Trim trailing whitespace, then strip up to one </html> and one </body>
+  // suffix (in either order). This handles the common shapes
+  // `…</body></html>`, `…</body>`, and `…</html>` produced by HTML serializers.
+  for (let i = 0; i < 2; i++) {
+    out = out.trimEnd();
+    outLower = out.toLowerCase();
+    if (outLower.endsWith('</html>')) {
+      out = out.slice(0, -'</html>'.length);
+      outLower = out.toLowerCase();
+      continue;
+    }
+    if (outLower.endsWith('</body>')) {
+      out = out.slice(0, -'</body>'.length);
+      outLower = out.toLowerCase();
+      continue;
+    }
+    break;
+  }
+
   return out;
 }
 


### PR DESCRIPTION
## Summary

Replies built via Microsoft's `reply_to_email` were losing the prior thread because the action overwrote Graph's auto-generated quoted body. This PR centralizes both the send and draft reply paths in a private `prepareReplyDraft` helper that:

- Calls `createReplyAll` and uses Graph's auto-quoted body as the base
- Falls back to a `GET /messages/{id}` fetch when the POST response lacks a usable HTML body (Graph occasionally returns the body as `text` or omits it)
- Inserts the caller-supplied content directly after `<body>`, landing it above Graph's `<hr>` divider so the prior thread is preserved
- Strips outer `<html>`/`<body>` wrappers from caller-supplied HTML so it merges as a fragment
- Wraps plain-text replies in a minimal HTML fragment (`<div>…<br>…</div>`)
- Merges Graph's auto-populated CC/BCC recipients with caller-supplied additions, deduplicated case-insensitively
- Truncates the final body to fit Graph's 3.5 MB limit, preserving the caller content at the top

Closes #49

## Test plan

- [x] `pnpm test` — all existing tests pass; new tests cover quoted-thread preservation, HTML fragment merging, full-document wrapper stripping, fallback GET on missing/non-HTML body, CC merge + case-insensitive dedupe, BCC merge, CID image preservation, body truncation, defensive fallback when `<body>` is missing, sendMail fallback on 404, and `createReplyDraft` parity
- [x] `pnpm build && pnpm lint`