### PR TITLE
fix(email-core): enforce reply allowlist for reply-all recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Agent Email exposes 15 MCP tools:
 | `get_mailbox_status` | Connection status and warnings | read |
 | `get_thread` | Full conversation context | read |
 | `send_email` | Send new email (allowlist-gated) | write |
-| `reply_to_email` | Reply with RFC threading | write |
+| `reply_to_email` | Reply within thread (allowlist-gated on send) | write |
 | `create_draft` | Create email draft | write |
 | `update_draft` | Update draft content | write |
 | `send_draft` | Send a saved draft | write |

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { replyToEmailAction } from './reply.js';
-import type { ActionContext, MailboxEntry } from './registry.js';
+import type { ActionContext } from './registry.js';
 
 let provider: MockEmailProvider;
 let ctx: ActionContext;
@@ -22,6 +22,10 @@ beforeEach(() => {
   });
   ctx = {
     provider,
+    mailboxName: 'work',
+    allMailboxes: [
+      { name: 'work', emailAddress: 'me@company.com', provider, providerType: 'microsoft', isDefault: true, status: 'connected' },
+    ],
     sendAllowlist: { entries: ['*@lawfirm.com'] },
   };
 });
@@ -74,6 +78,81 @@ describe('email-write/Reply to Email', () => {
 
     expect(result.success).toBe(false);
     expect(result.error!.message).toContain('mailbox parameter required when multiple mailboxes are configured');
+  });
+});
+
+describe('email-write/Reply Allowlist Coverage', () => {
+  it('Scenario: reply_all blocks non-allowlisted thread cc recipients', async () => {
+    const replySpy = vi.spyOn(provider, 'replyToMessage');
+    const ccMsgId = 'reply_all_cc_1234567890';
+    provider.addMessage({
+      id: ccMsgId,
+      subject: 'Shared thread',
+      from: { email: 'partner@lawfirm.com', name: 'Partner' },
+      to: [{ email: 'me@company.com' }],
+      cc: [{ email: 'external@example.com', name: 'External' }],
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const input = replyToEmailAction.input.parse({
+      message_id: ccMsgId,
+      body: 'Reply all',
+    });
+
+    const result = await replyToEmailAction.run(ctx, input);
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(result.error!.message).toContain('Recipient not in send allowlist');
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: reply_all false ignores non-allowlisted thread cc recipients', async () => {
+    const replySpy = vi.spyOn(provider, 'replyToMessage');
+    const ccMsgId = 'sender_only_cc_1234567890';
+    provider.addMessage({
+      id: ccMsgId,
+      subject: 'Shared thread',
+      from: { email: 'partner@lawfirm.com', name: 'Partner' },
+      to: [{ email: 'me@company.com' }],
+      cc: [{ email: 'external@example.com', name: 'External' }],
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const input = replyToEmailAction.input.parse({
+      message_id: ccMsgId,
+      body: 'Sender only',
+      reply_all: false,
+    });
+
+    const result = await replyToEmailAction.run(ctx, input);
+
+    expect(result.success).toBe(true);
+    expect(replySpy).toHaveBeenCalledWith(
+      ccMsgId,
+      expect.any(String),
+      expect.objectContaining({ replyAll: false }),
+    );
+  });
+
+  it('Scenario: explicit cc recipients are also gated by allowlist', async () => {
+    const replySpy = vi.spyOn(provider, 'replyToMessage');
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Loop in external',
+      reply_all: false,
+      cc: ['external@example.com'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(result.error!.message).toContain('Recipient not in send allowlist');
+    expect(replySpy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -1,6 +1,7 @@
 // reply_to_email action — reply within existing thread, gated by send allowlist
 import { z } from 'zod';
-import type { EmailAction } from './registry.js';
+import type { ActionContext, EmailAction } from './registry.js';
+import type { EmailMessage } from '../types.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { isPlausibleMessageId } from '../security/reply-validation.js';
 import { withRetry } from '../providers/provider.js';
@@ -36,12 +37,71 @@ const ReplyToEmailOutput = z.object({
   }).optional(),
 });
 
+function collectCurrentMailboxEmails(ctx: ActionContext): Set<string> {
+  const currentMailboxEmails = new Set<string>();
+
+  if (ctx.mailboxName?.includes('@')) {
+    currentMailboxEmails.add(ctx.mailboxName.toLowerCase());
+  }
+
+  const resolvedMailbox = ctx.mailboxName
+    ? ctx.allMailboxes?.find(mailbox =>
+      mailbox.name.toLowerCase() === ctx.mailboxName!.toLowerCase()
+      || mailbox.emailAddress?.toLowerCase() === ctx.mailboxName!.toLowerCase(),
+    )
+    : (ctx.allMailboxes?.length === 1
+      ? ctx.allMailboxes[0]
+      : ctx.allMailboxes?.find(mailbox => mailbox.isDefault));
+
+  if (resolvedMailbox?.emailAddress) {
+    currentMailboxEmails.add(resolvedMailbox.emailAddress.toLowerCase());
+  }
+
+  return currentMailboxEmails;
+}
+
+function collectReplyAllowlistRecipients(
+  ctx: ActionContext,
+  originalMessage: EmailMessage,
+  input: z.infer<typeof ReplyToEmailInput>,
+): string[] {
+  const currentMailboxEmails = collectCurrentMailboxEmails(ctx);
+  const recipients: string[] = [];
+  const seen = new Set<string>();
+
+  const addRecipient = (email: string, opts?: { skipCurrentMailbox?: boolean }) => {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) return;
+    if (opts?.skipCurrentMailbox && currentMailboxEmails.has(normalized)) return;
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    recipients.push(email);
+  };
+
+  addRecipient(originalMessage.from.email);
+
+  if (input.reply_all !== false) {
+    for (const recipient of originalMessage.to) {
+      addRecipient(recipient.email, { skipCurrentMailbox: true });
+    }
+    for (const recipient of originalMessage.cc ?? []) {
+      addRecipient(recipient.email, { skipCurrentMailbox: true });
+    }
+  }
+
+  for (const recipient of input.cc ?? []) {
+    addRecipient(recipient);
+  }
+
+  return recipients;
+}
+
 export const replyToEmailAction: EmailAction<
   z.infer<typeof ReplyToEmailInput>,
   z.infer<typeof ReplyToEmailOutput>
 > = {
   name: 'reply_to_email',
-  description: 'Reply to an email within an existing thread. Default reply_all=true cc\'s the original thread; pass reply_all=false to reply only to the sender. Send path gated by send allowlist; draft path bypasses.',
+  description: 'Reply to an email within an existing thread. Default reply_all=true cc\'s the original thread; pass reply_all=false to reply only to the sender. Send path validates all effective recipients against the send allowlist; draft path bypasses.',
   input: ReplyToEmailInput,
   output: ReplyToEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -101,12 +161,12 @@ export const replyToEmailAction: EmailAction<
       }
     }
 
-    // Send path — get the original message to check the recipient against allowlist
+    // Send path — check every effective recipient against the allowlist
     const originalMessage = await ctx.provider.getMessage(input.message_id);
-    const replyRecipient = originalMessage.from.email;
+    const replyRecipients = collectReplyAllowlistRecipients(ctx, originalMessage, input);
 
     // Check send allowlist — reply recipients must also be allowed
-    const allowlistError = checkSendAllowlist([replyRecipient], ctx.sendAllowlist);
+    const allowlistError = checkSendAllowlist(replyRecipients, ctx.sendAllowlist);
     if (allowlistError) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

This closes the reply allowlist gap in `reply_to_email` when `reply_all` is enabled.

- validate the full effective recipient set before sending a reply
- include caller-supplied `cc` addresses in the allowlist gate
- skip the current mailbox only for auto-expanded thread recipients so reply-all does not self-block
- add regression coverage for reply-all thread CCs, sender-only replies, and explicit CCs
- update the tool reference wording to reflect send-path allowlist enforcement

## Root Cause

`reply_to_email` only checked `originalMessage.from.email` before calling the provider send path. When `reply_all` was left at its default `true`, provider reply expansion could still add non-allowlisted thread recipients, which bypassed the send allowlist.

## Impact

Outbound replies now fail before send if any effective reply recipient falls outside the send allowlist, which brings the action behavior back in line with the documented security model.

Fixes #57.

## Validation

- `npm run test:run -w @usejunior/email-core -- src/actions/reply.test.ts`
- `npm run lint -w @usejunior/email-core`
