### PR TITLE
fix(graph): preserve auto-quoted thread history in update_draft

### DIFF
--- a/openspec/specs/provider-microsoft/spec.md
+++ b/openspec/specs/provider-microsoft/spec.md
@@ -46,6 +46,15 @@ The system SHALL use `createReplyAll` for replies. `createReplyAll` preserves em
 - **THEN** `replyToMessage` returns `{ success: false, error: { code: 'REPLY_FAILED', recoverable: false } }`
 - **AND** does not call `sendMail`
 
+#### Scenario: update_draft preserves Graph auto-quoted thread
+- **WHEN** `update_draft` is called with a new body on a draft that contains Graph's auto-quoted thread (divider + `From:/Sent:/To:/Subject:` block)
+- **THEN** the resulting PATCH replaces only the caller content above the divider
+- **AND** preserves the divider, header block, and prior message body intact
+
+#### Scenario: update_draft on a fresh draft replaces body wholesale
+- **WHEN** `update_draft` is called on a draft with no quoted-thread marker
+- **THEN** the body is PATCHed wholesale via `buildGraphBody` (existing behavior unchanged)
+
 ### Requirement: Validation Token Handling
 
 The system SHALL respond to Graph validation requests on BOTH GET and POST methods. The `validationToken` query parameter SHALL be HTML-escaped and returned as `200 OK` plaintext.

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -764,25 +764,25 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
 });
 
 describe('provider-microsoft/update_draft Quote Preservation', () => {
-  it('Scenario: update_draft preserves Graph auto-quoted thread', async () => {
-    // Simulate a reply draft already merged by prepareReplyDraft: caller fragment
-    // sits between <body> and <hr>, then Graph's quoted block follows.
-    const REPLY_DRAFT_BODY = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
-      + '<body style="font-size:10pt; font-family:Verdana,Geneva,sans-serif">'
-      + '<div>Old caller content</div>'
-      + '<hr tabindex="-1" style="display:inline-block; width:98%">'
-      + '<div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" color="#000000" style="font-size:11pt">'
-      + '<b>From:</b> Alice &lt;alice@corp.com&gt;<br>'
-      + '<b>Sent:</b> Saturday, 25 April 2026 16:08:46<br>'
-      + '<b>To:</b> Steven &lt;steven@corp.com&gt;<br>'
-      + '<b>Subject:</b> Re: Quarterly Report</font><div>&nbsp;</div></div>'
-      + '<div><p>Original message content</p></div>'
-      + '</body></html>';
+  // Compose the realistic "post-prepareReplyDraft" fixture by simulating the
+  // create-path: caller fragment inserted by the same merge logic the production
+  // code uses. Round-trips through the merge helper so the fixture stays in sync
+  // with the splice anatomy if either side changes.
+  function replyDraftWith(callerFragment: string): string {
+    const bodyOpenEnd = QUOTED_REPLY_BODY.match(/<body[^>]*>/i);
+    if (!bodyOpenEnd || bodyOpenEnd.index === undefined) {
+      throw new Error('QUOTED_REPLY_BODY fixture missing <body> tag');
+    }
+    const idx = bodyOpenEnd.index + bodyOpenEnd[0].length;
+    return QUOTED_REPLY_BODY.slice(0, idx) + callerFragment + QUOTED_REPLY_BODY.slice(idx);
+  }
 
+  it('Scenario: update_draft preserves Graph auto-quoted thread', async () => {
+    const replyDraftBody = replyDraftWith('<div>Old caller content</div>');
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
         id: 'draft-update-1',
-        body: { contentType: 'html', content: REPLY_DRAFT_BODY },
+        body: { contentType: 'html', content: replyDraftBody },
       }),
       patch: vi.fn().mockResolvedValueOnce({}),
     });
@@ -791,13 +791,12 @@ describe('provider-microsoft/update_draft Quote Preservation', () => {
     const result = await provider.updateDraft('draft-update-1', { body: 'Updated reply text' });
 
     expect(result.success).toBe(true);
-    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('draft-update-1'));
+    // Narrowed GET — only the body field is fetched
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('$select=body'));
     const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
     const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
     expect(patchBody.contentType).toBe('HTML');
-    // New caller content present
     expect(patchBody.content).toContain('Updated reply text');
-    // Old caller content gone
     expect(patchBody.content).not.toContain('Old caller content');
     // Quoted thread preserved (divider, header block, prior message body)
     expect(patchBody.content).toContain('divRplyFwdMsg');
@@ -806,6 +805,7 @@ describe('provider-microsoft/update_draft Quote Preservation', () => {
   });
 
   it('Scenario: update_draft on a fresh draft replaces body wholesale', async () => {
+    // No <hr> after <body> → no recognizable Graph reply anatomy → fall through to buildGraphBody
     const FRESH_DRAFT_BODY = '<html><body><div>Old fresh content</div></body></html>';
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
@@ -820,42 +820,9 @@ describe('provider-microsoft/update_draft Quote Preservation', () => {
 
     const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
     const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
-    // No quoted-thread marker → falls through to buildGraphBody, which produces Text contentType
     expect(patchBody.contentType).toBe('Text');
     expect(patchBody.content).toBe('New body');
     expect(patchBody.content).not.toContain('Old fresh content');
-  });
-
-  it('Scenario: update_draft with bodyHtml preserves quoted thread and strips outer wrappers', async () => {
-    const REPLY_DRAFT_BODY = '<html><body>'
-      + '<div>Old caller</div>'
-      + '<hr><div id="divRplyFwdMsg"><b>From:</b> Bob</div>'
-      + '<div>Prior body</div>'
-      + '</body></html>';
-
-    const client = createMockClient({
-      get: vi.fn().mockResolvedValueOnce({
-        id: 'draft-update-3',
-        body: { contentType: 'html', content: REPLY_DRAFT_BODY },
-      }),
-      patch: vi.fn().mockResolvedValueOnce({}),
-    });
-    const provider = new GraphEmailProvider(client);
-
-    await provider.updateDraft('draft-update-3', {
-      body: 'plain fallback',
-      bodyHtml: '<html><body><p>rendered update</p></body></html>',
-    });
-
-    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    const content = (patchArgs[1] as { body: { content: string } }).body.content;
-    // Caller's outer <html>/<body> from bodyHtml stripped — only one of each (Graph's outer ones)
-    expect(content.match(/<html[\s>]/gi)?.length ?? 0).toBe(1);
-    expect(content.match(/<body[\s>]/gi)?.length ?? 0).toBe(1);
-    expect(content).toContain('<p>rendered update</p>');
-    expect(content).toContain('divRplyFwdMsg');
-    expect(content).toContain('From:</b> Bob');
-    expect(content).not.toContain('Old caller');
   });
 });
 

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -763,6 +763,102 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
   });
 });
 
+describe('provider-microsoft/update_draft Quote Preservation', () => {
+  it('Scenario: update_draft preserves Graph auto-quoted thread', async () => {
+    // Simulate a reply draft already merged by prepareReplyDraft: caller fragment
+    // sits between <body> and <hr>, then Graph's quoted block follows.
+    const REPLY_DRAFT_BODY = '<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8"></head>'
+      + '<body style="font-size:10pt; font-family:Verdana,Geneva,sans-serif">'
+      + '<div>Old caller content</div>'
+      + '<hr tabindex="-1" style="display:inline-block; width:98%">'
+      + '<div id="divRplyFwdMsg" dir="ltr"><font face="Calibri, sans-serif" color="#000000" style="font-size:11pt">'
+      + '<b>From:</b> Alice &lt;alice@corp.com&gt;<br>'
+      + '<b>Sent:</b> Saturday, 25 April 2026 16:08:46<br>'
+      + '<b>To:</b> Steven &lt;steven@corp.com&gt;<br>'
+      + '<b>Subject:</b> Re: Quarterly Report</font><div>&nbsp;</div></div>'
+      + '<div><p>Original message content</p></div>'
+      + '</body></html>';
+
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'draft-update-1',
+        body: { contentType: 'html', content: REPLY_DRAFT_BODY },
+      }),
+      patch: vi.fn().mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.updateDraft('draft-update-1', { body: 'Updated reply text' });
+
+    expect(result.success).toBe(true);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('draft-update-1'));
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
+    expect(patchBody.contentType).toBe('HTML');
+    // New caller content present
+    expect(patchBody.content).toContain('Updated reply text');
+    // Old caller content gone
+    expect(patchBody.content).not.toContain('Old caller content');
+    // Quoted thread preserved (divider, header block, prior message body)
+    expect(patchBody.content).toContain('divRplyFwdMsg');
+    expect(patchBody.content).toContain('From:</b> Alice');
+    expect(patchBody.content).toContain('Original message content');
+  });
+
+  it('Scenario: update_draft on a fresh draft replaces body wholesale', async () => {
+    const FRESH_DRAFT_BODY = '<html><body><div>Old fresh content</div></body></html>';
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'draft-update-2',
+        body: { contentType: 'html', content: FRESH_DRAFT_BODY },
+      }),
+      patch: vi.fn().mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.updateDraft('draft-update-2', { body: 'New body' });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
+    // No quoted-thread marker → falls through to buildGraphBody, which produces Text contentType
+    expect(patchBody.contentType).toBe('Text');
+    expect(patchBody.content).toBe('New body');
+    expect(patchBody.content).not.toContain('Old fresh content');
+  });
+
+  it('Scenario: update_draft with bodyHtml preserves quoted thread and strips outer wrappers', async () => {
+    const REPLY_DRAFT_BODY = '<html><body>'
+      + '<div>Old caller</div>'
+      + '<hr><div id="divRplyFwdMsg"><b>From:</b> Bob</div>'
+      + '<div>Prior body</div>'
+      + '</body></html>';
+
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'draft-update-3',
+        body: { contentType: 'html', content: REPLY_DRAFT_BODY },
+      }),
+      patch: vi.fn().mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.updateDraft('draft-update-3', {
+      body: 'plain fallback',
+      bodyHtml: '<html><body><p>rendered update</p></body></html>',
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const content = (patchArgs[1] as { body: { content: string } }).body.content;
+    // Caller's outer <html>/<body> from bodyHtml stripped — only one of each (Graph's outer ones)
+    expect(content.match(/<html[\s>]/gi)?.length ?? 0).toBe(1);
+    expect(content.match(/<body[\s>]/gi)?.length ?? 0).toBe(1);
+    expect(content).toContain('<p>rendered update</p>');
+    expect(content).toContain('divRplyFwdMsg');
+    expect(content).toContain('From:</b> Bob');
+    expect(content).not.toContain('Old caller');
+  });
+});
+
 describe('provider-microsoft/Reply-All Routing', () => {
   it('Scenario: replyAll omitted defaults to createReplyAll', async () => {
     const client = createMockClient({

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -497,7 +497,25 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {
     const patch: Record<string, unknown> = {};
     if (msg.body !== undefined || msg.bodyHtml !== undefined) {
-      patch.body = buildGraphBody(msg.bodyHtml, msg.body ?? '');
+      // For reply drafts, GET the existing body so we can preserve Graph's auto-quoted
+      // thread (divider + From/Sent/To/Subject + prior message). Replacing the body
+      // wholesale via PATCH would drop the quoted history that prepareReplyDraft set up.
+      // For non-reply drafts (no quoted-thread marker), this falls through to the
+      // normal buildGraphBody path so behavior is unchanged.
+      const current = await this.client.get(`${this.basePath}/messages/${encodeGraphPathId(draftId)}`);
+      const currentBody = current.body as { contentType?: string; content?: string } | undefined;
+      const currentContent = typeof currentBody?.content === 'string' ? currentBody.content : '';
+      const currentIsHtml = currentBody?.contentType?.toLowerCase() === 'html';
+
+      if (currentIsHtml && hasQuotedReplyThread(currentContent)) {
+        const callerFragment = msg.bodyHtml !== undefined
+          ? stripHtmlBodyWrappers(msg.bodyHtml)
+          : wrapPlainTextAsHtml(msg.body ?? '');
+        const merged = replaceCallerFragmentPreservingQuote(currentContent, callerFragment);
+        patch.body = { contentType: 'HTML', content: truncateBody(merged) };
+      } else {
+        patch.body = buildGraphBody(msg.bodyHtml, msg.body ?? '');
+      }
     }
     if (msg.subject !== undefined) patch.subject = msg.subject.slice(0, SUBJECT_MAX_LENGTH);
     if (msg.to) patch.toRecipients = msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
@@ -789,6 +807,51 @@ function mergeQuotedReplyHtml(draftContent: string, callerFragment: string): str
   }
   const insertAt = bodyTagMatch.index + bodyTagMatch[0].length;
   return draftContent.slice(0, insertAt) + callerFragment + draftContent.slice(insertAt);
+}
+
+/**
+ * Detect whether a draft body contains Graph's auto-generated quoted reply thread.
+ *
+ * Graph's reply drafts have a stable shape: `<body ...><hr ...><div id="divRplyFwdMsg">`
+ * (the divider + the `From:/Sent:/To:/Subject:` block). Either marker is sufficient
+ * evidence that the draft has a quoted thread we need to preserve.
+ *
+ * Used by `updateDraft` to decide whether to splice a new caller fragment into an
+ * existing reply draft or PATCH the body wholesale (fresh draft).
+ */
+function hasQuotedReplyThread(content: string): boolean {
+  return /divRplyFwdMsg/i.test(content) || /<hr\b[^>]*>\s*<div[^>]*<b>From:<\/b>/i.test(content);
+}
+
+/**
+ * Replace the caller fragment in an existing reply draft while preserving Graph's
+ * auto-quoted thread (divider + header block + prior message body).
+ *
+ * Strategy:
+ * - Locate `<body>` opening tag and the first `<hr ...>` after it.
+ * - Replace everything between `<body>` and that `<hr>` with the new fragment.
+ * - Leave the `<hr>` and everything after it untouched (preserves divider, From:/Sent:/To:/Subject:,
+ *   prior body, and `</body></html>` tail).
+ *
+ * Falls back to inserting the fragment after `<body>` (without removing anything) when
+ * no `<hr>` divider is present — the caller has already verified `hasQuotedReplyThread`,
+ * so this fallback is purely defensive.
+ *
+ * Falls back to `callerFragment + draftContent` when there's no `<body>` tag at all.
+ */
+function replaceCallerFragmentPreservingQuote(draftContent: string, callerFragment: string): string {
+  const bodyMatch = draftContent.match(/<body[^>]*>/i);
+  if (!bodyMatch || bodyMatch.index === undefined) {
+    return callerFragment + draftContent;
+  }
+  const afterBody = bodyMatch.index + bodyMatch[0].length;
+  const tail = draftContent.slice(afterBody);
+  const dividerMatch = tail.match(/<hr\b[^>]*>/i);
+  if (!dividerMatch || dividerMatch.index === undefined) {
+    return draftContent.slice(0, afterBody) + callerFragment + draftContent.slice(afterBody);
+  }
+  const dividerStart = afterBody + dividerMatch.index;
+  return draftContent.slice(0, afterBody) + callerFragment + draftContent.slice(dividerStart);
 }
 
 /**

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -500,18 +500,24 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       // For reply drafts, GET the existing body so we can preserve Graph's auto-quoted
       // thread (divider + From/Sent/To/Subject + prior message). Replacing the body
       // wholesale via PATCH would drop the quoted history that prepareReplyDraft set up.
-      // For non-reply drafts (no quoted-thread marker), this falls through to the
+      // For non-reply drafts (no quoted-thread anatomy), this falls through to the
       // normal buildGraphBody path so behavior is unchanged.
-      const current = await this.client.get(`${this.basePath}/messages/${encodeGraphPathId(draftId)}`);
+      // $select=body narrows the response — we only need the body field here.
+      const current = await this.client.get(
+        `${this.basePath}/messages/${encodeGraphPathId(draftId)}?$select=body`,
+      );
       const currentBody = current.body as { contentType?: string; content?: string } | undefined;
       const currentContent = typeof currentBody?.content === 'string' ? currentBody.content : '';
       const currentIsHtml = currentBody?.contentType?.toLowerCase() === 'html';
+      const region = currentIsHtml ? findGraphQuotedReplyRegion(currentContent) : null;
 
-      if (currentIsHtml && hasQuotedReplyThread(currentContent)) {
+      if (region) {
         const callerFragment = msg.bodyHtml !== undefined
           ? stripHtmlBodyWrappers(msg.bodyHtml)
           : wrapPlainTextAsHtml(msg.body ?? '');
-        const merged = replaceCallerFragmentPreservingQuote(currentContent, callerFragment);
+        const merged = currentContent.slice(0, region.bodyOpenEnd)
+          + callerFragment
+          + currentContent.slice(region.dividerStart);
         patch.body = { contentType: 'HTML', content: truncateBody(merged) };
       } else {
         patch.body = buildGraphBody(msg.bodyHtml, msg.body ?? '');
@@ -800,58 +806,45 @@ function wrapPlainTextAsHtml(text: string): string {
  *
  * Defensive fallback (no `<body>` tag): concatenate fragment + content.
  */
+/**
+ * Locate the splice region in a Graph reply draft body.
+ *
+ * Returns null when the content is not a recognizable Graph reply (no `<body>` tag,
+ * or `<body>` without a following `<hr>` divider). Returns the anchors otherwise:
+ * - `bodyOpenEnd`: index of the first character after the `<body ...>` opening tag
+ * - `dividerStart`: index of the first `<hr ...>` that follows
+ *
+ * Both create-path (`mergeQuotedReplyHtml`, inserts at `bodyOpenEnd`) and update-path
+ * (`updateDraft`, replaces `bodyOpenEnd..dividerStart`) share this anatomy parser so
+ * detection and splicing always agree on what counts as a reply draft.
+ */
+function findGraphQuotedReplyRegion(
+  content: string,
+): { bodyOpenEnd: number; dividerStart: number } | null {
+  const bodyMatch = content.match(/<body[^>]*>/i);
+  if (!bodyMatch || bodyMatch.index === undefined) return null;
+  const bodyOpenEnd = bodyMatch.index + bodyMatch[0].length;
+  const dividerMatch = content.slice(bodyOpenEnd).match(/<hr\b[^>]*>/i);
+  if (!dividerMatch || dividerMatch.index === undefined) return null;
+  return { bodyOpenEnd, dividerStart: bodyOpenEnd + dividerMatch.index };
+}
+
+/**
+ * Merge a caller-supplied HTML fragment into Graph's auto-quoted reply document so
+ * that Graph's `From:/Sent:/To:/Subject:` divider and the prior thread are preserved.
+ *
+ * Insertion strategy: place the fragment immediately after the `<body>` opening tag.
+ * Graph's response begins with an `<hr>` right after `<body>`, so the caller's content
+ * naturally appears above that divider — no need to add our own.
+ *
+ * Defensive fallback (no recognizable Graph anatomy): concatenate fragment + content.
+ */
 function mergeQuotedReplyHtml(draftContent: string, callerFragment: string): string {
-  const bodyTagMatch = draftContent.match(/<body[^>]*>/i);
-  if (!bodyTagMatch || bodyTagMatch.index === undefined) {
-    return callerFragment + draftContent;
-  }
-  const insertAt = bodyTagMatch.index + bodyTagMatch[0].length;
-  return draftContent.slice(0, insertAt) + callerFragment + draftContent.slice(insertAt);
-}
-
-/**
- * Detect whether a draft body contains Graph's auto-generated quoted reply thread.
- *
- * Graph's reply drafts have a stable shape: `<body ...><hr ...><div id="divRplyFwdMsg">`
- * (the divider + the `From:/Sent:/To:/Subject:` block). Either marker is sufficient
- * evidence that the draft has a quoted thread we need to preserve.
- *
- * Used by `updateDraft` to decide whether to splice a new caller fragment into an
- * existing reply draft or PATCH the body wholesale (fresh draft).
- */
-function hasQuotedReplyThread(content: string): boolean {
-  return /divRplyFwdMsg/i.test(content) || /<hr\b[^>]*>\s*<div[^>]*<b>From:<\/b>/i.test(content);
-}
-
-/**
- * Replace the caller fragment in an existing reply draft while preserving Graph's
- * auto-quoted thread (divider + header block + prior message body).
- *
- * Strategy:
- * - Locate `<body>` opening tag and the first `<hr ...>` after it.
- * - Replace everything between `<body>` and that `<hr>` with the new fragment.
- * - Leave the `<hr>` and everything after it untouched (preserves divider, From:/Sent:/To:/Subject:,
- *   prior body, and `</body></html>` tail).
- *
- * Falls back to inserting the fragment after `<body>` (without removing anything) when
- * no `<hr>` divider is present — the caller has already verified `hasQuotedReplyThread`,
- * so this fallback is purely defensive.
- *
- * Falls back to `callerFragment + draftContent` when there's no `<body>` tag at all.
- */
-function replaceCallerFragmentPreservingQuote(draftContent: string, callerFragment: string): string {
-  const bodyMatch = draftContent.match(/<body[^>]*>/i);
-  if (!bodyMatch || bodyMatch.index === undefined) {
-    return callerFragment + draftContent;
-  }
-  const afterBody = bodyMatch.index + bodyMatch[0].length;
-  const tail = draftContent.slice(afterBody);
-  const dividerMatch = tail.match(/<hr\b[^>]*>/i);
-  if (!dividerMatch || dividerMatch.index === undefined) {
-    return draftContent.slice(0, afterBody) + callerFragment + draftContent.slice(afterBody);
-  }
-  const dividerStart = afterBody + dividerMatch.index;
-  return draftContent.slice(0, afterBody) + callerFragment + draftContent.slice(dividerStart);
+  const region = findGraphQuotedReplyRegion(draftContent);
+  if (!region) return callerFragment + draftContent;
+  return draftContent.slice(0, region.bodyOpenEnd)
+    + callerFragment
+    + draftContent.slice(region.bodyOpenEnd);
 }
 
 /**


### PR DESCRIPTION
## Summary

- `update_draft` on a reply draft was PATCHing the body wholesale via `buildGraphBody`, which dropped the auto-quoted thread that `prepareReplyDraft` (fix #52) had merged in.
- When the body field is changing, `updateDraft` now GETs the current draft body, detects the quoted thread (`divRplyFwdMsg` or `<hr>` followed by `<b>From:</b>`), and splices the new caller fragment in above the divider — preserving the divider, header block, and prior message body.
- Falls back to existing `buildGraphBody` behavior on fresh drafts (no quoted-thread marker), so non-reply drafts are unaffected.

Closes #70.

## Test plan

- [x] Added 3 scenarios in `email-graph-provider.test.ts`:
  - `update_draft preserves Graph auto-quoted thread` — old caller content gone, new content inserted, divider + header + prior body preserved
  - `update_draft on a fresh draft replaces body wholesale` — no quoted-thread marker → unchanged behavior, falls through to `buildGraphBody`
  - `update_draft with bodyHtml preserves quoted thread and strips outer wrappers` — exactly one `<html>` and `<body>` in the merged content
- [x] Added 2 openspec scenarios under `Draft-Then-Send via createReplyAll`
- [x] `npm run test:run --workspace packages/provider-microsoft` — 134/134 pass
- [x] `npm run lint --workspace packages/provider-microsoft` — clean
- [x] `npm run check:spec-coverage` — 188/188 scenarios covered