### PR TITLE
feat(cli): add `call` subcommand for one-shot tool invocation

### DIFF
--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -139,6 +139,18 @@ The system SHALL provide a `call` subcommand that invokes a single MCP tool in a
 - **WHEN** stdout is piped (not a TTY)
 - **THEN** the JSON is emitted compactly so downstream tools like `jq` consume it cleanly
 
+#### Scenario: call --mailbox is merged into tool input args
+- **WHEN** `email-agent-mcp call <tool> --mailbox <id> --args '<json>'` is run
+- **AND** the JSON args do NOT already contain a `mailbox` field
+- **THEN** the system forwards `--mailbox` into the tool input as `args.mailbox` so mailbox-sensitive tools route to the requested account
+- **AND** when args ALREADY contain a `mailbox` field, the in-args value wins (the CLI flag does not clobber explicit args)
+
+#### Scenario: call get_mailbox_status reports state without requiring provider readiness
+- **WHEN** `email-agent-mcp call get_mailbox_status` is run
+- **AND** the provider is not configured, still warming up, or in an error state
+- **THEN** the system bypasses the eager-init gate and runs the diagnostic tool
+- **AND** the result reflects the actual state (`pending` / `not configured` / `error` / `connected`) instead of exiting with a provider-init error
+
 ### Requirement: Exit Codes
 
 The system SHALL use standard exit codes: 0 for success, 1 for runtime errors (e.g., serve startup failure), 2 for usage / invalid-argument errors, and 3 for `call` tool-failure results.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -107,9 +107,41 @@ The system SHALL provide `--version` and `--help` flags with diagnostic output.
 - **WHEN** `email-agent-mcp --version` is run
 - **THEN** the system prints the package version
 
+### Requirement: Call Subcommand
+
+The system SHALL provide a `call` subcommand that invokes a single MCP tool in a one-shot CLI process. Each invocation runs in a fresh process so source-code changes take effect without restarting any long-lived MCP host. Tool input may be supplied as inline JSON, a file path, or stdin.
+
+#### Scenario: call invokes a tool with --args JSON and prints raw result to stdout
+- **WHEN** `email-agent-mcp call <tool> --args '<json>'` is run
+- **THEN** the system eagerly initializes the provider, dispatches to the tool via the same `executeTool` primitive used by `serve`, and prints the raw action result as JSON on stdout
+- **AND** the result is NOT wrapped in any MCP transport envelope
+
+#### Scenario: call --list enumerates available tools
+- **WHEN** `email-agent-mcp call --list` is run
+- **THEN** the system prints a JSON array of `{name, description, annotations}` for every registered tool
+
+#### Scenario: call <tool> --schema prints input schema
+- **WHEN** `email-agent-mcp call <tool> --schema` is run
+- **THEN** the system prints the input JSON Schema for that tool (the same schema returned by MCP `tools/list`)
+
+#### Scenario: call exits with 2 on invalid args / unknown tool
+- **WHEN** `email-agent-mcp call` is invoked with an unknown tool name, malformed JSON args, or schema validation failure
+- **THEN** the process exits with code 2 and writes a clear error message to stderr
+
+#### Scenario: call exits with 3 on tool failure
+- **WHEN** the dispatched tool throws or returns a typed failure object (`{ success: false, error: ... }`)
+- **THEN** the process exits with code 3 (distinct from CLI/argument errors at code 2)
+
+#### Scenario: call output is pretty-printed to TTY and compact when piped
+- **WHEN** the result is written to stdout
+- **AND** stdout is a TTY (human session)
+- **THEN** the JSON is pretty-printed with 2-space indentation
+- **WHEN** stdout is piped (not a TTY)
+- **THEN** the JSON is emitted compactly so downstream tools like `jq` consume it cleanly
+
 ### Requirement: Exit Codes
 
-The system SHALL use standard exit codes: 0 for success, 1 for errors, 2 for usage errors.
+The system SHALL use standard exit codes: 0 for success, 1 for runtime errors (e.g., serve startup failure), 2 for usage / invalid-argument errors, and 3 for `call` tool-failure results.
 
 #### Scenario: Configuration error
 - **WHEN** `email-agent-mcp serve` fails due to missing configuration

--- a/packages/email-agent-mcp/bin/email-agent-mcp.js
+++ b/packages/email-agent-mcp/bin/email-agent-mcp.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { runCli } from '@usejunior/email-mcp';
+import { runCliDirect } from '@usejunior/email-mcp';
 
-runCli(process.argv.slice(2)).catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+// runCliDirect sets process.exitCode (not process.exit) so `serve` can stay
+// alive for the MCP stdio handshake while one-shot subcommands like `call`
+// propagate their non-zero exit codes to the shell.
+runCliDirect(process.argv.slice(2));

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -946,6 +946,121 @@ describe('cli/TTY-Aware Default Behavior', () => {
   });
 });
 
+describe('cli/Call Subcommand Argument Parsing', () => {
+  it('Scenario: call invokes a tool with --args JSON and prints raw result to stdout', () => {
+    const opts = parseCliArgs(['call', 'list_emails', '--args', '{"limit":5}']);
+    expect(opts.command).toBe('call');
+    expect(opts.callTool).toBe('list_emails');
+    expect(opts.callArgs).toBe('{"limit":5}');
+  });
+
+  it('Scenario: call --list enumerates available tools', () => {
+    const opts = parseCliArgs(['call', '--list']);
+    expect(opts.command).toBe('call');
+    expect(opts.callList).toBe(true);
+    expect(opts.callTool).toBeUndefined();
+  });
+
+  it('Scenario: call <tool> --schema prints input schema', () => {
+    const opts = parseCliArgs(['call', 'send_email', '--schema']);
+    expect(opts.command).toBe('call');
+    expect(opts.callTool).toBe('send_email');
+    expect(opts.callSchema).toBe(true);
+  });
+
+  it('Scenario: call accepts --args-file as an alternative to inline JSON', () => {
+    const opts = parseCliArgs(['call', 'send_email', '--args-file', '/tmp/args.json']);
+    expect(opts.callTool).toBe('send_email');
+    expect(opts.callArgsFile).toBe('/tmp/args.json');
+  });
+
+  it('Scenario: call accepts --args-stdin as an alternative to inline JSON', () => {
+    const opts = parseCliArgs(['call', 'send_email', '--args-stdin']);
+    expect(opts.callTool).toBe('send_email');
+    expect(opts.callArgsStdin).toBe(true);
+  });
+});
+
+describe('cli/Call Subcommand Exit Codes', () => {
+  it('Scenario: call exits with 2 on invalid args / unknown tool', async () => {
+    // Unknown tool — runCall errors out before provider init
+    const exitCode = await runCli(['call', 'no_such_tool_exists', '--args', '{}']);
+    expect(exitCode).toBe(2);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('unknown tool'),
+    );
+  });
+
+  it('Scenario: call exits with 2 on malformed --args JSON', async () => {
+    // Malformed JSON in --args — readCallArgs throws before provider init
+    const exitCode = await runCli(['call', 'list_emails', '--args', 'not-json']);
+    expect(exitCode).toBe(2);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid JSON args'),
+    );
+  });
+
+  it('Scenario: call exits with 2 when no tool name is provided', async () => {
+    const exitCode = await runCli(['call']);
+    expect(exitCode).toBe(2);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('requires a tool name'),
+    );
+  });
+
+  it('Scenario: call exits with 3 on tool failure', async () => {
+    // Inject a stub action that returns a typed failure object via vi.doMock,
+    // then verify runCall maps that to exit code 3 (distinct from CLI errors at 2).
+    const { z } = await import('zod');
+    const failingAction = {
+      name: 'always_fails',
+      description: 'test stub',
+      input: z.object({}),
+      output: z.object({ success: z.boolean() }),
+      annotations: {},
+      run: async () => ({ success: false, error: { code: 'TEST_FAILURE', message: 'stubbed' } }),
+    };
+    const noopState = { status: 'connected', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => noopState,
+        buildLazyActions: async () => [failingAction],
+        ensureProvider: async () => undefined,
+        waitForInit: async () => undefined,
+      };
+    });
+    try {
+      const { runCall } = await import('./cli.js');
+      const exitCode = await runCall({ command: 'call', callTool: 'always_fails', callArgs: '{}' });
+      expect(exitCode).toBe(3);
+    } finally {
+      vi.doUnmock('./server.js');
+    }
+  });
+});
+
+describe('cli/Call Subcommand Output Formatting', () => {
+  it('Scenario: call output is pretty-printed to TTY and compact when piped', async () => {
+    const { formatJsonForOutput } = await import('./cli.js');
+    const value = { emails: [{ id: '1' }, { id: '2' }] };
+
+    // TTY: pretty-printed with newlines and 2-space indent
+    const tty = formatJsonForOutput(value, true);
+    expect(tty).toContain('\n');
+    expect(tty).toContain('  ');
+    expect(JSON.parse(tty)).toEqual(value);
+
+    // Pipe: compact, no newlines, jq-friendly
+    const piped = formatJsonForOutput(value, false);
+    expect(piped).not.toContain('\n');
+    expect(piped).toBe(JSON.stringify(value));
+    expect(JSON.parse(piped)).toEqual(value);
+  });
+});
+
 describe('cli/Exit Codes', () => {
   it('Scenario: Configuration error', async () => {
     // WHEN email-agent-mcp serve fails due to missing configuration

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -367,6 +367,22 @@ describe('cli/Direct entrypoint lifecycle', () => {
       expect.stringContaining('MCP server started'),
     );
   });
+
+  it('Scenario: Direct entrypoint propagates non-zero exit code from runCli to process.exitCode', async () => {
+    // Regression: the bin script previously discarded runCli's return value, so
+    // `email-agent-mcp call <bogus>` returned exit 0 to the shell even though
+    // runCall correctly returned 2. The fix routes the bin through runCliDirect
+    // which sets process.exitCode. This test pins that propagation in place.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await runCliDirect(['bogus-command']);
+
+    expect(process.exitCode).toBe(2);
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown command'),
+    );
+  });
 });
 
 describe('cli/Watch Subcommand', () => {

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -1058,6 +1058,139 @@ describe('cli/Call Subcommand Exit Codes', () => {
   });
 });
 
+describe('cli/Call Subcommand Mailbox Routing', () => {
+  it('Scenario: call --mailbox is merged into tool input args', async () => {
+    // Regression: peer review caught that --mailbox was parsed but never
+    // forwarded to executeTool, which meant `call delete_email --mailbox
+    // personal --args '{}'` silently targeted the default mailbox. The fix
+    // merges opts.mailbox into args when args.mailbox isn't already set.
+    const { z } = await import('zod');
+    const capturedInputs: Array<{ mailbox?: string }> = [];
+    const recordingAction = {
+      name: 'records_mailbox',
+      description: 'test stub that records its input mailbox',
+      input: z.object({ mailbox: z.string().optional() }),
+      output: z.object({ ok: z.boolean() }),
+      annotations: {},
+      run: async (_ctx: unknown, input: { mailbox?: string }) => {
+        capturedInputs.push(input);
+        return { ok: true };
+      },
+    };
+    const noopState = { status: 'connected', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => noopState,
+        buildLazyActions: async () => [recordingAction],
+        ensureProvider: async () => undefined,
+      };
+    });
+    try {
+      const { runCall } = await import('./cli.js');
+      const exitCode = await runCall({
+        command: 'call',
+        callTool: 'records_mailbox',
+        callArgs: '{}',
+        mailbox: 'personal',
+      });
+      expect(exitCode).toBe(0);
+      expect(capturedInputs[0]?.mailbox).toBe('personal');
+    } finally {
+      vi.doUnmock('./server.js');
+    }
+  });
+
+  it('Scenario: call --mailbox does not clobber a mailbox already in --args', async () => {
+    const { z } = await import('zod');
+    const capturedInputs: Array<{ mailbox?: string }> = [];
+    const recordingAction = {
+      name: 'records_mailbox_2',
+      description: 'test stub',
+      input: z.object({ mailbox: z.string().optional() }),
+      output: z.object({ ok: z.boolean() }),
+      annotations: {},
+      run: async (_ctx: unknown, input: { mailbox?: string }) => {
+        capturedInputs.push(input);
+        return { ok: true };
+      },
+    };
+    const noopState = { status: 'connected', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => noopState,
+        buildLazyActions: async () => [recordingAction],
+        ensureProvider: async () => undefined,
+      };
+    });
+    try {
+      const { runCall } = await import('./cli.js');
+      // --args has a mailbox; --mailbox flag should NOT overwrite it
+      const exitCode = await runCall({
+        command: 'call',
+        callTool: 'records_mailbox_2',
+        callArgs: '{"mailbox":"work"}',
+        mailbox: 'personal',
+      });
+      expect(exitCode).toBe(0);
+      expect(capturedInputs[0]?.mailbox).toBe('work');
+    } finally {
+      vi.doUnmock('./server.js');
+    }
+  });
+});
+
+describe('cli/Call Subcommand Diagnostic Tools', () => {
+  it('Scenario: call get_mailbox_status reports state without requiring provider readiness', async () => {
+    // Regression: the eager-init gate previously short-circuited get_mailbox_status
+    // before it could run, even though that tool is intentionally non-blocking and
+    // designed to report `pending`/`not_configured`/`error` states. The fix skips
+    // ensureProvider when the tool name is `get_mailbox_status`.
+    const { z } = await import('zod');
+    let ranWithoutInit = false;
+    const statusAction = {
+      name: 'get_mailbox_status',
+      description: 'diagnostic stub',
+      input: z.object({}),
+      output: z.object({ status: z.string() }),
+      annotations: {},
+      run: async () => {
+        ranWithoutInit = true;
+        return { status: 'not configured' };
+      },
+    };
+    const errorState = { status: 'error', error: 'simulated init failure', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => errorState,
+        buildLazyActions: async () => [statusAction],
+        // ensureProvider would normally throw here — verify we never call it
+        ensureProvider: async () => { throw new Error('should not be called for get_mailbox_status'); },
+      };
+    });
+    try {
+      const { runCall } = await import('./cli.js');
+      const exitCode = await runCall({
+        command: 'call',
+        callTool: 'get_mailbox_status',
+        callArgs: '{}',
+      });
+      expect(ranWithoutInit).toBe(true);
+      expect(exitCode).toBe(0);
+    } finally {
+      vi.doUnmock('./server.js');
+    }
+  });
+});
+
 describe('cli/Call Subcommand Output Formatting', () => {
   it('Scenario: call output is pretty-printed to TTY and compact when piped', async () => {
     const { formatJsonForOutput } = await import('./cli.js');

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -25,6 +25,13 @@ export interface CliOptions {
   clientId?: string;
   clientSecret?: string;
   pollInterval?: number; // seconds
+  // `call` subcommand options
+  callTool?: string;          // first positional after `call` — the tool name
+  callArgs?: string;          // raw JSON string from --args
+  callArgsFile?: string;      // path passed via --args-file
+  callArgsStdin?: boolean;    // read JSON args from stdin
+  callList?: boolean;         // --list — enumerate tools
+  callSchema?: boolean;       // --schema — print input schema for a tool
 }
 
 // NemoClaw egress domains for all providers
@@ -394,10 +401,37 @@ export function parseCliArgs(args: string[]): CliOptions {
       opts.pollInterval = parseInt(args[++i]!, 10);
       continue;
     }
+    // `call` subcommand flags
+    if (arg === '--args' && i + 1 < args.length) {
+      opts.callArgs = args[++i];
+      continue;
+    }
+    if (arg === '--args-file' && i + 1 < args.length) {
+      opts.callArgsFile = args[++i];
+      continue;
+    }
+    if (arg === '--args-stdin') {
+      opts.callArgsStdin = true;
+      continue;
+    }
+    if (arg === '--list') {
+      opts.callList = true;
+      continue;
+    }
+    if (arg === '--schema') {
+      opts.callSchema = true;
+      continue;
+    }
 
     // First positional arg is the command
     if (!opts.command && !arg.startsWith('-')) {
       opts.command = arg;
+      continue;
+    }
+    // Second positional (only meaningful for `call`) is the tool name
+    if (opts.command === 'call' && !opts.callTool && !arg.startsWith('-')) {
+      opts.callTool = arg;
+      continue;
     }
   }
 
@@ -434,6 +468,8 @@ export async function runCli(args: string[]): Promise<number> {
       return await runStatus();
     case 'token':
       return await runToken(opts);
+    case 'call':
+      return await runCall(opts);
     case 'help':
       printHelp();
       return 0;
@@ -471,6 +507,158 @@ async function runServe(_opts: CliOptions): Promise<number> {
   } catch (err) {
     console.error('Error starting MCP server:', err instanceof Error ? err.message : err);
     return 1;
+  }
+}
+
+/**
+ * Read JSON args for `call` from --args, --args-file, or --args-stdin.
+ * Returns the parsed object, or `{}` when no source is provided. Throws on
+ * source conflict or JSON parse failure (caller maps to exit code 2).
+ */
+async function readCallArgs(opts: CliOptions): Promise<Record<string, unknown>> {
+  const sources = [opts.callArgs !== undefined, opts.callArgsFile !== undefined, opts.callArgsStdin === true]
+    .filter(Boolean).length;
+  if (sources > 1) {
+    throw new Error('Pass at most one of --args, --args-file, --args-stdin');
+  }
+
+  let raw: string | undefined;
+  if (opts.callArgs !== undefined) {
+    raw = opts.callArgs;
+  } else if (opts.callArgsFile !== undefined) {
+    raw = await readFile(opts.callArgsFile, 'utf-8');
+  } else if (opts.callArgsStdin) {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    raw = Buffer.concat(chunks).toString('utf-8').trim();
+  }
+
+  if (!raw) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Invalid JSON args: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Args must be a JSON object');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Format a JSON value for CLI output. Pretty-prints with 2-space indentation
+ * when the destination is a TTY (human session); emits compact JSON when piped
+ * so downstream tools like `jq` consume it cleanly. Exported for testability.
+ */
+export function formatJsonForOutput(value: unknown, isTty: boolean): string {
+  return isTty ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+}
+
+function printJsonResult(value: unknown): void {
+  process.stdout.write(formatJsonForOutput(value, !!process.stdout.isTTY) + '\n');
+}
+
+/**
+ * Run a single tool invocation as a one-shot CLI command. Eagerly initializes
+ * the provider (no demo-mode fallback) so auth failures surface as exit codes
+ * rather than masquerading as `connecting` results.
+ *
+ * Exit codes:
+ *   0 — tool ran and returned a non-failure result
+ *   2 — CLI/argument/schema/unknown-tool error
+ *   3 — tool returned a typed failure ({ success: false, error: ... }) or threw
+ */
+export async function runCall(opts: CliOptions): Promise<number> {
+  const { createLazyProviderState, buildLazyActions, ensureProvider, waitForInit, executeTool, getActionInputJsonSchema } =
+    await import('./server.js');
+  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist } = await import('@usejunior/email-core');
+
+  // Match `serve`'s allowlist setup, but DON'T spawn a watcher in a one-shot
+  // process — load once and snapshot.
+  const sendAllowlistPath = getSendAllowlistPath();
+  const sendAllowlistWatcher = new WatchedAllowlist(sendAllowlistPath, loadSendAllowlist);
+  await sendAllowlistWatcher.start();
+  const snapshot = sendAllowlistWatcher.config;
+  sendAllowlistWatcher.close();
+  const getSendAllowlist = () => snapshot;
+
+  const state = createLazyProviderState();
+  const actions = await buildLazyActions(state, getSendAllowlist);
+
+  // --list: enumerate tools and exit
+  if (opts.callList) {
+    const summary = actions.map(a => ({
+      name: a.name,
+      description: a.description,
+      annotations: a.annotations ?? {},
+    }));
+    printJsonResult(summary);
+    return 0;
+  }
+
+  if (!opts.callTool) {
+    console.error('Error: `call` requires a tool name. Usage: email-agent-mcp call <tool> [--args \'<json>\' | --args-file <path> | --args-stdin]');
+    console.error('       email-agent-mcp call --list                # enumerate tools');
+    console.error('       email-agent-mcp call <tool> --schema       # print input schema');
+    return 2;
+  }
+
+  const action = actions.find(a => a.name === opts.callTool);
+  if (!action) {
+    console.error(`Error: unknown tool "${opts.callTool}". Run \`email-agent-mcp call --list\` to see available tools.`);
+    return 2;
+  }
+
+  // --schema: print input JSON Schema and exit
+  if (opts.callSchema) {
+    printJsonResult(getActionInputJsonSchema(action));
+    return 0;
+  }
+
+  // Read args
+  let args: Record<string, unknown>;
+  try {
+    args = await readCallArgs(opts);
+  } catch (err) {
+    console.error(`Error: ${err instanceof Error ? err.message : String(err)}`);
+    return 2;
+  }
+
+  // Eagerly initialize the provider — no demo-mode fallback for one-shot CLI
+  try {
+    await ensureProvider(state);
+    await waitForInit(state);
+  } catch (err) {
+    console.error(`Error: provider initialization failed — ${err instanceof Error ? err.message : String(err)}`);
+    return 3;
+  }
+  if (state.status === 'error') {
+    console.error(`Error: provider error — ${state.error ?? 'unknown'}`);
+    return 3;
+  }
+
+  // Execute
+  try {
+    const { result } = await executeTool(actions, {}, opts.callTool, args);
+    printJsonResult(result);
+    // Map typed-failure results to exit code 3 so shell consumers can detect failure
+    if (result !== null && typeof result === 'object' && (result as { success?: unknown }).success === false) {
+      return 3;
+    }
+    return 0;
+  } catch (err) {
+    // Zod parse errors and unknown-tool errors land here; treat schema errors as 2, runtime errors as 3
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.startsWith('Unknown tool:') || /^\[?{?"?(issues|code|expected|received)/.test(message)) {
+      console.error(`Error: ${message}`);
+      return 2;
+    }
+    console.error(`Error: ${message}`);
+    return 3;
   }
 }
 
@@ -1175,6 +1363,8 @@ COMMANDS:
   email-agent-mcp status       Show account + connection health
   email-agent-mcp token        Print a Graph API bearer token to stdout
   email-agent-mcp serve        Force MCP server mode
+  email-agent-mcp call <tool>  Invoke a single MCP tool one-shot (no long-lived server)
+                              See \`call\` examples below
   email-agent-mcp help         Show this help
 
 OPTIONS:
@@ -1188,6 +1378,25 @@ OPTIONS:
   --provider <name>      Auth provider (microsoft, gmail)
   --client-id <id>       OAuth client ID override
   --client-secret <val>  OAuth client secret override (used for Gmail configure)
+
+CALL OPTIONS (used with \`call <tool>\`):
+  --args '<json>'        Inline JSON args for the tool
+  --args-file <path>     Read JSON args from a file
+  --args-stdin           Read JSON args from stdin
+  --list                 (with \`call\`) List available tools and exit
+  --schema               Print the input JSON Schema for the named tool
+
+CALL EXAMPLES:
+  email-agent-mcp call --list
+  email-agent-mcp call list_emails --schema
+  email-agent-mcp call list_emails --args '{"limit":5,"unread":true}'
+  echo '{"limit":5}' | email-agent-mcp call list_emails --args-stdin
+  email-agent-mcp call list_emails --args '{"limit":5}' | jq '.emails[].subject'
+
+CALL EXIT CODES:
+  0  Tool ran and returned a non-failure result
+  2  CLI / argument / unknown-tool / schema-validation error
+  3  Tool returned a typed failure ({success:false,...}) or threw at runtime
 `.trim());
 }
 

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -573,17 +573,15 @@ function printJsonResult(value: unknown): void {
  *   3 — tool returned a typed failure ({ success: false, error: ... }) or threw
  */
 export async function runCall(opts: CliOptions): Promise<number> {
-  const { createLazyProviderState, buildLazyActions, ensureProvider, waitForInit, executeTool, getActionInputJsonSchema } =
+  const { createLazyProviderState, buildLazyActions, ensureProvider, executeTool, getActionInputJsonSchema } =
     await import('./server.js');
-  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist } = await import('@usejunior/email-core');
+  const { loadSendAllowlist, getSendAllowlistPath } = await import('@usejunior/email-core');
 
   // Match `serve`'s allowlist setup, but DON'T spawn a watcher in a one-shot
-  // process — load once and snapshot.
+  // process — load once and snapshot. (`serve` uses `WatchedAllowlist` for
+  // hot-reload; `call` exits before any reload could fire.)
   const sendAllowlistPath = getSendAllowlistPath();
-  const sendAllowlistWatcher = new WatchedAllowlist(sendAllowlistPath, loadSendAllowlist);
-  await sendAllowlistWatcher.start();
-  const snapshot = sendAllowlistWatcher.config;
-  sendAllowlistWatcher.close();
+  const snapshot = await loadSendAllowlist(sendAllowlistPath);
   const getSendAllowlist = () => snapshot;
 
   const state = createLazyProviderState();
@@ -628,10 +626,10 @@ export async function runCall(opts: CliOptions): Promise<number> {
     return 2;
   }
 
-  // Eagerly initialize the provider — no demo-mode fallback for one-shot CLI
+  // Eagerly initialize the provider — no demo-mode fallback for one-shot CLI.
+  // ensureProvider() awaits init internally, so no separate waitForInit() needed.
   try {
     await ensureProvider(state);
-    await waitForInit(state);
   } catch (err) {
     console.error(`Error: provider initialization failed — ${err instanceof Error ? err.message : String(err)}`);
     return 3;
@@ -642,6 +640,7 @@ export async function runCall(opts: CliOptions): Promise<number> {
   }
 
   // Execute
+  const { z } = await import('zod');
   try {
     const { result } = await executeTool(actions, {}, opts.callTool, args);
     printJsonResult(result);
@@ -651,9 +650,13 @@ export async function runCall(opts: CliOptions): Promise<number> {
     }
     return 0;
   } catch (err) {
-    // Zod parse errors and unknown-tool errors land here; treat schema errors as 2, runtime errors as 3
+    // ZodError = schema validation failure (CLI/user error); everything else is runtime
+    if (err instanceof z.ZodError) {
+      console.error(`Error: ${err.message}`);
+      return 2;
+    }
     const message = err instanceof Error ? err.message : String(err);
-    if (message.startsWith('Unknown tool:') || /^\[?{?"?(issues|code|expected|received)/.test(message)) {
+    if (message.startsWith('Unknown tool:')) {
       console.error(`Error: ${message}`);
       return 2;
     }

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -626,17 +626,32 @@ export async function runCall(opts: CliOptions): Promise<number> {
     return 2;
   }
 
-  // Eagerly initialize the provider — no demo-mode fallback for one-shot CLI.
-  // ensureProvider() awaits init internally, so no separate waitForInit() needed.
-  try {
-    await ensureProvider(state);
-  } catch (err) {
-    console.error(`Error: provider initialization failed — ${err instanceof Error ? err.message : String(err)}`);
-    return 3;
+  // The general-purpose `--mailbox` flag (also used by `serve`/`watch`) routes
+  // mailbox-sensitive tools to a specific account. If the caller passed it AND
+  // didn't already encode it in --args, forward it into the tool input — without
+  // this merge, `call delete_email --mailbox personal --args '{...}'` would
+  // silently target the default mailbox.
+  if (opts.mailbox && args['mailbox'] === undefined) {
+    args['mailbox'] = opts.mailbox;
   }
-  if (state.status === 'error') {
-    console.error(`Error: provider error — ${state.error ?? 'unknown'}`);
-    return 3;
+
+  // `get_mailbox_status` is intentionally non-blocking: it inspects state.status
+  // (pending/connecting/not_configured/error) and reports it as the result. Skip
+  // the eager-init gate for this tool so it can serve as a diagnostic even when
+  // the provider isn't ready.
+  if (opts.callTool !== 'get_mailbox_status') {
+    // Eagerly initialize the provider — no demo-mode fallback for one-shot CLI.
+    // ensureProvider() awaits init internally, so no separate waitForInit() needed.
+    try {
+      await ensureProvider(state);
+    } catch (err) {
+      console.error(`Error: provider initialization failed — ${err instanceof Error ? err.message : String(err)}`);
+      return 3;
+    }
+    if (state.status === 'error') {
+      console.error(`Error: provider error — ${state.error ?? 'unknown'}`);
+      return 3;
+    }
   }
 
   // Execute

--- a/packages/email-mcp/src/index.ts
+++ b/packages/email-mcp/src/index.ts
@@ -1,4 +1,4 @@
 // @usejunior/email-mcp — MCP server, CLI, and watcher
 export { runServer, createSandboxServer } from './server.js';
-export { runCli } from './cli.js';
+export { runCli, runCliDirect } from './cli.js';
 export { sendWake, buildWakePayload, getWatchMode } from './watcher.js';

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -4,6 +4,8 @@ import { deleteEmailAction } from '@usejunior/email-core';
 import {
   actionsToMcpTools,
   handleToolCall,
+  executeTool,
+  getActionInputJsonSchema,
   getServerManifest,
   createLazyProviderState,
   waitForInit,
@@ -33,6 +35,42 @@ const testActions: EmailActionDef[] = [
     run: async (_ctx, _input) => ({ success: true }),
   },
 ];
+
+describe('mcp-transport/executeTool primitive', () => {
+  it('Scenario: executeTool returns raw action result without MCP envelope', async () => {
+    // Both `serve` (via handleToolCall) and `call` (via the CLI) dispatch through
+    // executeTool. The raw shape MUST be free of MCP transport formatting so the
+    // CLI can emit it directly while handleToolCall layers the envelope on top.
+    const { result, input } = await executeTool(testActions, {}, 'list_emails', { unread: true });
+    expect(result).toEqual({ emails: [{ id: 'msg-1' }] });
+    expect(input).toEqual({ unread: true });
+  });
+
+  it('Scenario: executeTool throws on unknown tool', async () => {
+    await expect(executeTool(testActions, {}, 'nonexistent', {}))
+      .rejects.toThrow(/Unknown tool/);
+  });
+
+  it('Scenario: handleToolCall wraps executeTool result in MCP content envelope', async () => {
+    // Regression: handleToolCall must continue to produce the MCP `content` envelope
+    // after the executeTool extraction.
+    const result = await handleToolCall(testActions, {}, 'list_emails', { unread: true });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]!.type).toBe('text');
+    const parsed = JSON.parse((result.content[0] as { text: string }).text);
+    expect(parsed.emails).toEqual([{ id: 'msg-1' }]);
+  });
+
+  it('Scenario: getActionInputJsonSchema returns JSON Schema for `call <tool> --schema`', () => {
+    const action = testActions.find(a => a.name === 'send_email')!;
+    const schema = getActionInputJsonSchema(action);
+    expect(schema['type']).toBe('object');
+    const properties = schema['properties'] as Record<string, unknown>;
+    expect(properties['to']).toBeDefined();
+    expect(properties['subject']).toBeDefined();
+    expect(properties['body']).toBeDefined();
+  });
+});
 
 describe('mcp-transport/Action to Tool Mapping', () => {
   it('Scenario: Auto-registration', () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -215,14 +215,23 @@ export function coerceArgsForZod(schema: z.ZodType, args: unknown): unknown {
 }
 
 /**
- * Handle an MCP tool call by dispatching to the right action.
+ * Execute a tool by dispatching to the right action and returning the raw
+ * action result (no transport-specific wrapping).
+ *
+ * Both transports (`serve` via `handleToolCall`, and `call` via the CLI) run
+ * inputs through this single primitive so they share parsing, coercion, and
+ * dispatch behavior. Transport-specific formatting (MCP envelopes, CLI JSON
+ * output) is layered on top by the caller.
+ *
+ * Returns `{ result, input }` so callers that need the parsed input later
+ * (e.g., to format MCP `resource` URIs) don't have to re-parse.
  */
-export async function handleToolCall(
+export async function executeTool(
   actions: EmailActionDef[],
   ctx: unknown,
   toolName: string,
   args: Record<string, unknown>,
-): Promise<McpToolCallResult> {
+): Promise<{ result: unknown; input: unknown }> {
   const action = actions.find(a => a.name === toolName);
   if (!action) {
     throw new Error(`Unknown tool: ${toolName}`);
@@ -231,6 +240,20 @@ export async function handleToolCall(
   const coerced = coerceArgsForZod(action.input, args);
   const input = action.input.parse(coerced);
   const result = await action.run(ctx, input);
+  return { result, input };
+}
+
+/**
+ * Handle an MCP tool call by dispatching via `executeTool` and wrapping the
+ * raw result in the MCP `content` envelope.
+ */
+export async function handleToolCall(
+  actions: EmailActionDef[],
+  ctx: unknown,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<McpToolCallResult> {
+  const { result, input } = await executeTool(actions, ctx, toolName, args);
 
   // download_attachment returns base64 inline. To avoid stuffing megabytes of
   // base64 inside the JSON-stringified text envelope (which agents have to
@@ -272,6 +295,14 @@ export async function handleToolCall(
   return {
     content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
   };
+}
+
+/**
+ * Public Zod-to-JSON-Schema helper exposed for the `call <tool> --schema` CLI
+ * surface. Mirrors the conversion used by `actionsToMcpTools` for `tools/list`.
+ */
+export function getActionInputJsonSchema(action: EmailActionDef): Record<string, unknown> {
+  return zodToJsonSchema(action.input);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `email-agent-mcp call <tool> --args '<json>'` so MCP tools can be invoked one-shot from a fresh process — no long-lived MCP host required.
- Sidesteps the "code change → restart Claude Code → MCP picks up new build" cycle. Side benefit: tools become scriptable from cron, launchd, hooks, and shell pipelines.
- Also exposes `--list` (enumerate tools) and `--schema` (print input JSON Schema), and accepts args via `--args` / `--args-file` / `--args-stdin`.

Closes #72.

## Architecture

Extracted `executeTool()` in `server.ts` as the shared dispatch primitive. `handleToolCall()` (MCP transport) becomes a thin wrapper that calls `executeTool()` then formats the result into the MCP `content` envelope (preserving the `download_attachment` resource special-case). `runCall()` in the CLI calls `executeTool()` then writes raw JSON to stdout.

This keeps `serve` and `call` parity by construction — they share the same action registry and the dispatch path. Only the output formatting diverges.

**Differences vs. `serve`:**
- Eager provider init (no demo-mode fallback) — auth failures surface as exit codes instead of masquerading as `connecting` results
- Snapshot allowlist (no `WatchedAllowlist` FS watcher in a one-shot process)

## Output

- **stdout** = JSON tool result (pretty-printed for TTY, compact for pipe via `process.stdout.isTTY`)
- **stderr** = logs / errors only, so `call ... | jq` works
- **Exit codes**:
  - `0` success
  - `2` CLI / argument / schema / unknown-tool error
  - `3` typed tool failure (`{success:false,...}`) or runtime throw

## Out of scope (per peer review with Codex + Gemini)

- Schema-generated per-tool flags — heterogeneous tool inputs, low ROI vs. the `--args` JSON path
- JSON-RPC over stdin as a public surface — confusing UX, requires MCP envelope knowledge; keep as internal debug if useful later
- Cross-process token-refresh locking — existing single-flight is process-local; mostly fine for read-path `call` invocations, low risk

## Test plan

- [x] 5 new openspec scenarios under `cli/Call Subcommand` + `cli/Exit Codes`
- [x] Unit: `parseCliArgs` handles `call` / `--args` / `--args-file` / `--args-stdin` / `--list` / `--schema`
- [x] Unit: `executeTool` returns raw action result; `handleToolCall` wraps it (regression)
- [x] Unit: `getActionInputJsonSchema` exposes input schema
- [x] Unit: `runCall` exits with 2 on unknown tool, malformed JSON, missing tool name
- [x] Unit: `runCall` exits with 3 on typed tool failure (via `vi.doMock` stub)
- [x] Unit: `formatJsonForOutput` pretty-vs-compact based on isTty
- [x] **177/177 tests pass, 194/194 spec coverage**
- [x] Smoke-tested live against real Microsoft Graph API:
  - `call --list` returned all 17 tools
  - `call list_emails --schema` returned valid JSON Schema
  - `call list_emails --args '{"limit":2}'` returned live Graph results