### PR TITLE
fix(provider-microsoft): return structured failure when reply createReplyAll fails (#50)

### DIFF
--- a/openspec/specs/provider-microsoft/spec.md
+++ b/openspec/specs/provider-microsoft/spec.md
@@ -29,7 +29,7 @@ The system SHALL support client credentials (app-only) authentication for daemon
 
 ### Requirement: Draft-Then-Send via createReplyAll
 
-The system SHALL use `createReplyAll` (not `sendMail`) for replies. `createReplyAll` preserves embedded images, CID references, and thread metadata. The system merges Graph's auto-quoted body with caller content rather than overwriting it. `sendMail` is fallback only when the original message is deleted (404).
+The system SHALL use `createReplyAll` for replies. `createReplyAll` preserves embedded images, CID references, and thread metadata. The system merges Graph's auto-quoted body with caller content rather than overwriting it. When `createReplyAll`, the body merge PATCH, or the final `/send` POST fails, `replyToMessage` SHALL return a structured `{ success: false, error: { code: 'REPLY_FAILED', recoverable: false } }` rather than silently falling back to `sendMail` — a `sendMail`-based message would lack `In-Reply-To` / `References` headers and so would not thread on the recipient side.
 
 #### Scenario: Reply preserves Graph auto-quoted thread (plain text)
 - **WHEN** the original email has prior thread history
@@ -41,9 +41,10 @@ The system SHALL use `createReplyAll` (not `sendMail`) for replies. `createReply
 - **AND** the system replies via `createReplyAll`
 - **THEN** the merged draft body retains every `cid:` reference intact
 
-#### Scenario: Fallback to sendMail on 404
-- **WHEN** `createReplyAll` returns 404 (original message deleted)
-- **THEN** the system falls back to `sendMail` with manually constructed quoted content
+#### Scenario: createReplyAll failure returns structured REPLY_FAILED
+- **WHEN** `createReplyAll`, the body-merge PATCH, or the final `/send` POST throws
+- **THEN** `replyToMessage` returns `{ success: false, error: { code: 'REPLY_FAILED', recoverable: false } }`
+- **AND** does not call `sendMail`
 
 ### Requirement: Validation Token Handling
 

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -412,25 +412,75 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
     expect(content.indexOf('<p>rendered</p>')).toBeLessThan(content.indexOf('just a fragment'));
   });
 
-  it('Scenario: Fallback to sendMail on 404', async () => {
+  it('Scenario: createReplyAll failure returns structured REPLY_FAILED error', async () => {
     const client = createMockClient({
-      post: vi.fn()
-        .mockRejectedValueOnce(new Error('404 Not Found')) // createReplyAll fails
-        .mockResolvedValueOnce({ id: 'sent-msg' }), // sendMail fallback
-      get: vi.fn().mockResolvedValue({
-        id: 'deleted-msg',
-        subject: 'Deleted',
-        from: { emailAddress: { address: 'alice@corp.com' } },
-        receivedDateTime: '2024-03-15T10:00:00Z',
-      }),
+      post: vi.fn().mockRejectedValueOnce(new GraphApiError(404, 'Not Found')),
     });
     const provider = new GraphEmailProvider(client);
 
     const result = await provider.replyToMessage('deleted-msg', 'Response');
 
-    expect(result.success).toBe(true);
-    // Falls back to sendMail
-    expect(client.post).toHaveBeenCalledWith(
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('REPLY_FAILED');
+    expect(result.error?.recoverable).toBe(false);
+    expect(result.error?.message).toBeTruthy();
+    // Critical: does NOT silently send via sendMail
+    expect(client.post).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendMail'),
+      expect.anything(),
+    );
+  });
+
+  it('Scenario: replyToMessage failure does not use opts.cc as to:', async () => {
+    // Regression guard for the silent-fallback bug — even when cc is supplied,
+    // a createReplyAll failure must not turn into a fresh email to the cc list.
+    const client = createMockClient({
+      post: vi.fn().mockRejectedValueOnce(new GraphApiError(404, 'Not Found')),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.replyToMessage('deleted-msg', 'Response', {
+      cc: [{ email: 'bystander@corp.com' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(client.post).toHaveBeenCalledTimes(1); // only the failed createReplyAll
+  });
+
+  it('Scenario: send failure (createReplyAll succeeds, /send fails) returns REPLY_FAILED', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse())
+        .mockRejectedValueOnce(new GraphApiError(500, 'Server Error')),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.replyToMessage('msg-1', 'Response');
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('REPLY_FAILED');
+    expect(result.error?.message).toBeTruthy();
+  });
+
+  it('Scenario: PATCH failure inside prepareReplyDraft returns REPLY_FAILED', async () => {
+    // Helper-stage failure: createReplyAll succeeds, PATCH rejects. Previously
+    // this also fell into the broken sendMail fallback.
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+      patch: vi.fn().mockRejectedValueOnce(new GraphApiError(500, 'Server Error')),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.replyToMessage('msg-1', 'Response');
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('REPLY_FAILED');
+    // Critical: no /send and no /sendMail call
+    expect(client.post).not.toHaveBeenCalledWith(
+      expect.stringContaining('/send'),
+      expect.anything(),
+    );
+    expect(client.post).not.toHaveBeenCalledWith(
       expect.stringContaining('sendMail'),
       expect.anything(),
     );

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -412,7 +412,7 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
     expect(content.indexOf('<p>rendered</p>')).toBeLessThan(content.indexOf('just a fragment'));
   });
 
-  it('Scenario: createReplyAll failure returns structured REPLY_FAILED error', async () => {
+  it('Scenario: createReplyAll failure returns structured REPLY_FAILED', async () => {
     const client = createMockClient({
       post: vi.fn().mockRejectedValueOnce(new GraphApiError(404, 'Not Found')),
     });

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -315,17 +315,10 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       const draftId = await this.prepareReplyDraft(messageId, body, opts);
       await this.client.post(`${this.basePath}/messages/${draftId}/send`, {});
       return { success: true, messageId: draftId };
-    } catch {
-      // Fallback to sendMail on 404 (original deleted) or other failures
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send reply';
+      return { success: false, error: { code: 'REPLY_FAILED', message, recoverable: false } };
     }
-
-    // Fallback: construct reply manually via sendMail
-    return this.sendMessage({
-      to: opts?.cc ?? [],
-      subject: `Re: `,
-      body,
-      bodyHtml: opts?.bodyHtml,
-    });
   }
 
   async createDraft(msg: ComposeMessage): Promise<DraftResult> {


### PR DESCRIPTION
## Summary

- Drop the silent sendMail fallback in `GraphEmailProvider.replyToMessage`. When `createReplyAll` (or any subsequent step in `prepareReplyDraft` / `/send`) throws, return a structured `{ success: false, error: { code: 'REPLY_FAILED', recoverable: false } }` instead of a fresh email to `opts?.cc`.
- Mirrors the failure shape already used by `createReplyDraft`.
- Replace the existing test that asserted the broken behavior; add 4 new failure-path tests (createReplyAll throw, opts.cc regression guard, /send failure, PATCH failure inside the helper).

## Why not "hydrate then sendMail"?

A sendMail-based reply has no `In-Reply-To` / `References` headers, so even with the original `to` / `subject` / `cc` correctly hydrated, recipients' clients won't thread it. Faking a reply via sendMail is structurally inferior to a loud failure — the caller is in a better position to decide whether to send a fresh email.

## Scope note

This is a provider-layer fix. `replyToEmailAction` already prefetches the original message via `ctx.provider.getMessage(input.message_id)` (`packages/email-core/src/actions/reply.ts:102`), so the issue's literal repro (delete the message, then call `reply_to_email`) currently surfaces as `PROVIDER_UNAVAILABLE` from the lazy server wrapper, not from `replyToMessage`. The provider bug is real and worth fixing for any other failure mode (auth, transient errors, malformed IDs that pass `getMessage` but fail `createReplyAll`); aligning the action layer to translate `MESSAGE_NOT_FOUND` into `REPLY_FAILED` is a separate concern.

## Test plan

- [x] `npm run -w @usejunior/provider-microsoft test:run` — 114/114 (4 new tests added).
- [x] `npm run test:run` — all suites green (525 tests across 4 packages).
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.
- [ ] Manual: skipped. Reproducing requires a real Graph 4xx/5xx, which isn't safe to run against the user's mailbox. Mocked tests (especially the "no sendMail call after failure" assertion) are the regression guard.

Closes #50