### PR TITLE
fix(provider-microsoft): populate attachments on getMessage (fixes #55)

### DIFF
--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -41,6 +41,131 @@ function quotedReplyResponse(overrides: Record<string, unknown> = {}): Record<st
   };
 }
 
+describe('provider-microsoft/Message Mapping', () => {
+  it('Scenario: getMessage maps Graph attachment metadata and inline content ids', async () => {
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValue({
+        id: 'msg-attachments',
+        subject: 'Attachments',
+        from: { emailAddress: { address: 'sender@example.com' } },
+        toRecipients: [{ emailAddress: { address: 'recipient@example.com' } }],
+        receivedDateTime: '2026-04-09T12:00:00Z',
+        hasAttachments: true,
+        attachments: [
+          {
+            id: 'att-pdf',
+            '@odata.type': '#microsoft.graph.fileAttachment',
+            name: 'contract.pdf',
+            contentType: 'application/pdf',
+            size: 245000,
+            isInline: false,
+          },
+          {
+            id: 'att-inline',
+            '@odata.type': '#microsoft.graph.fileAttachment',
+            name: 'inline.png',
+            contentType: 'image/png',
+            size: 1024,
+            isInline: true,
+            contentId: 'image001',
+          },
+        ],
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-attachments');
+
+    expect(msg.hasAttachments).toBe(true);
+    expect(msg.attachments).toEqual([
+      {
+        id: 'att-pdf',
+        filename: 'contract.pdf',
+        mimeType: 'application/pdf',
+        size: 245000,
+        contentId: undefined,
+        isInline: false,
+      },
+      {
+        id: 'att-inline',
+        filename: 'inline.png',
+        mimeType: 'image/png',
+        size: 1024,
+        contentId: 'image001',
+        isInline: true,
+      },
+    ]);
+    expect(client.get).toHaveBeenCalledWith(
+      '/me/messages/msg-attachments?$expand=attachments($select=id,name,contentType,size,isInline,contentId)',
+    );
+  });
+
+  it('Scenario: getMessage falls back to /attachments when expanded query is rejected', async () => {
+    const client = createMockClient({
+      get: vi.fn()
+        .mockRejectedValueOnce(new GraphApiError(400, 'Bad Request'))
+        .mockResolvedValueOnce({
+          id: 'msg-attachments',
+          subject: 'Attachments',
+          from: { emailAddress: { address: 'sender@example.com' } },
+          toRecipients: [{ emailAddress: { address: 'recipient@example.com' } }],
+          receivedDateTime: '2026-04-09T12:00:00Z',
+          hasAttachments: true,
+        })
+        .mockResolvedValueOnce({
+          value: [
+            {
+              id: 'att-pdf',
+              name: 'contract.pdf',
+              contentType: 'application/pdf',
+              size: 245000,
+              isInline: false,
+            },
+            {
+              id: 'att-inline',
+              name: 'inline.png',
+              contentType: 'image/png',
+              size: 1024,
+              isInline: true,
+              contentId: 'image001',
+            },
+          ],
+        }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-attachments');
+
+    expect(msg.attachments).toEqual([
+      {
+        id: 'att-pdf',
+        filename: 'contract.pdf',
+        mimeType: 'application/pdf',
+        size: 245000,
+        contentId: undefined,
+        isInline: false,
+      },
+      {
+        id: 'att-inline',
+        filename: 'inline.png',
+        mimeType: 'image/png',
+        size: 1024,
+        contentId: 'image001',
+        isInline: true,
+      },
+    ]);
+    expect(client.get).toHaveBeenNthCalledWith(
+      1,
+      '/me/messages/msg-attachments?$expand=attachments($select=id,name,contentType,size,isInline,contentId)',
+    );
+    expect(client.get).toHaveBeenNthCalledWith(2, '/me/messages/msg-attachments');
+    expect(client.get).toHaveBeenNthCalledWith(
+      3,
+      '/me/messages/msg-attachments/attachments?$select=id,name,contentType,size,isInline,contentId',
+    );
+  });
+});
+
 describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
   it('Scenario: Reply preserves Graph auto-quoted thread (plain text)', async () => {
     const client = createMockClient({
@@ -603,7 +728,10 @@ describe('provider-microsoft/Thread Lookup', () => {
 
     expect(thread.id).toBe('conv-123');
     expect(thread.messageCount).toBe(2);
-    expect(client.get).toHaveBeenNthCalledWith(1, '/me/messages/msg-1');
+    expect(client.get).toHaveBeenNthCalledWith(
+      1,
+      '/me/messages/msg-1?$expand=attachments($select=id,name,contentType,size,isInline,contentId)',
+    );
     const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[1]![0] as string;
     const decodedUrl = decodeURIComponent(url).replaceAll('+', ' ');
     expect(decodedUrl).toContain("conversationId eq 'conv-123'");

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -1,5 +1,6 @@
 // GraphEmailProvider — Microsoft Graph API email provider
 import type {
+  EmailAttachment,
   EmailMessage,
   EmailThread,
   ComposeMessage,
@@ -43,6 +44,7 @@ export interface GraphApiClient {
 
 /** Delta query select fields for efficiency */
 const DELTA_SELECT = '$select=subject,from,toRecipients,ccRecipients,receivedDateTime,hasAttachments,isRead,id';
+const ATTACHMENT_SELECT = 'id,name,contentType,size,isInline,contentId';
 
 /** Result from delta query, including messages and the deltaLink for persistence */
 export interface DeltaResult {
@@ -172,8 +174,26 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async getMessage(id: string): Promise<EmailMessage> {
-    const response = await this.client.get(`${this.basePath}/messages/${id}`) as unknown as GraphMessage;
-    return mapGraphMessage(response);
+    const expandedUrl = `${this.basePath}/messages/${id}?$expand=attachments($select=${ATTACHMENT_SELECT})`;
+
+    try {
+      const response = await this.client.get(expandedUrl) as unknown as GraphMessage;
+      return mapGraphMessage(response);
+    } catch (err) {
+      // Some mailboxes reject nested $select inside $expand; fall back to a
+      // second metadata-only attachments request rather than dropping data.
+      if (!(err instanceof GraphApiError) || err.status !== 400) throw err;
+    }
+
+    const message = await this.client.get(`${this.basePath}/messages/${id}`) as unknown as GraphMessage;
+    const attachments = await this.client.get(
+      `${this.basePath}/messages/${id}/attachments?$select=${ATTACHMENT_SELECT}`,
+    );
+
+    return mapGraphMessage({
+      ...message,
+      attachments: ((attachments.value ?? []) as GraphAttachment[]),
+    });
   }
 
   async searchMessages(query: string, folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]> {
@@ -489,6 +509,17 @@ interface GraphMessage {
   flag?: { flagStatus?: string };
   internetMessageId?: string;
   internetMessageHeaders?: Array<{ name: string; value: string }>;
+  attachments?: GraphAttachment[];
+}
+
+interface GraphAttachment {
+  id: string;
+  '@odata.type'?: string;
+  name?: string;
+  contentType?: string;
+  size?: number;
+  isInline?: boolean;
+  contentId?: string;
 }
 
 /** A single item in a delta response — may include @removed for tombstones */
@@ -504,6 +535,15 @@ interface DeltaPageResponse {
 }
 
 function mapGraphMessage(msg: GraphMessage): EmailMessage {
+  const attachments = (msg.attachments ?? []).map((attachment): EmailAttachment => ({
+    id: attachment.id,
+    filename: attachment.name ?? '',
+    mimeType: attachment.contentType ?? 'application/octet-stream',
+    size: attachment.size ?? 0,
+    isInline: attachment.isInline ?? false,
+    contentId: attachment.contentId,
+  }));
+
   return {
     id: msg.id,
     subject: msg.subject ?? '',
@@ -525,6 +565,7 @@ function mapGraphMessage(msg: GraphMessage): EmailMessage {
     hasAttachments: msg.hasAttachments ?? false,
     body: msg.body?.contentType?.toLowerCase() === 'text' ? msg.body.content : undefined,
     bodyHtml: msg.body?.contentType?.toLowerCase() === 'html' ? msg.body.content : undefined,
+    attachments,
     labels: msg.categories,
     conversationId: msg.conversationId,
     messageId: msg.internetMessageId,


### PR DESCRIPTION
## Summary
- fix `GraphEmailProvider.getMessage()` to request Microsoft Graph attachment metadata with `$expand=attachments($select=id,name,contentType,size,isInline,contentId)`
- fall back to `GET /messages/{id}/attachments?$select=...` when Graph rejects the nested `$select`
- map Graph attachment metadata into `EmailMessage.attachments` so `list_attachments` returns both file and inline attachments instead of `[]`
- add regression coverage for both the expanded-fetch path and the fallback attachments endpoint

## Root Cause
`list_attachments` reads from `ctx.provider.getMessage(message_id)`, but the Microsoft provider previously fetched only the message record and never populated `EmailMessage.attachments`. The core action then defensively coerced that missing field to `[]`.

## Tests
- `Scenario: getMessage maps Graph attachment metadata and inline content ids`
- `Scenario: getMessage falls back to /attachments when expanded query is rejected`
- `npm run test:run -w @usejunior/provider-microsoft -- src/email-graph-provider.test.ts`
- `npm run test:run`
- `npm run build`

Fixes #55.
