### PR TITLE
fix(reply): add reply_all toggle to reply_to_email

### DIFF
--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { replyToEmailAction } from './reply.js';
 import type { ActionContext, MailboxEntry } from './registry.js';
@@ -190,5 +190,88 @@ describe('email-write/Body Rendering', () => {
     const sent = provider.getSentMessages()[0]!;
     expect(sent.body).toBe('### Not a header');
     expect(sent.bodyHtml).toBeUndefined();
+  });
+});
+
+describe('email-write/Reply All Toggle', () => {
+  // Note: Zod defaults are applied at parse() time, not in run(). The MCP server
+  // calls action.input.parse() before action.run(), so production callers see
+  // the default. These tests parse first to mirror that real flow.
+
+  it('Scenario: reply_all defaults to true and propagates to provider', async () => {
+    const replySpy = vi.spyOn(provider, 'replyToMessage');
+
+    const input = replyToEmailAction.input.parse({
+      message_id: VALID_MSG_ID,
+      body: 'Thanks!',
+    });
+    expect(input.reply_all).toBe(true);
+
+    const result = await replyToEmailAction.run(ctx, input);
+
+    expect(result.success).toBe(true);
+    expect(replySpy).toHaveBeenCalledWith(
+      VALID_MSG_ID,
+      expect.any(String),
+      expect.objectContaining({ replyAll: true }),
+    );
+  });
+
+  it('Scenario: reply_all: false propagates to provider on send path', async () => {
+    const replySpy = vi.spyOn(provider, 'replyToMessage');
+
+    const input = replyToEmailAction.input.parse({
+      message_id: VALID_MSG_ID,
+      body: 'Sender only',
+      reply_all: false,
+    });
+
+    const result = await replyToEmailAction.run(ctx, input);
+
+    expect(result.success).toBe(true);
+    expect(replySpy).toHaveBeenCalledWith(
+      VALID_MSG_ID,
+      expect.any(String),
+      expect.objectContaining({ replyAll: false }),
+    );
+  });
+
+  it('Scenario: reply_all: false propagates to provider on draft path', async () => {
+    const draftSpy = vi.spyOn(provider, 'createReplyDraft');
+
+    const input = replyToEmailAction.input.parse({
+      message_id: VALID_MSG_ID,
+      body: 'Draft reply',
+      draft: true,
+      reply_all: false,
+    });
+
+    const result = await replyToEmailAction.run(ctx, input);
+
+    expect(result.success).toBe(true);
+    expect(draftSpy).toHaveBeenCalledWith(
+      VALID_MSG_ID,
+      expect.any(String),
+      expect.objectContaining({ replyAll: false }),
+    );
+  });
+
+  it('Scenario: reply_all defaults to true on draft path', async () => {
+    const draftSpy = vi.spyOn(provider, 'createReplyDraft');
+
+    const input = replyToEmailAction.input.parse({
+      message_id: VALID_MSG_ID,
+      body: 'Draft reply',
+      draft: true,
+    });
+    expect(input.reply_all).toBe(true);
+
+    await replyToEmailAction.run(ctx, input);
+
+    expect(draftSpy).toHaveBeenCalledWith(
+      VALID_MSG_ID,
+      expect.any(String),
+      expect.objectContaining({ replyAll: true }),
+    );
   });
 });

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -17,6 +17,8 @@ const ReplyToEmailInput = z.object({
   mailbox: z.string().optional(),
   cc: z.array(z.string()).optional(),
   draft: z.boolean().optional(),
+  reply_all: z.boolean().optional().default(true)
+    .describe('When false, reply only to the original sender. Default true preserves reply-all behavior (cc the original thread).'),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
@@ -39,7 +41,7 @@ export const replyToEmailAction: EmailAction<
   z.infer<typeof ReplyToEmailOutput>
 > = {
   name: 'reply_to_email',
-  description: 'Reply to an email within an existing thread. Send path gated by send allowlist; draft path bypasses.',
+  description: 'Reply to an email within an existing thread. Default reply_all=true cc\'s the original thread; pass reply_all=false to reply only to the sender. Send path gated by send allowlist; draft path bypasses.',
   input: ReplyToEmailInput,
   output: ReplyToEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -83,6 +85,7 @@ export const replyToEmailAction: EmailAction<
         const draftResult = await ctx.provider.createReplyDraft(input.message_id, bodyPlain, {
           cc: input.cc?.map(email => ({ email })),
           bodyHtml,
+          replyAll: input.reply_all,
         });
         return {
           success: draftResult.success,
@@ -128,6 +131,7 @@ export const replyToEmailAction: EmailAction<
         () => ctx.provider.replyToMessage(input.message_id, bodyPlain, {
           cc: input.cc?.map(email => ({ email })),
           bodyHtml,
+          replyAll: input.reply_all,
         }),
         { maxRetries: 3, baseDelay: 1000 },
       );

--- a/packages/email-core/src/types.ts
+++ b/packages/email-core/src/types.ts
@@ -124,6 +124,13 @@ export interface ReplyOptions {
    * send with plain-text content-type.
    */
   bodyHtml?: string;
+  /**
+   * When false, reply only to the original sender. When true or omitted,
+   * include the original thread's To/Cc recipients (reply-all). Providers
+   * branch on the explicit `false` value; `undefined` preserves the
+   * historical reply-all default.
+   */
+  replyAll?: boolean;
 }
 
 export interface Subscription {

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -554,9 +554,77 @@ describe('provider-gmail/Reply Drafts', () => {
     expect(result.error?.code).toBe('DRAFT_FAILED');
     expect(result.error?.message).toMatch(/quota exceeded/);
   });
+
+  it('Scenario: replyAll: false omits thread To/Cc from Cc header', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'sender-only reply', { replyAll: false });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    // To: still the original sender.
+    expect(raw).toContain('To: "Alice" <alice@corp.com>');
+    // Cc: must not contain the thread's To/Cc participants.
+    expect(raw).not.toContain('bob@corp.com');
+    expect(raw).not.toContain('carol@corp.com');
+    // No Cc header at all when there are no recipients.
+    expect(raw).not.toMatch(/^Cc:/m);
+  });
+
+  it('Scenario: replyAll: false still honors caller-supplied opts.cc', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', {
+      replyAll: false,
+      cc: [{ email: 'manager@corp.com', name: 'Manager' }],
+    });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('To: "Alice" <alice@corp.com>');
+    // Cc contains only the caller's address — thread participants excluded.
+    expect(raw).toMatch(/^Cc: .*manager@corp\.com/m);
+    expect(raw).not.toContain('bob@corp.com');
+    expect(raw).not.toContain('carol@corp.com');
+  });
+
+  it('Scenario: replyAll omitted preserves reply-all behavior (regression guard)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply');
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toMatch(/Cc: .*bob@corp\.com.*carol@corp\.com/);
+  });
 });
 
 describe('provider-gmail/Reply Threading on Send', () => {
+  function ccThreadMessageMock() {
+    return {
+      id: 'msg-original',
+      threadId: 'thread-xyz',
+      labelIds: [],
+      payload: {
+        headers: [
+          { name: 'From', value: '"Alice" <alice@corp.com>' },
+          { name: 'To', value: 'bob@corp.com' },
+          { name: 'Cc', value: 'carol@corp.com' },
+          { name: 'Subject', value: 'Urgent' },
+          { name: 'Date', value: '2026-01-15T10:00:00Z' },
+          { name: 'Message-ID', value: '<msg-xyz@corp.com>' },
+        ],
+      },
+      internalDate: String(Date.now()),
+    };
+  }
+
   it('Scenario: replyToMessage sends with threadId and In-Reply-To header', async () => {
     const client = createMockGmailClient({
       getMessage: vi.fn().mockResolvedValue({
@@ -585,6 +653,33 @@ describe('provider-gmail/Reply Threading on Send', () => {
     expect(raw).toContain('In-Reply-To: <msg-xyz@corp.com>');
     expect(raw).toContain('References: <msg-xyz@corp.com>');
     expect(raw).toContain('Subject: Re: Urgent');
+  });
+
+  it('Scenario: replyToMessage with replyAll: false omits thread participants from Cc', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(ccThreadMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.replyToMessage('msg-original', 'sender-only reply', { replyAll: false });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('To: "Alice" <alice@corp.com>');
+    expect(raw).not.toContain('bob@corp.com');
+    expect(raw).not.toContain('carol@corp.com');
+    expect(raw).not.toMatch(/^Cc:/m);
+  });
+
+  it('Scenario: replyToMessage default (replyAll omitted) preserves reply-all', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(ccThreadMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.replyToMessage('msg-original', 'reply');
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toMatch(/Cc: .*bob@corp\.com.*carol@corp\.com/);
   });
 });
 

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -162,19 +162,22 @@ export class GmailEmailProvider {
   }
 
   async replyToMessage(messageId: string, body: string, opts?: ReplyOptions): Promise<SendResult> {
-    // Match Microsoft's createReplyAll semantics: reply to sender and cc
-    // everyone else on the original message. Caller-supplied opts.cc/bcc
-    // layer on top. Shipping without self-exclusion — an agent that replies
-    // to its own sent mail may cc itself; documented caveat.
+    // Default reply-all: cc every other thread participant (matches Microsoft's
+    // createReplyAll semantics). When opts.replyAll is explicitly false, reply
+    // only to the original sender. Caller-supplied opts.cc/bcc layer on top
+    // either way. No self-exclusion — an agent that replies to its own sent
+    // mail may cc itself; documented caveat.
     const original = await this.getMessage(messageId);
-    const replyAllCc = mergeAddressLists(original.to, original.cc, opts?.cc);
+    const replyCc = opts?.replyAll === false
+      ? (opts?.cc ?? [])
+      : mergeAddressLists(original.to, original.cc, opts?.cc);
     const subject = prefixReSubject(original.subject);
     const references = buildReferences(original.references, original.messageId);
 
     const raw = buildRawMessage(
       {
         to: [original.from],
-        cc: replyAllCc.length > 0 ? replyAllCc : undefined,
+        cc: replyCc.length > 0 ? replyCc : undefined,
         bcc: opts?.bcc,
         subject,
         body,
@@ -204,14 +207,16 @@ export class GmailEmailProvider {
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
     try {
       const original = await this.getMessage(messageId);
-      const replyAllCc = mergeAddressLists(original.to, original.cc, opts?.cc);
+      const replyCc = opts?.replyAll === false
+        ? (opts?.cc ?? [])
+        : mergeAddressLists(original.to, original.cc, opts?.cc);
       const subject = prefixReSubject(original.subject);
       const references = buildReferences(original.references, original.messageId);
 
       const raw = buildRawMessage(
         {
           to: [original.from],
-          cc: replyAllCc.length > 0 ? replyAllCc : undefined,
+          cc: replyCc.length > 0 ? replyCc : undefined,
           bcc: opts?.bcc,
           subject,
           body,

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -339,6 +339,80 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
   });
 });
 
+describe('provider-microsoft/Reply-All Routing', () => {
+  it('Scenario: replyAll omitted defaults to createReplyAll', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse())
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply');
+
+    const firstUrl = (client.post as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(firstUrl).toContain('createReplyAll');
+  });
+
+  it('Scenario: replyAll: true routes to createReplyAll', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', { replyAll: true });
+
+    const firstUrl = (client.post as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(firstUrl).toContain('createReplyAll');
+  });
+
+  it('Scenario: replyAll: false routes to createReply (sender only)', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', { replyAll: false });
+
+    const firstUrl = (client.post as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(firstUrl).toContain('/createReply');
+    expect(firstUrl).not.toContain('createReplyAll');
+  });
+
+  it('Scenario: replyAll: false on send path uses createReply', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse())
+        .mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.replyToMessage('msg-1', 'reply', { replyAll: false });
+
+    const firstUrl = (client.post as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(firstUrl).toContain('/createReply');
+    expect(firstUrl).not.toContain('createReplyAll');
+  });
+
+  it('Scenario: replyAll: false preserves caller-supplied cc', async () => {
+    // Graph's createReply returns no auto-populated CCs (sender-only), so the
+    // PATCH should contain only the caller's cc.
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse({ ccRecipients: [] })),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      replyAll: false,
+      cc: [{ email: 'manager@corp.com', name: 'Manager' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as { ccRecipients?: Array<{ emailAddress: { address: string } }> };
+    expect(patch.ccRecipients?.map(r => r.emailAddress.address)).toEqual(['manager@corp.com']);
+  });
+});
+
 describe('provider-microsoft/Size Limits', () => {
   it('Scenario: Body size enforcement', async () => {
     const client = createMockClient();

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -289,13 +289,14 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async replyToMessage(messageId: string, body: string, opts?: ReplyOptions): Promise<SendResult> {
-    // Use createReplyAll to preserve embedded images, CID references, and Graph's auto-quoted thread.
+    // Routes to createReply or createReplyAll based on opts.replyAll. Both Graph
+    // endpoints preserve embedded images, CID references, and the auto-quoted thread.
     try {
       const draftId = await this.prepareReplyDraft(messageId, body, opts);
       await this.client.post(`${this.basePath}/messages/${draftId}/send`, {});
       return { success: true, messageId: draftId };
     } catch {
-      // Fallback to sendMail on 404 (original deleted) or other createReplyAll failures
+      // Fallback to sendMail on 404 (original deleted) or other failures
     }
 
     // Fallback: construct reply manually via sendMail
@@ -324,7 +325,8 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
-    // Use createReplyAll to preserve embedded images, CID references, and Graph's auto-quoted thread.
+    // Routes to createReply or createReplyAll based on opts.replyAll. Both Graph
+    // endpoints preserve embedded images, CID references, and the auto-quoted thread.
     try {
       const draftId = await this.prepareReplyDraft(messageId, body, opts);
       return { success: true, draftId };
@@ -335,22 +337,25 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   /**
-   * Shared helper for both reply paths. Calls createReplyAll, then merges Graph's
-   * auto-quoted body with the caller's content and merges Graph's auto-populated
-   * recipients with caller-supplied additions before PATCHing the draft.
+   * Shared helper for both reply paths. Calls createReply (sender only) when
+   * opts.replyAll is explicitly false, otherwise createReplyAll (sender + thread
+   * recipients). Then merges Graph's auto-quoted body with the caller's content
+   * and merges Graph's auto-populated recipients with caller-supplied additions
+   * before PATCHing the draft.
    *
-   * Returns the draft id. Throws if createReplyAll fails or returns no id.
+   * Returns the draft id. Throws if the Graph endpoint fails or returns no id.
    */
   private async prepareReplyDraft(
     messageId: string,
     body: string,
     opts?: ReplyOptions,
   ): Promise<string> {
+    const endpoint = opts?.replyAll === false ? 'createReply' : 'createReplyAll';
     const draft = await this.client.post(
-      `${this.basePath}/messages/${messageId}/createReplyAll`,
+      `${this.basePath}/messages/${messageId}/${endpoint}`,
       {},
     );
-    if (!draft.id) throw new Error('createReplyAll did not return a draft id');
+    if (!draft.id) throw new Error(`${endpoint} did not return a draft id`);
 
     let draftBody = draft.body as { contentType?: string; content?: string } | undefined;
     let draftCc = (draft.ccRecipients as GraphRecipient[] | undefined) ?? [];


### PR DESCRIPTION
## Summary

The `reply_to_email` action was unconditionally cc'ing every recipient on the original thread. Microsoft hard-coded Graph's `createReplyAll` endpoint and Gmail unconditionally merged `original.to + original.cc` into the `Cc` header — so callers asking for a reply to the sender silently leaked the response to the broader thread.

This PR surfaces the choice as an MCP action parameter:

- `ReplyOptions` gains an optional `replyAll` boolean. Providers branch only on the explicit `false` value; `undefined` preserves the historical reply-all default.
- `reply_to_email` gains a `reply_all` field defaulting to `true` so existing callers see no behavior change. Pass `false` to reply only to the original sender.
- **Microsoft**: `prepareReplyDraft` routes to `createReply` when `replyAll` is false, `createReplyAll` otherwise. The body/CC/BCC merge logic is unchanged — when `createReply` populates 0 CCs, the existing recipient merge already handles it.
- **Gmail**: `replyToMessage` and `createReplyDraft` skip the thread To/Cc merge when `replyAll` is false; only `opts.cc` layers on top.

Closes #51

Builds on #49 (PR #52, just merged) which centralized Microsoft's reply paths in the `prepareReplyDraft` helper — the routing fix here is now a one-line endpoint switch in that helper.

## Test plan

- [x] `pnpm test` — 536 tests pass; new tests cover the three states (true / false / omitted) on both providers and at the action layer
- [x] `pnpm build && pnpm lint`
- [x] `node scripts/check-spec-coverage.mjs` — 186/186 scenarios covered
- [ ] Manual M365 probe: confirm `createReplyDraft` with `reply_all: false` produces a draft with no CCs from the original thread (deferred to maintainer)

## Out of scope (follow-ups)

- The `reply_to_email` allowlist gate only checks `originalMessage.from`, so reply-all sends can still reach non-allowlisted addresses. Pre-existing; flagged by Codex peer review.
- The `create_draft` action's `reply_to` path doesn't yet expose `reply_all` — separate API surface, can add if anyone asks.
- Microsoft `replyToMessage` fallback path (lines 301-308) puts CCs in the To field with an empty subject. Pre-existing bug, separate fix.

## Peer review

Plan was reviewed by Gemini CLI and Codex CLI before implementation. Both confirmed the approach (one-line endpoint switch on Microsoft; conditional CC merge on Gmail). Codex's feedback drove three test-quality improvements: parsing the action input through the schema in tests so the `default(true)` is exercised; using `vi.spyOn` instead of teaching `MockEmailProvider` new bookkeeping; and asserting the `To:` header (not just `Cc:` absence) on Gmail to confirm sender-only routing.