### PR TITLE
fix(email-core): parse name-address strings in cc/to compose inputs

### DIFF
--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -3,6 +3,8 @@ import type { RateLimiter, MailboxEntry } from './registry.js';
 import { ProviderError } from '../providers/provider.js';
 import { resolveBodyFile } from '../content/body-loader.js';
 import type { BodyFormat } from '../content/body-renderer.js';
+import { parseAddressList } from '../utils/address.js';
+import type { EmailAddress } from '../types.js';
 
 // --- Error shape used by all actions ---
 
@@ -145,6 +147,36 @@ export function checkRateLimit(
     };
   }
   return null;
+}
+
+// --- parseRecipients ---
+
+export type ParsedRecipients =
+  | { to: EmailAddress[]; cc: EmailAddress[] }
+  | { error: ActionError };
+
+export function parseRecipients(input: { to?: string[]; cc?: string[] }): ParsedRecipients {
+  const toResult = parseAddressList(input.to, 'to');
+  if (!toResult.ok) {
+    return {
+      error: {
+        code: 'INVALID_ADDRESS',
+        message: `${toResult.field}[${toResult.index}] invalid address: "${toResult.value}"`,
+        recoverable: false,
+      },
+    };
+  }
+  const ccResult = parseAddressList(input.cc, 'cc');
+  if (!ccResult.ok) {
+    return {
+      error: {
+        code: 'INVALID_ADDRESS',
+        message: `${ccResult.field}[${ccResult.index}] invalid address: "${ccResult.value}"`,
+        recoverable: false,
+      },
+    };
+  }
+  return { to: toResult.addresses, cc: ccResult.addresses };
 }
 
 // --- handleProviderError ---

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -313,3 +313,113 @@ describe('email-write/Body Rendering', () => {
     expect(draft.bodyHtml).toBeUndefined();
   });
 });
+
+describe('email-write/Draft Address Parsing', () => {
+  it('create_draft parses name-address strings on standard path', async () => {
+    const result = await createDraftAction.run(ctx, {
+      to: ['Alice <alice@allowed.com>'],
+      cc: ['"Doe, Bob" <bob@allowed.com>'],
+      subject: 'Hi',
+      body: 'Hello',
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.to).toEqual([{ name: 'Alice', email: 'alice@allowed.com' }]);
+    expect(draft.cc).toEqual([{ name: 'Doe, Bob', email: 'bob@allowed.com' }]);
+  });
+
+  it('create_draft parses name-address cc on reply-draft path', async () => {
+    provider.addMessage({
+      id: 'reply-orig',
+      subject: 'Original',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'partner@allowed.com',
+      subject: 'Re: Original',
+      reply_to: 'reply-orig',
+      cc: ['Jane <jane@allowed.com>'],
+      body: 'Reply draft body',
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.cc).toEqual([{ name: 'Jane', email: 'jane@allowed.com' }]);
+  });
+
+  it('create_draft returns INVALID_ADDRESS for bad input', async () => {
+    const result = await createDraftAction.run(ctx, {
+      to: ['alice@allowed.com', 'not an email'],
+      subject: 'Bad',
+      body: 'Hi',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('INVALID_ADDRESS');
+    expect(result.error!.message).toContain('to[1]');
+    expect(provider.getDrafts().size).toBe(0);
+  });
+
+  it('update_draft parses name-address strings', async () => {
+    const created = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Original',
+      body: 'Body',
+    });
+    expect(created.success).toBe(true);
+
+    const updated = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      to: ['Alice Updated <alice@allowed.com>'],
+      cc: ['Bob <bob@allowed.com>'],
+    });
+
+    expect(updated.success).toBe(true);
+    const draft = provider.getDrafts().get(created.draftId!)!;
+    expect(draft.to).toEqual([{ name: 'Alice Updated', email: 'alice@allowed.com' }]);
+    expect(draft.cc).toEqual([{ name: 'Bob', email: 'bob@allowed.com' }]);
+  });
+
+  it('update_draft with cc: [] explicitly clears cc', async () => {
+    const created = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      cc: ['bob@allowed.com'],
+      subject: 'Original',
+      body: 'Body',
+    });
+    expect(created.success).toBe(true);
+
+    const updated = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      cc: [],
+    });
+
+    expect(updated.success).toBe(true);
+    const draft = provider.getDrafts().get(created.draftId!)!;
+    expect(draft.cc).toEqual([]);
+  });
+
+  it('update_draft returns INVALID_ADDRESS for bad input', async () => {
+    const created = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Original',
+      body: 'Body',
+    });
+    expect(created.success).toBe(true);
+
+    const updated = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      cc: ['not an email'],
+    });
+
+    expect(updated.success).toBe(false);
+    expect(updated.error!.code).toBe('INVALID_ADDRESS');
+    expect(updated.error!.message).toContain('cc[0]');
+  });
+});

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -12,6 +12,7 @@ import {
   validateRequiredFields,
   checkRateLimit,
   handleProviderError,
+  parseRecipients,
 } from './compose-helpers.js';
 
 // --- Shared schemas ---
@@ -75,6 +76,12 @@ export const createDraftAction: EmailAction<
 
     const recipients = Array.isArray(to) ? to : [to!];
 
+    // Parse name-address strings into {name, email} once before any provider call.
+    const parsed = parseRecipients({ to: recipients, cc });
+    if ('error' in parsed) {
+      return { success: false, error: parsed.error };
+    }
+
     // Drafts bypass allowlist — enforcement happens at send_draft time
 
     // Re: threading guardrail
@@ -106,7 +113,7 @@ export const createDraftAction: EmailAction<
       }
       try {
         const result = await ctx.provider.createReplyDraft(replyTo, body, {
-          cc: cc?.map(email => ({ email })),
+          cc: parsed.cc,
           bodyHtml: outBodyHtml,
         });
         return {
@@ -122,8 +129,8 @@ export const createDraftAction: EmailAction<
     // Standard draft path
     try {
       const result = await ctx.provider.createDraft({
-        to: recipients.map(email => ({ email })),
-        cc: cc?.map(email => ({ email })),
+        to: parsed.to,
+        cc: parsed.cc,
         subject: subject!,
         body,
         bodyHtml: outBodyHtml,
@@ -292,13 +299,19 @@ export const updateDraftAction: EmailAction<
       }
     }
 
-    // Build partial update
+    // Build partial update — parse name-address strings only for fields the caller actually provided.
     const partial: Partial<import('../types.js').ComposeMessage> = {};
-    if (to) {
-      const recipients = Array.isArray(to) ? to : [to];
-      partial.to = recipients.map(email => ({ email }));
+    if (to !== undefined || cc !== undefined) {
+      const parsed = parseRecipients({
+        to: to !== undefined ? (Array.isArray(to) ? to : [to]) : undefined,
+        cc,
+      });
+      if ('error' in parsed) {
+        return { success: false, error: parsed.error };
+      }
+      if (to !== undefined) partial.to = parsed.to;
+      if (cc !== undefined) partial.cc = parsed.cc;
     }
-    if (cc) partial.cc = cc.map(email => ({ email }));
     if (subject) partial.subject = subject;
     if (body) {
       const rendered = renderEmailBody(body, { format, forceBlack });

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -354,3 +354,57 @@ describe('email-write/Reply All Toggle', () => {
     );
   });
 });
+
+describe('email-write/Reply CC Address Parsing', () => {
+  it('Scenario: name-address cc string is parsed into {name, email} on send path', async () => {
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Looping in counsel',
+      reply_all: false,
+      cc: ['Jane Doe <jane@lawfirm.com>'],
+    });
+
+    expect(result.success).toBe(true);
+    const sent = provider.getSentMessages()[0]!;
+    expect(sent.cc).toEqual([{ name: 'Jane Doe', email: 'jane@lawfirm.com' }]);
+  });
+
+  it('Scenario: name-address cc string is parsed on draft path', async () => {
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Draft with cc',
+      draft: true,
+      cc: ['"Doe, Jane" <jane@lawfirm.com>'],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.cc).toEqual([{ name: 'Doe, Jane', email: 'jane@lawfirm.com' }]);
+  });
+
+  it('Scenario: invalid cc address returns INVALID_ADDRESS with field/index', async () => {
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Bad cc',
+      cc: ['jane@lawfirm.com', 'not an email'],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('INVALID_ADDRESS');
+    expect(result.error!.message).toContain('cc[1]');
+    expect(result.error!.message).toContain('not an email');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
+  it('Scenario: parsed cc email is what feeds the allowlist (no false reject for name-address form)', async () => {
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Looping in counsel',
+      reply_all: false,
+      cc: ['Jane <jane@lawfirm.com>'],
+    });
+
+    // sendAllowlist is *@lawfirm.com — parsed cc email matches; should pass.
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -1,7 +1,7 @@
 // reply_to_email action — reply within existing thread, gated by send allowlist
 import { z } from 'zod';
 import type { ActionContext, EmailAction } from './registry.js';
-import type { EmailMessage } from '../types.js';
+import type { EmailAddress, EmailMessage } from '../types.js';
 import { checkSendAllowlist } from '../security/send-allowlist.js';
 import { isPlausibleMessageId } from '../security/reply-validation.js';
 import { withRetry } from '../providers/provider.js';
@@ -10,6 +10,7 @@ import {
   checkMailboxRequired,
   checkRateLimit,
   handleProviderError,
+  parseRecipients,
 } from './compose-helpers.js';
 
 const ReplyToEmailInput = z.object({
@@ -63,7 +64,8 @@ function collectCurrentMailboxEmails(ctx: ActionContext): Set<string> {
 function collectReplyAllowlistRecipients(
   ctx: ActionContext,
   originalMessage: EmailMessage,
-  input: z.infer<typeof ReplyToEmailInput>,
+  parsedCc: EmailAddress[],
+  replyAll: boolean,
 ): string[] {
   const currentMailboxEmails = collectCurrentMailboxEmails(ctx);
   const recipients: string[] = [];
@@ -80,7 +82,7 @@ function collectReplyAllowlistRecipients(
 
   addRecipient(originalMessage.from.email);
 
-  if (input.reply_all !== false) {
+  if (replyAll) {
     for (const recipient of originalMessage.to) {
       addRecipient(recipient.email, { skipCurrentMailbox: true });
     }
@@ -89,8 +91,8 @@ function collectReplyAllowlistRecipients(
     }
   }
 
-  for (const recipient of input.cc ?? []) {
-    addRecipient(recipient);
+  for (const recipient of parsedCc) {
+    addRecipient(recipient.email);
   }
 
   return recipients;
@@ -124,6 +126,13 @@ export const replyToEmailAction: EmailAction<
       };
     }
 
+    // Parse cc once — name-address strings ('Jane <jane@x>') become {name, email}.
+    // Errors return INVALID_ADDRESS before any provider call or retry logic.
+    const parsed = parseRecipients({ cc: input.cc });
+    if ('error' in parsed) {
+      return { success: false, error: parsed.error };
+    }
+
     // Render body: markdown → HTML by default
     const rendered = renderEmailBody(input.body, { format: input.format, forceBlack: input.force_black });
     const bodyPlain = rendered.body;
@@ -143,7 +152,7 @@ export const replyToEmailAction: EmailAction<
       }
       try {
         const draftResult = await ctx.provider.createReplyDraft(input.message_id, bodyPlain, {
-          cc: input.cc?.map(email => ({ email })),
+          cc: parsed.cc,
           bodyHtml,
           replyAll: input.reply_all,
         });
@@ -163,7 +172,7 @@ export const replyToEmailAction: EmailAction<
 
     // Send path — check every effective recipient against the allowlist
     const originalMessage = await ctx.provider.getMessage(input.message_id);
-    const replyRecipients = collectReplyAllowlistRecipients(ctx, originalMessage, input);
+    const replyRecipients = collectReplyAllowlistRecipients(ctx, originalMessage, parsed.cc, input.reply_all !== false);
 
     // Check send allowlist — reply recipients must also be allowed
     const allowlistError = checkSendAllowlist(replyRecipients, ctx.sendAllowlist);
@@ -189,7 +198,7 @@ export const replyToEmailAction: EmailAction<
     try {
       const result = await withRetry(
         () => ctx.provider.replyToMessage(input.message_id, bodyPlain, {
-          cc: input.cc?.map(email => ({ email })),
+          cc: parsed.cc,
           bodyHtml,
           replyAll: input.reply_all,
         }),

--- a/packages/email-core/src/actions/send.test.ts
+++ b/packages/email-core/src/actions/send.test.ts
@@ -484,3 +484,75 @@ format: text
     expect(sent.bodyHtml).toBeUndefined();
   });
 });
+
+describe('email-write/Send Address Parsing', () => {
+  it('Scenario: name-address strings parse on send path (to + cc)', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: ['Alice <alice@allowed.com>'],
+      cc: ['"Doe, Bob" <bob@allowed.com>'],
+      subject: 'Hi',
+      body: 'Hello team',
+    });
+
+    expect(result.success).toBe(true);
+    const sent = provider.getSentMessages()[0]!;
+    expect(sent.to).toEqual([{ name: 'Alice', email: 'alice@allowed.com' }]);
+    expect(sent.cc).toEqual([{ name: 'Doe, Bob', email: 'bob@allowed.com' }]);
+  });
+
+  it('Scenario: name-address strings parse on draft path', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: 'Alice <alice@allowed.com>',
+      cc: ['Bob <bob@allowed.com>'],
+      subject: 'Draft hi',
+      body: 'Hello team',
+      draft: true,
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.to).toEqual([{ name: 'Alice', email: 'alice@allowed.com' }]);
+    expect(draft.cc).toEqual([{ name: 'Bob', email: 'bob@allowed.com' }]);
+  });
+
+  it('Scenario: name-address `to` is NOT falsely rejected by allowlist (regression guard)', async () => {
+    // Pre-fix, allowlist saw 'Alice <alice@allowed.com>' verbatim and rejected it.
+    // Post-fix, allowlist receives the parsed bare email and accepts.
+    const result = await sendEmailAction.run(ctx, {
+      to: 'Alice <alice@allowed.com>',
+      subject: 'Hi',
+      body: 'Hello',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('Scenario: invalid `to` returns INVALID_ADDRESS with field/index', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: ['alice@allowed.com', 'not an email'],
+      subject: 'Bad',
+      body: 'Hi',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('INVALID_ADDRESS');
+    expect(result.error!.message).toContain('to[1]');
+    expect(result.error!.message).toContain('not an email');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
+  it('Scenario: invalid `cc` returns INVALID_ADDRESS even on draft path', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      cc: ['bob@allowed.com', 'Alice <a@x>, Bob <b@y>'],
+      subject: 'Bad',
+      body: 'Hi',
+      draft: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('INVALID_ADDRESS');
+    expect(result.error!.message).toContain('cc[1]');
+    expect(provider.getDrafts().size).toBe(0);
+  });
+});

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -12,6 +12,7 @@ import {
   validateRequiredFields,
   checkRateLimit,
   handleProviderError,
+  parseRecipients,
 } from './compose-helpers.js';
 
 const SendEmailInput = z.object({
@@ -73,6 +74,13 @@ export const sendEmailAction: EmailAction<
     // Resolve recipients
     const recipients = Array.isArray(to) ? to : [to!];
 
+    // Parse name-address strings ('Jane <jane@x>') into {name, email} once,
+    // before allowlist or provider call, so both consume the same parsed list.
+    const parsed = parseRecipients({ to: recipients, cc });
+    if ('error' in parsed) {
+      return { success: false, error: parsed.error };
+    }
+
     // Re: threading guardrail
     const threadingError = checkReplyThreading(subject!);
     if (threadingError) {
@@ -98,8 +106,8 @@ export const sendEmailAction: EmailAction<
     // Draft workflow — skip allowlist check and rate limit
     if (draft) {
       const draftResult = await ctx.provider.createDraft({
-        to: recipients.map(email => ({ email })),
-        cc: cc?.map(email => ({ email })),
+        to: parsed.to,
+        cc: parsed.cc,
         subject: subject!,
         body,
         bodyHtml: outBodyHtml,
@@ -115,8 +123,8 @@ export const sendEmailAction: EmailAction<
       };
     }
 
-    // Send path — check allowlist
-    const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
+    // Send path — check allowlist (use parsed bare emails so name-address form passes correctly)
+    const allowlistError = checkSendAllowlist(parsed.to.map(a => a.email), ctx.sendAllowlist);
     if (allowlistError) {
       return {
         success: false,
@@ -134,8 +142,8 @@ export const sendEmailAction: EmailAction<
     try {
       const result = await withRetry(
         () => ctx.provider.sendMessage({
-          to: recipients.map(email => ({ email })),
-          cc: cc?.map(email => ({ email })),
+          to: parsed.to,
+          cc: parsed.cc,
           subject: subject!,
           body,
           bodyHtml: outBodyHtml,

--- a/packages/email-core/src/utils/address.test.ts
+++ b/packages/email-core/src/utils/address.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { parseAddressString, parseAddressList } from './address.js';
+
+describe('parseAddressString — positive cases', () => {
+  it('parses a bare email', () => {
+    expect(parseAddressString('jane@example.com')).toEqual({ email: 'jane@example.com' });
+  });
+
+  it('trims surrounding whitespace on bare email', () => {
+    expect(parseAddressString('  jane@example.com  ')).toEqual({ email: 'jane@example.com' });
+  });
+
+  it('parses name-address form', () => {
+    expect(parseAddressString('Jane Doe <jane@example.com>')).toEqual({
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+    });
+  });
+
+  it('parses quoted display name with comma', () => {
+    expect(parseAddressString('"Doe, Jane" <jane@example.com>')).toEqual({
+      name: 'Doe, Jane',
+      email: 'jane@example.com',
+    });
+  });
+
+  it('parses angle-only form (empty display name) without a name field', () => {
+    expect(parseAddressString('<jane@example.com>')).toEqual({ email: 'jane@example.com' });
+  });
+
+  it('tolerates inner whitespace around the angle brackets', () => {
+    expect(parseAddressString('Jane Doe   <  jane@example.com  >')).toEqual({
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+    });
+  });
+
+  it('parses Unicode display names', () => {
+    expect(parseAddressString('山田太郎 <yamada@example.jp>')).toEqual({
+      name: '山田太郎',
+      email: 'yamada@example.jp',
+    });
+  });
+});
+
+describe('parseAddressString — negative cases', () => {
+  it.each([
+    ['empty string', ''],
+    ['plain text', 'not an email'],
+    ['only angle brackets', '<@>'],
+    ['stray angle bracket', 'foo<bar'],
+    ['space-separated double email', 'a@b c@d'],
+    ['multi-address single string (comma)', 'Alice <a@example.com>, Bob <b@example.com>'],
+    ['multiple angle pairs', 'Name <one@x.com> <two@x.com>'],
+    ['unmatched outer quote', '"unbalanced <jane@example.com>'],
+    ['name with stray <', 'Bad < Name <jane@example.com>'],
+    ['no @ in bare', 'jane.example.com'],
+  ])('rejects %s', (_label, value) => {
+    expect(() => parseAddressString(value)).toThrow();
+  });
+});
+
+describe('parseAddressList', () => {
+  it('returns ok with empty array for undefined input', () => {
+    expect(parseAddressList(undefined, 'cc')).toEqual({ ok: true, addresses: [] });
+  });
+
+  it('returns ok with parsed addresses', () => {
+    const result = parseAddressList(
+      ['jane@example.com', 'Bob <bob@example.com>'],
+      'to',
+    );
+    expect(result).toEqual({
+      ok: true,
+      addresses: [
+        { email: 'jane@example.com' },
+        { name: 'Bob', email: 'bob@example.com' },
+      ],
+    });
+  });
+
+  it('returns offender (field, index, value) on first invalid entry', () => {
+    const result = parseAddressList(
+      ['jane@example.com', 'not an email', 'bob@example.com'],
+      'cc',
+    );
+    expect(result).toEqual({ ok: false, field: 'cc', index: 1, value: 'not an email' });
+  });
+
+  it('returns the first offender when multiple are invalid', () => {
+    const result = parseAddressList(['bad-1', 'bad-2'], 'to');
+    expect(result).toEqual({ ok: false, field: 'to', index: 0, value: 'bad-1' });
+  });
+});

--- a/packages/email-core/src/utils/address.ts
+++ b/packages/email-core/src/utils/address.ts
@@ -1,0 +1,50 @@
+import type { EmailAddress } from '../types.js';
+
+export class AddressParseError extends Error {
+  constructor(public readonly field: string, public readonly index: number, public readonly value: string) {
+    super(`${field}[${index}] invalid address: "${value}"`);
+    this.name = 'AddressParseError';
+  }
+}
+
+export function parseAddressString(raw: string): EmailAddress {
+  const trimmed = raw.trim();
+
+  // Reject stringly-multi-address inputs ('Alice <a@x>, Bob <b@y>') — multiple
+  // angle brackets signal a joined list, not a single entry.
+  const angleCount = (trimmed.match(/</g) ?? []).length;
+  if (angleCount > 1) throw new Error(`invalid address: "${raw}"`);
+
+  // Bare email (no angle brackets).
+  if (!trimmed.includes('<') && !trimmed.includes('>')) {
+    if (/^[^\s"<>@]+@[^\s"<>@]+$/.test(trimmed)) return { email: trimmed };
+    throw new Error(`invalid address: "${raw}"`);
+  }
+
+  // Name-address: either "quoted name" + <email>, or bare-name + <email>.
+  // Quotes must be balanced when present; bare name cannot contain '<' or '"'.
+  const m = /^\s*(?:"([^"]*)"|([^<"]*?))\s*<\s*([^\s"<>@]+@[^\s"<>@]+)\s*>\s*$/.exec(trimmed);
+  if (!m || m[3] === undefined) throw new Error(`invalid address: "${raw}"`);
+
+  const rawName = (m[1] ?? m[2] ?? '').trim();
+  const email = m[3];
+  return rawName ? { name: rawName, email } : { email };
+}
+
+export type ParsedList =
+  | { ok: true; addresses: EmailAddress[] }
+  | { ok: false; field: string; index: number; value: string };
+
+export function parseAddressList(raws: string[] | undefined, field: string): ParsedList {
+  if (!raws) return { ok: true, addresses: [] };
+  const out: EmailAddress[] = [];
+  for (let i = 0; i < raws.length; i++) {
+    const raw = raws[i] ?? '';
+    try {
+      out.push(parseAddressString(raw));
+    } catch {
+      return { ok: false, field, index: i, value: raw };
+    }
+  }
+  return { ok: true, addresses: out };
+}

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -364,6 +364,21 @@ describe('provider-gmail/buildRawMessage', () => {
     expect(raw).toContain('Bcc: legal@corp.com');
   });
 
+  it('Scenario: Cc with display name emits quoted name-address form', async () => {
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      cc: [{ name: 'Jane Doe', email: 'jane@corp.com' }],
+      subject: 'Hi',
+      body: 'Hello',
+    });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('Cc: "Jane Doe" <jane@corp.com>');
+  });
+
   it('Scenario: Cc and Bcc headers omitted when no recipients', async () => {
     const client = createMockGmailClient();
     const provider = new GmailEmailProvider(client);


### PR DESCRIPTION
## Summary

`read_email` returns recipients in `"Name <email>"` form, but the compose actions (`reply_to_email`, `send_email`, `create_draft`, `update_draft`) wrapped each input string blindly as `{email: rawString}`. The full `"Name <email>"` string ended up in `EmailAddress.email`, producing malformed `Cc:`/`To:` headers in Gmail (silent recipient drop) and corrupt `emailAddress.address` in Microsoft Graph.

Fixes #47.

## What changed

- New `packages/email-core/src/utils/address.ts` with `parseAddressString` + `parseAddressList`. Narrow on purpose — bare email, `Name <email>`, `"Quoted, Name" <email>`, `<email>`. Rejects multi-address strings (`Alice <a@x>, Bob <b@y>`), unbalanced quotes, and stray angle brackets.
- New `parseRecipients` helper in `compose-helpers.ts` that returns `{to, cc}` parsed or a structured `INVALID_ADDRESS` error.
- `reply.ts`, `send.ts`, `draft.ts` parse input recipients **once at the top of `run()`** and feed the parsed `EmailAddress[]` to both the allowlist check and the provider payload.
- `send.ts`'s allowlist now receives `parsed.to.map(a => a.email)` instead of raw strings — without this, passing `to: "Alice <alice@allowed.com>"` would be falsely rejected as not allowlisted.
- `update_draft` preserves the `cc: []` explicit-clear semantics.

Total non-test diff: ~80 lines.

## Scope notes (after peer review)

The minimal "swap the mapper" version of this fix would have introduced a regression in `send_email`'s allowlist enforcement. Both Gemini and Codex peer reviews flagged this and a related concern that throwing parse errors inside `withRetry` would cause spurious retries. The implemented version parses early and returns structured `INVALID_ADDRESS` before either allowlist or retry logic.

## Out of scope (follow-ups)

- `cc` is never explicitly allowlisted on `send_email`. This is a pre-existing concern that becomes more visible once parsing works correctly. Will file a separate issue.
- `list_emails` / `search_emails` schemas don't expose `to`/`cc`. Separate change.
- MS Graph sibling bug (#48) intentionally untouched.

## Test plan

- [x] `npm run test:run` — all 581 tests pass across 4 packages
- [x] Type-check clean across all 4 packages (`npm run lint --workspaces`)
- [x] Grep guard: zero remaining `.map(email => ({ email }))` call sites in source
- [x] New tests cover: parser unit cases (incl. multi-address rejection regression guard), allowlist-not-falsely-rejecting name-address `to`, structured `INVALID_ADDRESS` errors with field/index, `update_draft cc: []` explicit-clear, Gmail `Cc: "Name" <email>` serializer assertion

Observed 2026-04-24. Do not merge — please review.