### PR TITLE
refactor(email-core,provider-microsoft,provider-gmail,email-mcp): harden download_attachment (#68)

### DIFF
--- a/packages/email-core/src/actions/attachments.test.ts
+++ b/packages/email-core/src/actions/attachments.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { listAttachmentsAction, downloadAttachmentAction, detectMimeType, validateAttachment, sanitizeFilename } from './attachments.js';
-import { AttachmentNotSupportedError } from '../providers/provider.js';
+import { AttachmentNotSupportedError, AttachmentNotFoundError } from '../providers/provider.js';
 import type { ActionContext } from './registry.js';
 
 let provider: MockEmailProvider;
@@ -31,6 +31,7 @@ describe('email-attachments/Download Attachments', () => {
     expect(result.attachments[0]).toMatchObject({
       id: 'att1',
       filename: 'report.pdf',
+      original_filename: 'report.pdf',
       mimeType: 'application/pdf',
       size: 245000,
       isInline: false,
@@ -40,12 +41,28 @@ describe('email-attachments/Download Attachments', () => {
       isInline: true,
     });
   });
+
+  it('Scenario: list_attachments preserves the raw filename in original_filename even when sanitization mangles it', async () => {
+    provider.addMessage({
+      id: 'msg-i18n',
+      hasAttachments: true,
+      attachments: [
+        { id: 'att-i18n', filename: 'Räsumé (Final).pdf', mimeType: 'application/pdf', size: 1024, isInline: false },
+      ],
+    });
+
+    const result = await listAttachmentsAction.run(ctx, { message_id: 'msg-i18n' });
+
+    expect(result.attachments[0]!.original_filename).toBe('Räsumé (Final).pdf');
+    expect(result.attachments[0]!.filename).toMatch(/\.pdf$/);
+    expect(result.attachments[0]!.filename).not.toContain('(');
+  });
 });
 
 describe('email-attachments/Download Attachment', () => {
   const PDF_BYTES = Buffer.from('%PDF-1.4 fake pdf body for tests');
 
-  it('Scenario: Happy path returns sanitized filename, declared mimeType, and round-trippable base64', async () => {
+  it('Scenario: Happy path returns sanitized filename, original_filename, declared mimeType, and round-trippable base64', async () => {
     provider.addMessage({
       id: 'msg-dl',
       hasAttachments: true,
@@ -66,19 +83,41 @@ describe('email-attachments/Download Attachment', () => {
     expect(result.size).toBe(PDF_BYTES.length);
     expect(result.filename).not.toContain('(');
     expect(result.filename).toMatch(/\.pdf$/);
+    expect(result.original_filename).toBe('Report (Final).pdf');
     expect(Buffer.from(result.base64!, 'base64').equals(PDF_BYTES)).toBe(true);
   });
 
-  it('Scenario: Pre-download size rejection — declared size exceeds cap, downloadAttachment is not called', async () => {
+  it('Scenario: Non-ASCII filename round-trips through original_filename while filename gets sanitized', async () => {
+    provider.addMessage({
+      id: 'msg-i18n',
+      hasAttachments: true,
+      attachments: [
+        { id: 'att-i18n', filename: 'Räsumé.pdf', mimeType: 'application/pdf', size: PDF_BYTES.length, isInline: false },
+      ],
+    });
+    provider.addAttachmentData('msg-i18n', 'att-i18n', PDF_BYTES);
+
+    const result = await downloadAttachmentAction.run(ctx, {
+      message_id: 'msg-i18n',
+      attachment_id: 'att-i18n',
+      max_size_mb: 5,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.original_filename).toBe('Räsumé.pdf');
+    expect(result.filename).toMatch(/\.pdf$/);
+  });
+
+  it('Scenario: Size rejection when downloaded payload exceeds the cap', async () => {
+    const actualBuf = Buffer.alloc(2 * 1024 * 1024);
     provider.addMessage({
       id: 'msg-big',
       hasAttachments: true,
       attachments: [
-        { id: 'att-big', filename: 'huge.pdf', mimeType: 'application/pdf', size: 2 * 1024 * 1024, isInline: false },
+        { id: 'att-big', filename: 'huge.bin', mimeType: 'application/octet-stream', size: actualBuf.length, isInline: false },
       ],
     });
-    provider.addAttachmentData('msg-big', 'att-big', Buffer.alloc(2 * 1024 * 1024));
-    const downloadSpy = vi.spyOn(provider, 'downloadAttachment');
+    provider.addAttachmentData('msg-big', 'att-big', actualBuf);
 
     const result = await downloadAttachmentAction.run(ctx, {
       message_id: 'msg-big',
@@ -89,30 +128,6 @@ describe('email-attachments/Download Attachment', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('ATTACHMENT_TOO_LARGE');
     expect(result.error?.message).toMatch(/exceeds max_size_mb=1/);
-    expect(downloadSpy).not.toHaveBeenCalled();
-  });
-
-  it('Scenario: Post-download size rejection — provider lies about size, actual buffer overruns the cap', async () => {
-    const declaredSize = 100;
-    const actualBuf = Buffer.alloc(2 * 1024 * 1024);
-    provider.addMessage({
-      id: 'msg-liar',
-      hasAttachments: true,
-      attachments: [
-        { id: 'att-liar', filename: 'liar.bin', mimeType: 'application/octet-stream', size: declaredSize, isInline: false },
-      ],
-    });
-    provider.addAttachmentData('msg-liar', 'att-liar', actualBuf);
-
-    const result = await downloadAttachmentAction.run(ctx, {
-      message_id: 'msg-liar',
-      attachment_id: 'att-liar',
-      max_size_mb: 1,
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.error?.code).toBe('ATTACHMENT_TOO_LARGE');
-    expect(result.error?.message).toMatch(new RegExp(`${actualBuf.length} bytes`));
   });
 
   it('Scenario: NOT_SUPPORTED when provider lacks downloadAttachment', async () => {
@@ -128,7 +143,7 @@ describe('email-attachments/Download Attachment', () => {
     expect(result.error?.code).toBe('NOT_SUPPORTED');
   });
 
-  it('Scenario: ATTACHMENT_NOT_FOUND when attachment id is missing from listAttachments', async () => {
+  it('Scenario: ATTACHMENT_NOT_FOUND when provider throws AttachmentNotFoundError (race deletion or bad id)', async () => {
     provider.addMessage({
       id: 'msg-empty',
       hasAttachments: true,
@@ -147,14 +162,23 @@ describe('email-attachments/Download Attachment', () => {
     expect(result.error?.code).toBe('ATTACHMENT_NOT_FOUND');
   });
 
-  it('Scenario: NOT_SUPPORTED when provider throws AttachmentNotSupportedError during download (e.g. Graph itemAttachment)', async () => {
-    provider.addMessage({
-      id: 'msg-item',
-      hasAttachments: true,
-      attachments: [
-        { id: 'att-item', filename: 'embedded.eml', mimeType: 'message/rfc822', size: 1000, isInline: false },
-      ],
+  it('Scenario: explicit AttachmentNotFoundError thrown by provider maps to ATTACHMENT_NOT_FOUND', async () => {
+    vi.spyOn(provider, 'downloadAttachment').mockRejectedValue(
+      new AttachmentNotFoundError('race-deleted attachment'),
+    );
+
+    const result = await downloadAttachmentAction.run(ctx, {
+      message_id: 'msg-deleted',
+      attachment_id: 'att-deleted',
+      max_size_mb: 5,
     });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('ATTACHMENT_NOT_FOUND');
+    expect(result.error?.message).toMatch(/race-deleted/);
+  });
+
+  it('Scenario: NOT_SUPPORTED when provider throws AttachmentNotSupportedError during download (e.g. Graph itemAttachment)', async () => {
     vi.spyOn(provider, 'downloadAttachment').mockRejectedValue(
       new AttachmentNotSupportedError('Attachment att-item has @odata.type=#microsoft.graph.itemAttachment'),
     );
@@ -170,8 +194,8 @@ describe('email-attachments/Download Attachment', () => {
     expect(result.error?.message).toMatch(/itemAttachment/);
   });
 
-  it('Scenario: Network errors are NOT swallowed as ATTACHMENT_NOT_FOUND — must propagate so wrapAction returns PROVIDER_UNAVAILABLE', async () => {
-    vi.spyOn(provider, 'listAttachments').mockRejectedValue(new Error('Network unreachable'));
+  it('Scenario: Network errors are NOT swallowed — must propagate so wrapAction returns PROVIDER_UNAVAILABLE', async () => {
+    vi.spyOn(provider, 'downloadAttachment').mockRejectedValue(new Error('Network unreachable'));
 
     await expect(
       downloadAttachmentAction.run(ctx, {

--- a/packages/email-core/src/actions/attachments.ts
+++ b/packages/email-core/src/actions/attachments.ts
@@ -2,7 +2,7 @@
 import { z } from 'zod';
 import { extname } from 'node:path';
 import type { EmailAction } from './registry.js';
-import { AttachmentNotSupportedError } from '../providers/provider.js';
+import { AttachmentNotSupportedError, AttachmentNotFoundError } from '../providers/provider.js';
 
 const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024; // 25MB
 
@@ -54,6 +54,7 @@ const ListAttachmentsInput = z.object({
 const AttachmentInfo = z.object({
   id: z.string(),
   filename: z.string(),
+  original_filename: z.string(),
   mimeType: z.string(),
   size: z.number(),
   contentId: z.string().optional(),
@@ -78,6 +79,7 @@ export const listAttachmentsAction: EmailAction<
     const attachments = (msg.attachments ?? []).map(a => ({
       id: a.id,
       filename: sanitizeFilename(a.filename),
+      original_filename: a.filename,
       mimeType: a.mimeType,
       size: a.size,
       contentId: a.contentId,
@@ -98,6 +100,7 @@ const DownloadAttachmentInput = z.object({
 const DownloadAttachmentOutput = z.object({
   success: z.boolean(),
   filename: z.string().optional(),
+  original_filename: z.string().optional(),
   mimeType: z.string().optional(),
   size: z.number().optional(),
   base64: z.string().optional(),
@@ -129,37 +132,10 @@ export const downloadAttachmentAction: EmailAction<
       };
     }
 
-    const attachments = ctx.provider.listAttachments
-      ? await ctx.provider.listAttachments(input.message_id)
-      : ((await ctx.provider.getMessage(input.message_id)).attachments ?? []);
-
-    const meta = attachments.find(a => a.id === input.attachment_id);
-    if (!meta) {
-      return {
-        success: false,
-        error: {
-          code: 'ATTACHMENT_NOT_FOUND',
-          message: `Attachment ${input.attachment_id} not found on message ${input.message_id}`,
-          recoverable: false,
-        },
-      };
-    }
-
     const cap = input.max_size_mb * 1024 * 1024;
-    if (meta.size > cap) {
-      return {
-        success: false,
-        error: {
-          code: 'ATTACHMENT_TOO_LARGE',
-          message: `Attachment is ${meta.size} bytes; exceeds max_size_mb=${input.max_size_mb} (${cap} bytes)`,
-          recoverable: false,
-        },
-      };
-    }
-
-    let buf: Buffer;
+    let downloaded;
     try {
-      buf = await ctx.provider.downloadAttachment(input.message_id, input.attachment_id);
+      downloaded = await ctx.provider.downloadAttachment(input.message_id, input.attachment_id);
     } catch (err) {
       if (err instanceof AttachmentNotSupportedError) {
         return {
@@ -167,15 +143,21 @@ export const downloadAttachmentAction: EmailAction<
           error: { code: 'NOT_SUPPORTED', message: err.message, recoverable: false },
         };
       }
+      if (err instanceof AttachmentNotFoundError) {
+        return {
+          success: false,
+          error: { code: 'ATTACHMENT_NOT_FOUND', message: err.message, recoverable: false },
+        };
+      }
       throw err;
     }
 
-    if (buf.length > cap) {
+    if (downloaded.size > cap || downloaded.content.length > cap) {
       return {
         success: false,
         error: {
           code: 'ATTACHMENT_TOO_LARGE',
-          message: `Downloaded attachment is ${buf.length} bytes; exceeds max_size_mb=${input.max_size_mb} (${cap} bytes)`,
+          message: `Attachment is ${downloaded.size} bytes; exceeds max_size_mb=${input.max_size_mb} (${cap} bytes)`,
           recoverable: false,
         },
       };
@@ -183,10 +165,11 @@ export const downloadAttachmentAction: EmailAction<
 
     return {
       success: true,
-      filename: sanitizeFilename(meta.filename),
-      mimeType: meta.mimeType,
-      size: buf.length,
-      base64: buf.toString('base64'),
+      filename: sanitizeFilename(downloaded.filename),
+      original_filename: downloaded.filename,
+      mimeType: downloaded.mimeType,
+      size: downloaded.content.length,
+      base64: downloaded.content.toString('base64'),
     };
   },
 };

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -18,10 +18,11 @@ export type {
   EmailSubscriber,
   EmailCategorizer,
   EmailAttachmentHandler,
+  DownloadedAttachment,
   EmailProvider,
   AuthManager,
 } from './providers/provider.js';
-export { AttachmentNotSupportedError } from './providers/provider.js';
+export { AttachmentNotSupportedError, AttachmentNotFoundError } from './providers/provider.js';
 export {
   isAllowedSender,
   loadReceiveAllowlist,

--- a/packages/email-core/src/providers/provider.ts
+++ b/packages/email-core/src/providers/provider.ts
@@ -41,9 +41,16 @@ export interface EmailCategorizer {
   deleteMessage(messageId: string, hard?: boolean): Promise<void>;
 }
 
+export interface DownloadedAttachment {
+  content: Buffer;
+  filename: string;
+  mimeType: string;
+  size: number;
+}
+
 export interface EmailAttachmentHandler {
   listAttachments(messageId: string): Promise<import('../types.js').EmailAttachment[]>;
-  downloadAttachment(messageId: string, attachmentId: string): Promise<Buffer>;
+  downloadAttachment(messageId: string, attachmentId: string): Promise<DownloadedAttachment>;
 }
 
 // Combined provider type — providers implement what they support
@@ -102,6 +109,17 @@ export class AttachmentNotSupportedError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'AttachmentNotSupportedError';
+  }
+}
+
+// Thrown by providers when the requested attachment id does not exist on the
+// message (e.g. Graph 404 on the bytes call after a race deletion). The
+// download_attachment action remaps this to { code: 'ATTACHMENT_NOT_FOUND' }
+// so race-deleted attachments surface with the same code as a stale id.
+export class AttachmentNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AttachmentNotFoundError';
   }
 }
 

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -12,11 +12,13 @@ import type {
 } from '../types.js';
 import {
   ProviderError,
+  AttachmentNotFoundError,
   type EmailReader,
   type EmailSender,
   type EmailSubscriber,
   type EmailCategorizer,
   type EmailAttachmentHandler,
+  type DownloadedAttachment,
 } from '../providers/provider.js';
 
 export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscriber, EmailCategorizer, EmailAttachmentHandler {
@@ -368,10 +370,17 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
     return msg.attachments ?? [];
   }
 
-  async downloadAttachment(messageId: string, attachmentId: string): Promise<Buffer> {
+  async downloadAttachment(messageId: string, attachmentId: string): Promise<DownloadedAttachment> {
     this.maybeThrow();
     const data = this.attachmentData.get(`${messageId}:${attachmentId}`);
-    if (!data) throw new Error(`Attachment not found: ${attachmentId}`);
-    return data;
+    if (!data) throw new AttachmentNotFoundError(`Attachment not found: ${attachmentId}`);
+    const msg = this.messages.find(m => m.id === messageId);
+    const meta = msg?.attachments?.find(a => a.id === attachmentId);
+    return {
+      content: data,
+      filename: meta?.filename ?? attachmentId,
+      mimeType: meta?.mimeType ?? 'application/octet-stream',
+      size: data.length,
+    };
   }
 }

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -52,8 +52,85 @@ describe('mcp-transport/stdio Transport', () => {
 
     expect(result.content).toHaveLength(1);
     expect(result.content[0]!.type).toBe('text');
-    const parsed = JSON.parse(result.content[0]!.text);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
     expect(parsed.emails).toBeDefined();
+  });
+
+  it('Scenario: download_attachment emits typed resource content alongside text metadata', async () => {
+    // Bytes go in a `resource` content item (typed binary), not stuffed inside
+    // the text JSON envelope. The text item still carries metadata so clients
+    // that only parse text still get filename/size/mimeType.
+    const PAYLOAD = Buffer.from('hello attachment bytes');
+    const downloadActions: EmailActionDef[] = [
+      {
+        name: 'download_attachment',
+        description: 'Download',
+        input: z.object({
+          message_id: z.string(),
+          attachment_id: z.string(),
+          mailbox: z.string().optional(),
+          max_size_mb: z.number().optional(),
+        }),
+        output: z.object({
+          success: z.boolean(),
+          base64: z.string().optional(),
+          mimeType: z.string().optional(),
+          filename: z.string().optional(),
+        }),
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        run: async () => ({
+          success: true,
+          base64: PAYLOAD.toString('base64'),
+          mimeType: 'application/pdf',
+          filename: 'note.pdf',
+          original_filename: 'note.pdf',
+          size: PAYLOAD.length,
+        }),
+      },
+    ];
+
+    const result = await handleToolCall(downloadActions, {}, 'download_attachment', {
+      mailbox: 'work',
+      message_id: 'msg-1',
+      attachment_id: 'att-1',
+    });
+
+    expect(result.content).toHaveLength(2);
+    expect(result.content[0]!.type).toBe('text');
+    const metadata = JSON.parse((result.content[0] as { text: string }).text);
+    expect(metadata).not.toHaveProperty('base64');
+    expect(metadata.filename).toBe('note.pdf');
+    expect(metadata.mimeType).toBe('application/pdf');
+
+    expect(result.content[1]!.type).toBe('resource');
+    const resourceContent = result.content[1] as { resource: { uri: string; mimeType?: string; blob?: string } };
+    expect(resourceContent.resource.mimeType).toBe('application/pdf');
+    expect(resourceContent.resource.uri).toBe('attachment://work/msg-1/att-1');
+    expect(Buffer.from(resourceContent.resource.blob!, 'base64').equals(PAYLOAD)).toBe(true);
+  });
+
+  it('Scenario: download_attachment failure case still uses single text envelope', async () => {
+    const downloadActions: EmailActionDef[] = [
+      {
+        name: 'download_attachment',
+        description: 'Download',
+        input: z.object({ message_id: z.string(), attachment_id: z.string() }),
+        output: z.object({ success: z.boolean() }),
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        run: async () => ({
+          success: false,
+          error: { code: 'NOT_SUPPORTED', message: 'no go', recoverable: false },
+        }),
+      },
+    ];
+
+    const result = await handleToolCall(downloadActions, {}, 'download_attachment', {
+      message_id: 'msg-1',
+      attachment_id: 'att-1',
+    });
+
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
   });
 });
 
@@ -874,6 +951,7 @@ describe('mcp-transport/Lazy Provider State', () => {
       {
         id: 'att-1',
         filename: 'license.jpeg',
+        original_filename: 'license.jpeg',
         mimeType: 'image/jpeg',
         size: 692702,
         contentId: undefined,
@@ -889,7 +967,12 @@ describe('mcp-transport/Lazy Provider State', () => {
     const personalListAttachments = vi.fn().mockResolvedValue([
       { id: 'att-1', filename: 'note.txt', mimeType: 'text/plain', size: PAYLOAD.length, isInline: false },
     ]);
-    const personalDownloadAttachment = vi.fn().mockResolvedValue(PAYLOAD);
+    const personalDownloadAttachment = vi.fn().mockResolvedValue({
+      content: PAYLOAD,
+      filename: 'note.txt',
+      mimeType: 'text/plain',
+      size: PAYLOAD.length,
+    });
 
     const state = createLazyProviderState();
     state.status = 'connected';
@@ -1095,7 +1178,7 @@ describe('mcp-transport/Scalar Coercion at Boundary', () => {
       },
     ];
     const result = await handleToolCall(echoActions, {}, 'echo', { flag: 'true', n: '42' });
-    const parsed = JSON.parse(result.content[0]!.text);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
     expect(parsed).toEqual({ flag: true, n: 42 });
   });
 
@@ -1136,7 +1219,7 @@ describe('mcp-transport/Scalar Coercion at Boundary', () => {
     expect(deleteMessage).not.toHaveBeenCalled();
 
     // The action should return a policy error indicating the missing consent.
-    const parsed = JSON.parse(result.content[0]!.text);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
     expect(parsed.success).toBe(false);
     expect(parsed.error.message).toMatch(/user_explicitly_requested_deletion must be true/);
   });
@@ -1169,7 +1252,7 @@ describe('mcp-transport/Scalar Coercion at Boundary', () => {
     });
 
     expect(deleteMessage).toHaveBeenCalledWith('msg-1', false);
-    const parsed = JSON.parse(result.content[0]!.text);
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
     expect(parsed.success).toBe(true);
   });
 });

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -74,8 +74,15 @@ export interface McpTool {
   annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
 }
 
+export type McpContent =
+  | { type: 'text'; text: string }
+  | {
+      type: 'resource';
+      resource: { uri: string; mimeType?: string; blob?: string; text?: string };
+    };
+
 export interface McpToolCallResult {
-  content: Array<{ type: string; text: string }>;
+  content: McpContent[];
 }
 
 export interface EmailActionDef {
@@ -224,6 +231,43 @@ export async function handleToolCall(
   const coerced = coerceArgsForZod(action.input, args);
   const input = action.input.parse(coerced);
   const result = await action.run(ctx, input);
+
+  // download_attachment returns base64 inline. To avoid stuffing megabytes of
+  // base64 inside the JSON-stringified text envelope (which agents have to
+  // parse to extract the bytes), emit the bytes as a typed `resource` content
+  // item alongside a text item carrying just the metadata. Clients that
+  // understand `resource` content can decode the blob directly; clients that
+  // only know `text` still see the metadata.
+  if (toolName === 'download_attachment') {
+    const r = result as {
+      success?: boolean;
+      base64?: string;
+      mimeType?: string;
+      filename?: string;
+      original_filename?: string;
+      size?: number;
+    } & Record<string, unknown>;
+    if (r.success && typeof r.base64 === 'string') {
+      const { base64, ...metadata } = r;
+      const messageId = (input as { message_id?: string }).message_id ?? 'unknown';
+      const attachmentId = (input as { attachment_id?: string }).attachment_id ?? 'unknown';
+      const mailbox = (input as { mailbox?: string }).mailbox ?? 'default';
+      const uri = `attachment://${encodeURIComponent(mailbox)}/${encodeURIComponent(messageId)}/${encodeURIComponent(attachmentId)}`;
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify(metadata, null, 2) },
+          {
+            type: 'resource',
+            resource: {
+              uri,
+              mimeType: r.mimeType ?? 'application/octet-stream',
+              blob: base64,
+            },
+          },
+        ],
+      };
+    }
+  }
 
   return {
     content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { GmailEmailProvider, type GmailApiClient } from './email-gmail-provider.js';
+import { AttachmentNotFoundError } from '@usejunior/email-core';
 
 function createMockGmailClient(overrides: Partial<GmailApiClient> = {}): GmailApiClient {
   return {
@@ -234,14 +235,15 @@ describe('provider-gmail/NemoClaw Compatibility', () => {
 });
 
 describe('provider-gmail/Attachment Retrieval', () => {
-  it('Scenario: downloadAttachment fetches Gmail attachment bytes by attachment id', async () => {
+  it('Scenario: downloadAttachment fetches Gmail attachment bytes by attachment id and returns metadata', async () => {
     const client = createMockGmailClient();
     const provider = new GmailEmailProvider(client);
 
-    const bytes = await provider.downloadAttachment('msg-1', 'att-1');
+    const result = await provider.downloadAttachment('msg-1', 'att-1');
 
     expect(client.getAttachment).toHaveBeenCalledWith('msg-1', 'att-1');
-    expect(bytes.toString('utf-8')).toBe('attachment bytes');
+    expect(result.content.toString('utf-8')).toBe('attachment bytes');
+    expect(result.size).toBe(result.content.length);
   });
 
   it('Scenario: downloadAttachment falls back to inline part data for synthetic ids', async () => {
@@ -258,6 +260,7 @@ describe('provider-gmail/Attachment Retrieval', () => {
           parts: [
             {
               mimeType: 'image/png',
+              filename: 'logo.png',
               body: { data: Buffer.from('tiny-image').toString('base64url') },
               headers: [{ name: 'Content-ID', value: '<image002>' }],
             },
@@ -267,10 +270,96 @@ describe('provider-gmail/Attachment Retrieval', () => {
     });
     const provider = new GmailEmailProvider(client);
 
-    const bytes = await provider.downloadAttachment('msg-inline-body', 'part:0');
+    const result = await provider.downloadAttachment('msg-inline-body', 'part:0');
 
     expect(client.getAttachment).not.toHaveBeenCalled();
-    expect(bytes.toString('utf-8')).toBe('tiny-image');
+    expect(result.content.toString('utf-8')).toBe('tiny-image');
+    expect(result.filename).toBe('logo.png');
+    expect(result.mimeType).toBe('image/png');
+  });
+
+  it('Scenario: downloadAttachment falls back to Content-ID when an inline part has no filename', async () => {
+    // Mirrors collectPayloadContent's filename derivation — without this, the
+    // post-#67 contract reshape regressed CID-only inline parts to empty names.
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-cid',
+        threadId: 'thread-cid',
+        payload: {
+          headers: [],
+          parts: [
+            {
+              mimeType: 'image/png',
+              body: { data: Buffer.from('cid-image').toString('base64url') },
+              headers: [{ name: 'Content-ID', value: '<image003>' }],
+            },
+          ],
+        },
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const result = await provider.downloadAttachment('msg-cid', 'part:0');
+    expect(result.filename).toBe('image003');
+  });
+
+  it('Scenario: downloadAttachment falls back to attachment-<path> when neither filename nor Content-ID exists', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-bare',
+        threadId: 'thread-bare',
+        payload: {
+          headers: [],
+          parts: [
+            {
+              mimeType: 'application/octet-stream',
+              body: { attachmentId: 'att-bare-1', size: 4 },
+              headers: [],
+            },
+          ],
+        },
+      }),
+      getAttachment: vi.fn().mockResolvedValue({ data: Buffer.from('bare').toString('base64url') }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const result = await provider.downloadAttachment('msg-bare', 'att-bare-1');
+    expect(result.filename).toBe('attachment-0');
+  });
+
+  it('Scenario: downloadAttachment maps Gmail 404 on the attachment endpoint to AttachmentNotFoundError', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-1',
+        threadId: 'thread-1',
+        payload: { headers: [], parts: [{ mimeType: 'application/pdf', body: { attachmentId: 'att-gone' }, headers: [] }] },
+      }),
+      getAttachment: vi.fn().mockRejectedValue({ code: 404, message: 'Requested entity was not found' }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.downloadAttachment('msg-1', 'att-gone'))
+      .rejects.toBeInstanceOf(AttachmentNotFoundError);
+  });
+
+  it('Scenario: downloadAttachment maps Gmail 404 on the message endpoint to AttachmentNotFoundError (part:* synthetic id)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockRejectedValue({ response: { status: 404 } }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.downloadAttachment('msg-deleted', 'part:0'))
+      .rejects.toBeInstanceOf(AttachmentNotFoundError);
+  });
+
+  it('Scenario: downloadAttachment propagates non-404 errors unchanged (action layer maps to PROVIDER_UNAVAILABLE)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockRejectedValue({ code: 500, message: 'Internal error' }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.downloadAttachment('msg-1', 'att-1'))
+      .rejects.toMatchObject({ code: 500 });
   });
 });
 

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -10,7 +10,9 @@ import type {
   DraftResult,
   ListOptions,
   ReplyOptions,
+  DownloadedAttachment,
 } from '@usejunior/email-core';
+import { AttachmentNotFoundError } from '@usejunior/email-core';
 
 // Gmail label mapping
 const FOLDER_TO_LABEL: Record<string, string> = {
@@ -138,21 +140,50 @@ export class GmailEmailProvider {
     return message.attachments ?? [];
   }
 
-  async downloadAttachment(messageId: string, attachmentId: string): Promise<Buffer> {
+  async downloadAttachment(messageId: string, attachmentId: string): Promise<DownloadedAttachment> {
+    // Gmail's getAttachment endpoint returns only base64 bytes — it doesn't
+    // include filename/mimeType. Pull metadata from the message payload
+    // alongside the bytes so the action layer gets a self-contained result.
+    let message: GmailMessage;
+    try {
+      message = await this.client.getMessage(messageId);
+    } catch (err) {
+      if (isNotFoundError(err)) {
+        throw new AttachmentNotFoundError(`Gmail message ${messageId} not found`);
+      }
+      throw err;
+    }
+    const meta = findAttachmentMetadata(message.payload?.parts, attachmentId);
+
+    let content: Buffer;
     if (attachmentId.startsWith('part:')) {
-      const message = await this.client.getMessage(messageId);
       const part = findPartByPath(message.payload?.parts, attachmentId.slice('part:'.length));
       if (!part?.body?.data) {
-        throw new Error(`Gmail attachment ${attachmentId} is missing inline body data`);
+        throw new AttachmentNotFoundError(`Gmail attachment ${attachmentId} is missing inline body data`);
       }
-      return Buffer.from(part.body.data, 'base64url');
+      content = Buffer.from(part.body.data, 'base64url');
+    } else {
+      let attachment: { data?: string; size?: number };
+      try {
+        attachment = await this.client.getAttachment(messageId, attachmentId);
+      } catch (err) {
+        if (isNotFoundError(err)) {
+          throw new AttachmentNotFoundError(`Gmail attachment ${attachmentId} not found on message ${messageId}`);
+        }
+        throw err;
+      }
+      if (!attachment.data) {
+        throw new AttachmentNotFoundError(`Gmail attachment ${attachmentId} returned no data`);
+      }
+      content = Buffer.from(attachment.data, 'base64url');
     }
 
-    const attachment = await this.client.getAttachment(messageId, attachmentId);
-    if (!attachment.data) {
-      throw new Error(`Gmail attachment ${attachmentId} returned no data`);
-    }
-    return Buffer.from(attachment.data, 'base64url');
+    return {
+      content,
+      filename: meta?.filename || attachmentId,
+      mimeType: meta?.mimeType ?? 'application/octet-stream',
+      size: content.length,
+    };
   }
 
   async sendMessage(msg: ComposeMessage): Promise<SendResult> {
@@ -417,6 +448,66 @@ function findPartByPath(parts: GmailMessagePart[] | undefined, path: string): Gm
     currentParts = current.parts ?? [];
   }
   return current ?? null;
+}
+
+// Walk the part tree looking for an attachment by id (either body.attachmentId
+// for non-inline parts, or `part:<index-path>` for inline parts whose data is
+// already in the message payload). Returns filename + mimeType when found.
+//
+// Filename fallback mirrors collectPayloadContent: real filename → stripped
+// Content-ID → synthetic `attachment-<path>`. Without this, CID-only inline
+// parts (common for HTML emails) regress from a meaningful name like
+// `image002` to empty-string after the contract reshape.
+function findAttachmentMetadata(
+  parts: GmailMessagePart[] | undefined,
+  attachmentId: string,
+): { filename: string; mimeType: string } | null {
+  if (!parts) return null;
+  if (attachmentId.startsWith('part:')) {
+    const path = attachmentId.slice('part:'.length);
+    const part = findPartByPath(parts, path);
+    if (!part) return null;
+    return {
+      filename: deriveAttachmentFilename(part, path),
+      mimeType: part.mimeType ?? 'application/octet-stream',
+    };
+  }
+  const find = (
+    list: GmailMessagePart[],
+    pathPrefix: string,
+  ): { part: GmailMessagePart; path: string } | null => {
+    for (const [index, p] of list.entries()) {
+      const path = pathPrefix === '' ? String(index) : `${pathPrefix}.${index}`;
+      if (p.body?.attachmentId === attachmentId) return { part: p, path };
+      if (p.parts) {
+        const hit = find(p.parts, path);
+        if (hit) return hit;
+      }
+    }
+    return null;
+  };
+  const found = find(parts, '');
+  if (!found) return null;
+  return {
+    filename: deriveAttachmentFilename(found.part, found.path),
+    mimeType: found.part.mimeType ?? 'application/octet-stream',
+  };
+}
+
+function deriveAttachmentFilename(part: GmailMessagePart, path: string): string {
+  if (part.filename) return part.filename;
+  const contentId = getPartHeader(part, 'Content-ID');
+  const stripped = contentId ? stripAngleBrackets(contentId) : '';
+  if (stripped) return stripped;
+  return `attachment-${path.replace(/\./g, '-')}`;
+}
+
+function isNotFoundError(err: unknown): boolean {
+  const record = err as { code?: unknown; response?: { status?: unknown } } | null;
+  if (!record || typeof record !== 'object') return false;
+  if (record.code === 404) return true;
+  if (record.response && typeof record.response === 'object' && record.response.status === 404) return true;
+  return false;
 }
 
 function parseEmailAddress(raw: string): { email: string; name?: string } {

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { GraphEmailProvider, GraphApiError, RealGraphApiClient, simplifySearchQuery, type GraphApiClient } from './email-graph-provider.js';
-import { AttachmentNotSupportedError } from '@usejunior/email-core';
+import { AttachmentNotSupportedError, AttachmentNotFoundError } from '@usejunior/email-core';
 
 // Linux CI runners do not provide libsecret, so auth imports must not load the real cache plugin.
 vi.mock('@azure/identity-cache-persistence', () => ({
@@ -283,12 +283,68 @@ describe('provider-microsoft/Attachment Download', () => {
     ]);
     const provider = new GraphEmailProvider(client);
 
-    const buf = await provider.downloadAttachment('msg-1', 'att-pdf');
+    const result = await provider.downloadAttachment('msg-1', 'att-pdf');
 
-    expect(buf.equals(PAYLOAD)).toBe(true);
+    expect(result.content.equals(PAYLOAD)).toBe(true);
+    expect(result.filename).toBe('note.txt');
+    expect(result.mimeType).toBe('text/plain');
+    expect(result.size).toBe(PAYLOAD.length);
     expect(client.get).toHaveBeenCalledWith(
       '/me/messages/msg-1/attachments/att-pdf?$select=id,name,contentType,size,microsoft.graph.fileAttachment/contentBytes',
     );
+  });
+
+  it('Scenario: downloadAttachment URL-encodes message and attachment ids that contain /, +, =', async () => {
+    const PAYLOAD = Buffer.from('encoded id payload');
+    const client = createSchemaValidatingClient([
+      {
+        id: 'AAA/BBB+CCC=',
+        '@odata.type': '#microsoft.graph.fileAttachment',
+        name: 'a.bin',
+        contentType: 'application/octet-stream',
+        size: PAYLOAD.length,
+        contentBytes: PAYLOAD.toString('base64'),
+      },
+    ]);
+    const provider = new GraphEmailProvider(client);
+
+    await provider.downloadAttachment('AAMkAGI/=msg+id', 'AAA/BBB+CCC=');
+
+    const calledWith = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(calledWith).toContain('/messages/AAMkAGI%2F%3Dmsg%2Bid/attachments/AAA%2FBBB%2BCCC%3D');
+    expect(calledWith).not.toContain('AAMkAGI/=msg+id');
+  });
+
+  it('Scenario: listAttachments URL-encodes the message id', async () => {
+    const client = createSchemaValidatingClient([{ value: [] }]);
+    const provider = new GraphEmailProvider(client);
+
+    await provider.listAttachments('AAMkA/+=raw');
+
+    const calledWith = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(calledWith).toContain('/messages/AAMkA%2F%2B%3Draw/attachments');
+  });
+
+  it('Scenario: getMessage URL-encodes the message id (verifies the codebase-wide encoder applies beyond download paths)', async () => {
+    // Cross-method check: the `encodeGraphPathId` helper must wrap IDs at every
+    // path-segment interpolation, not just on the new attachment endpoints.
+    // getMessage was a pre-existing call site and should also encode.
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValue({
+        id: 'AAA/BBB+id=',
+        subject: 'encoded',
+        from: { emailAddress: { address: 's@e.com' } },
+        toRecipients: [],
+        receivedDateTime: '2026-04-09T00:00:00Z',
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.getMessage('AAA/BBB+id=');
+
+    const calledWith = (client.get as ReturnType<typeof vi.fn>).mock.calls[0]![0] as string;
+    expect(calledWith).toContain('/messages/AAA%2FBBB%2Bid%3D');
+    expect(calledWith).not.toContain('/messages/AAA/BBB+id=');
   });
 
   it('Scenario: downloadAttachment throws AttachmentNotSupportedError for itemAttachment (no contentBytes)', async () => {
@@ -307,13 +363,55 @@ describe('provider-microsoft/Attachment Download', () => {
     await expect(provider.downloadAttachment('msg-1', 'att-item')).rejects.toThrow(/itemAttachment/);
   });
 
-  it('Scenario: downloadAttachment surfaces 404 GraphApiError unchanged (action layer maps to PROVIDER_UNAVAILABLE)', async () => {
+  it('Scenario: downloadAttachment maps Graph 404 to AttachmentNotFoundError (race-deleted)', async () => {
     const client = createMockClient({
       get: vi.fn().mockRejectedValue(new GraphApiError(404, '{"error":{"code":"ErrorItemNotFound"}}')),
     });
     const provider = new GraphEmailProvider(client);
 
-    await expect(provider.downloadAttachment('msg-1', 'att-missing')).rejects.toBeInstanceOf(GraphApiError);
+    await expect(provider.downloadAttachment('msg-1', 'att-missing')).rejects.toBeInstanceOf(AttachmentNotFoundError);
+  });
+
+  it('Scenario: downloadAttachment surfaces non-404 GraphApiError unchanged', async () => {
+    const client = createMockClient({
+      get: vi.fn().mockRejectedValue(new GraphApiError(500, '{"error":{"code":"InternalServerError"}}')),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.downloadAttachment('msg-1', 'att-x')).rejects.toBeInstanceOf(GraphApiError);
+  });
+
+  it('Scenario: downloadAttachment rejects malformed base64 in contentBytes', async () => {
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValue({
+        id: 'att-bad',
+        '@odata.type': '#microsoft.graph.fileAttachment',
+        name: 'bad.bin',
+        contentType: 'application/octet-stream',
+        size: 4,
+        contentBytes: '!!!not_base64$$$',
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.downloadAttachment('msg-1', 'att-bad')).rejects.toThrow(/invalid base64/);
+  });
+
+  it('Scenario: downloadAttachment rejects size mismatch between Graph-reported size and decoded length', async () => {
+    const PAYLOAD = Buffer.from('actual bytes');
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValue({
+        id: 'att-mismatch',
+        '@odata.type': '#microsoft.graph.fileAttachment',
+        name: 'mismatch.bin',
+        contentType: 'application/octet-stream',
+        size: 9999, // lies — actual decoded length is PAYLOAD.length
+        contentBytes: PAYLOAD.toString('base64'),
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.downloadAttachment('msg-1', 'att-mismatch')).rejects.toThrow(/does not match/);
   });
 });
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -12,8 +12,9 @@ import type {
   EmailSender,
   EmailCategorizer,
   EmailAttachmentHandler,
+  DownloadedAttachment,
 } from '@usejunior/email-core';
-import { AttachmentNotSupportedError } from '@usejunior/email-core';
+import { AttachmentNotSupportedError, AttachmentNotFoundError } from '@usejunior/email-core';
 
 const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 const SUBJECT_MAX_LENGTH = 255;
@@ -52,6 +53,13 @@ const DELTA_SELECT = '$select=subject,from,toRecipients,ccRecipients,receivedDat
 //   base attachment: https://learn.microsoft.com/en-us/graph/api/resources/attachment?view=graph-rest-1.0
 //   fileAttachment:  https://learn.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-1.0
 const ATTACHMENT_SELECT = 'id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId';
+
+// Graph message and attachment IDs are base64url-flavored and routinely contain
+// `=`, `+`, `/`, `_`, `-`. Path segments must encode `+`, `/`, and `=` or Graph
+// returns 400/404. encodeURIComponent handles all three plus `?`, `#`, `&`.
+function encodeGraphPathId(id: string): string {
+  return encodeURIComponent(id);
+}
 
 /** Result from delta query, including messages and the deltaLink for persistence */
 export interface DeltaResult {
@@ -175,13 +183,14 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (filters.length > 0) params.set('$filter', filters.join(' and '));
 
     const folder = normalizeFolderId(opts.folder ?? 'inbox');
-    const url = `${this.basePath}/mailFolders/${folder}/messages?${params}`;
+    const url = `${this.basePath}/mailFolders/${encodeGraphPathId(folder)}/messages?${params}`;
     const response = await this.client.get(url);
     return ((response.value ?? []) as GraphMessage[]).map(mapGraphMessage);
   }
 
   async getMessage(id: string): Promise<EmailMessage> {
-    const expandedUrl = `${this.basePath}/messages/${id}?$expand=attachments($select=${ATTACHMENT_SELECT})`;
+    const encodedId = encodeGraphPathId(id);
+    const expandedUrl = `${this.basePath}/messages/${encodedId}?$expand=attachments($select=${ATTACHMENT_SELECT})`;
 
     try {
       const response = await this.client.get(expandedUrl) as unknown as GraphMessage;
@@ -192,9 +201,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       if (!(err instanceof GraphApiError) || err.status !== 400) throw err;
     }
 
-    const message = await this.client.get(`${this.basePath}/messages/${id}`) as unknown as GraphMessage;
+    const message = await this.client.get(`${this.basePath}/messages/${encodedId}`) as unknown as GraphMessage;
     const attachments = await this.client.get(
-      `${this.basePath}/messages/${id}/attachments?$select=${ATTACHMENT_SELECT}`,
+      `${this.basePath}/messages/${encodedId}/attachments?$select=${ATTACHMENT_SELECT}`,
     );
 
     return mapGraphMessage({
@@ -212,7 +221,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (offset) params.set('$skip', String(offset));
     const normalizedFolder = folder ? normalizeFolderId(folder) : undefined;
     const base = normalizedFolder
-      ? `${this.basePath}/mailFolders/${normalizedFolder}/messages`
+      ? `${this.basePath}/mailFolders/${encodeGraphPathId(normalizedFolder)}/messages`
       : `${this.basePath}/messages`;
 
     try {
@@ -258,11 +267,12 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     return { id: messageId, subject: message.subject, messages: [message], messageCount: 1 };
   }
 
-  // EmailAttachmentHandler — cheap metadata-only fetch. The download_attachment
-  // action prefers this over getMessage to avoid pulling the full HTML body.
+  // EmailAttachmentHandler — cheap metadata-only fetch. Used by callers that
+  // want metadata without bytes (e.g. `list_attachments`); downloadAttachment
+  // does its own single-call fetch and does not preflight through this method.
   async listAttachments(messageId: string): Promise<EmailAttachment[]> {
     const response = await this.client.get(
-      `${this.basePath}/messages/${messageId}/attachments?$select=${ATTACHMENT_SELECT}`,
+      `${this.basePath}/messages/${encodeGraphPathId(messageId)}/attachments?$select=${ATTACHMENT_SELECT}`,
     );
     return ((response.value ?? []) as GraphAttachment[]).map(a => ({
       id: a.id,
@@ -274,53 +284,90 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     }));
   }
 
-  // Returns base64-decoded bytes for fileAttachment only. itemAttachment and
+  // Returns bytes + fresh metadata for fileAttachment only. itemAttachment and
   // referenceAttachment lack contentBytes and require the /$value raw-bytes
   // endpoint, which is not yet wired into RealGraphApiClient — those throw
   // AttachmentNotSupportedError so the action layer surfaces NOT_SUPPORTED
-  // instead of a generic provider failure.
+  // instead of a generic provider failure. A 404 from Graph maps to
+  // AttachmentNotFoundError so race-deleted attachments surface uniformly.
   //   fileAttachment: https://learn.microsoft.com/en-us/graph/api/resources/fileattachment
   //   GET attachment: https://learn.microsoft.com/en-us/graph/api/attachment-get
-  async downloadAttachment(messageId: string, attachmentId: string): Promise<Buffer> {
+  async downloadAttachment(messageId: string, attachmentId: string): Promise<DownloadedAttachment> {
     const select = 'id,name,contentType,size,microsoft.graph.fileAttachment/contentBytes';
-    const response = await this.client.get(
-      `${this.basePath}/messages/${messageId}/attachments/${attachmentId}?$select=${select}`,
-    ) as unknown as GraphAttachment;
+    const url = `${this.basePath}/messages/${encodeGraphPathId(messageId)}/attachments/${encodeGraphPathId(attachmentId)}?$select=${select}`;
+    let response: GraphAttachment;
+    try {
+      response = await this.client.get(url) as unknown as GraphAttachment;
+    } catch (err) {
+      if (err instanceof GraphApiError && err.status === 404) {
+        throw new AttachmentNotFoundError(
+          `Attachment ${attachmentId} not found on message ${messageId}`,
+        );
+      }
+      throw err;
+    }
     if (typeof response.contentBytes !== 'string') {
       const odataType = response['@odata.type'] ?? 'unknown';
       throw new AttachmentNotSupportedError(
         `Attachment ${attachmentId} has @odata.type=${odataType}; only fileAttachment is supported in this version (item/reference attachments require /$value raw-bytes which is not yet implemented)`,
       );
     }
-    return Buffer.from(response.contentBytes, 'base64');
+    // Reject obviously malformed base64 before decode. Buffer.from silently
+    // strips invalid chars and can return truncated bytes, so guard explicitly.
+    // Strip whitespace first — some Graph backends emit MIME-style line-broken
+    // base64 in contentBytes, which is still valid; the regex below rejects
+    // genuinely garbage payloads like "!!!not_base64$$$".
+    const cleanedBytes = response.contentBytes.replace(/\s+/g, '');
+    if (!/^[A-Za-z0-9+/]*=*$/.test(cleanedBytes)) {
+      throw new GraphApiError(
+        500,
+        `Attachment ${attachmentId} contentBytes contains invalid base64 characters`,
+      );
+    }
+    const content = Buffer.from(cleanedBytes, 'base64');
+    // Compare decoded length to the size Graph reported on the same response.
+    // A mismatch signals truncation in transit or a malformed contentBytes
+    // payload — return a hard error rather than corrupt bytes.
+    if (typeof response.size === 'number' && content.length !== response.size) {
+      throw new GraphApiError(
+        500,
+        `Attachment ${attachmentId} decoded length ${content.length} does not match Graph-reported size ${response.size}`,
+      );
+    }
+    return {
+      content,
+      filename: response.name ?? '',
+      mimeType: response.contentType ?? 'application/octet-stream',
+      size: response.size ?? content.length,
+    };
   }
 
   async applyLabels(messageId: string, labels: string[]): Promise<void> {
     const existingCategories = await this.getMessageCategories(messageId);
     const categories = [...new Set([...existingCategories, ...labels])];
-    await this.client.patch(`${this.basePath}/messages/${messageId}`, { categories });
+    await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(messageId)}`, { categories });
   }
 
   async removeLabels(messageId: string, labels: string[]): Promise<void> {
     const labelsToRemove = new Set(labels);
     const existingCategories = await this.getMessageCategories(messageId);
     const categories = existingCategories.filter(label => !labelsToRemove.has(label));
-    await this.client.patch(`${this.basePath}/messages/${messageId}`, { categories });
+    await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(messageId)}`, { categories });
   }
 
   async setFlag(messageId: string, flagged: boolean): Promise<void> {
-    await this.client.patch(`${this.basePath}/messages/${messageId}`, {
+    await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(messageId)}`, {
       flag: { flagStatus: flagged ? 'flagged' : 'notFlagged' },
     });
   }
 
   async setReadState(messageId: string, isRead: boolean): Promise<void> {
-    await this.client.patch(`${this.basePath}/messages/${messageId}`, { isRead });
+    await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(messageId)}`, { isRead });
   }
 
   async moveToFolder(messageId: string, folder: string): Promise<string> {
     // Graph POST /move returns the moved message with a NEW id
-    const result = await this.client.post(`${this.basePath}/messages/${messageId}/move`, {
+    const result = await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(messageId)}/move`, {
       destinationId: normalizeFolderId(folder),
     });
     return result.id ?? messageId;
@@ -328,7 +375,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
 
   async deleteMessage(messageId: string, hard = false): Promise<void> {
     if (hard) {
-      await this.client.post(`${this.basePath}/messages/${messageId}/permanentDelete`);
+      await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(messageId)}/permanentDelete`);
       return;
     }
 
@@ -357,7 +404,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     // endpoints preserve embedded images, CID references, and the auto-quoted thread.
     try {
       const draftId = await this.prepareReplyDraft(messageId, body, opts);
-      await this.client.post(`${this.basePath}/messages/${draftId}/send`, {});
+      await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(draftId)}/send`, {});
       return { success: true, messageId: draftId };
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to send reply';
@@ -377,7 +424,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async sendDraft(draftId: string): Promise<SendResult> {
-    await this.client.post(`${this.basePath}/messages/${draftId}/send`, {});
+    await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(draftId)}/send`, {});
     return { success: true, messageId: draftId };
   }
 
@@ -409,7 +456,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   ): Promise<string> {
     const endpoint = opts?.replyAll === false ? 'createReply' : 'createReplyAll';
     const draft = await this.client.post(
-      `${this.basePath}/messages/${messageId}/${endpoint}`,
+      `${this.basePath}/messages/${encodeGraphPathId(messageId)}/${endpoint}`,
       {},
     );
     if (!draft.id) throw new Error(`${endpoint} did not return a draft id`);
@@ -421,7 +468,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     // Fallback GET when the POST response lacks a usable HTML body. Graph defaults
     // to HTML on `Get message` so no Prefer header is needed.
     if (typeof draftBody?.content !== 'string' || draftBody.contentType?.toLowerCase() !== 'html') {
-      const fetched = await this.client.get(`${this.basePath}/messages/${draft.id}`);
+      const fetched = await this.client.get(`${this.basePath}/messages/${encodeGraphPathId(draft.id)}`);
       draftBody = fetched.body as { contentType?: string; content?: string } | undefined;
       draftCc = (fetched.ccRecipients as GraphRecipient[] | undefined) ?? [];
       draftBcc = (fetched.bccRecipients as GraphRecipient[] | undefined) ?? [];
@@ -443,7 +490,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     const bccMerged = mergeRecipients(draftBcc, opts?.bcc ?? []);
     if (bccMerged.length > 0) patch.bccRecipients = bccMerged;
 
-    await this.client.patch(`${this.basePath}/messages/${draft.id}`, patch);
+    await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(draft.id)}`, patch);
     return draft.id;
   }
 
@@ -456,7 +503,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (msg.to) patch.toRecipients = msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
     if (msg.cc) patch.ccRecipients = msg.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
 
-    await this.client.patch(`${this.basePath}/messages/${draftId}`, patch);
+    await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(draftId)}`, patch);
     return { success: true, draftId };
   }
 
@@ -522,7 +569,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
 
   private async getMessageCategories(messageId: string): Promise<string[]> {
     const response = await this.client.get(
-      `${this.basePath}/messages/${messageId}?$select=categories`,
+      `${this.basePath}/messages/${encodeGraphPathId(messageId)}?$select=categories`,
     ) as { categories?: unknown };
 
     return Array.isArray(response.categories)


### PR DESCRIPTION
## Summary

Hardening pass on the `download_attachment` MCP tool added in #67. Addresses all 5 items raised by Gemini + Codex peer review (issue #68).

| # | Item | Fix |
|---|------|-----|
| 1 | MCP transport: base64 stuffed inside JSON-text envelope | `download_attachment` returns `[text, resource]` content array — bytes flow as a typed `resource.blob` with URI `attachment://<mailbox>/<messageId>/<attachmentId>` |
| 2 | Missing URL encoding on Graph IDs | New `encodeGraphPathId` helper applied at every path-segment ID interpolation (15+ sites); folder names too |
| 3 | Base64 silent corruption | Whitespace-strip + base64 character-set check + decoded-length vs Graph-reported `size` mismatch check |
| 4 | Lossy filename sanitization | `list_attachments` and `download_attachment` now return both `filename` (sanitized) and `original_filename` (raw) |
| 5 | `downloadAttachment` provider contract too narrow | Reshaped to return `{content, filename, mimeType, size}` — single round-trip, fresh metadata, race-deleted attachments map cleanly to `ATTACHMENT_NOT_FOUND` via new `AttachmentNotFoundError` sentinel (Graph 404 + Gmail 404 both mapped) |

Gmail provider also gets filename-fallback parity with `collectPayloadContent` (filename → Content-ID → `attachment-<path>`) so CID-only inline parts don't regress to empty names after the contract reshape.

## Test plan

- [x] `npm run build` — clean across all 4 packages
- [x] `npm run lint --workspaces --if-present` — clean
- [x] `npm run test:run` — **610 passing** (was 580 before; +30 added)
  - email-core: 248
  - email-mcp: 163
  - provider-gmail: 68
  - provider-microsoft: 131
- [x] `npm run check:spec-coverage` — 186/186
- [x] `npm run check:server-json`, `check:gemini-extension-manifest` — pass
- [ ] Manual end-to-end against a live mailbox once published — verify the resource content reaches an MCP client correctly, encoded message IDs work against real Outlook mailboxes

## New tests

- **Microsoft provider**: URL-encoding for `downloadAttachment`, `listAttachments`, `getMessage` (cross-method verification with `/`, `+`, `=`); malformed-base64 → `GraphApiError`; size-mismatch → `GraphApiError`; 404 → `AttachmentNotFoundError`; happy-path uses new return shape.
- **Gmail provider**: 404 on attachment endpoint → `AttachmentNotFoundError`; 404 on message endpoint (for `part:*` synthetic ids) → `AttachmentNotFoundError`; non-404 errors propagate unchanged; CID-only inline part filename fallback; bare-attachment `attachment-<path>` fallback.
- **Action layer**: non-ASCII filename round-trip via `original_filename`; explicit `AttachmentNotFoundError` mapping; updated existing tests for new contract shape.
- **MCP server**: `download_attachment` emits text + resource content items on success; failure path stays single text envelope.

## Reviewed by

Gemini and Codex via `/peer-review` CLI, both pre-implementation (scope framing) and post-implementation. Critical fixes from the post-implementation review:

- Gemini caught the base64 regex rejecting MIME-style line-broken `contentBytes` (whitespace now stripped before validation)
- Codex caught that Gmail 404s were only mapped on the "missing data" branch (full `getMessage` + `getAttachment` 404 mapping added)
- Codex caught the Gmail filename-fallback regression for CID-only inline parts (parity with `collectPayloadContent` restored)

Both reviewers endorsed keeping: `AttachmentNotSupportedError` sentinel, OData `microsoft.graph.fileAttachment/contentBytes` cast, runtime `NOT_SUPPORTED` for providers without the capability, and the `handleToolCall` string special-case for `download_attachment` (acceptable for v1.1; refactor to a generic content-formatter hook deferred).

Closes #68. Ref #67.