### PR TITLE
chore(release): 0.1.8

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.6",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -4082,10 +4082,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.1.6"
+        "@usejunior/email-mcp": "^0.1.8"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -4096,7 +4096,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "^18.0.0",
@@ -4115,17 +4115,14 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.1.6",
-        "@usejunior/provider-gmail": "^0.1.6",
-        "@usejunior/provider-microsoft": "^0.1.6"
-      },
-      "bin": {
-        "email-agent-mcp": "dist/cli.js"
+        "@usejunior/email-core": "^0.1.8",
+        "@usejunior/provider-gmail": "^0.1.8",
+        "@usejunior/provider-microsoft": "^0.1.8"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -4139,11 +4136,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.1.6"
+        "@usejunior/email-core": "^0.1.8"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -4157,13 +4154,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.1.6",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.1.6"
+        "@usejunior/email-core": "^0.1.8"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 and manual-token Gmail setup",
   "type": "module",

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook and manual-token Gmail setup",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.1.7"
+    "@usejunior/email-mcp": "^0.1.8"
   },
   "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -21,9 +21,9 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.1.7",
-    "@usejunior/provider-gmail": "^0.1.7",
-    "@usejunior/provider-microsoft": "^0.1.7"
+    "@usejunior/email-core": "^0.1.8",
+    "@usejunior/provider-gmail": "^0.1.8",
+    "@usejunior/provider-microsoft": "^0.1.8"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.1.7"
+    "@usejunior/email-core": "^0.1.8"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.1.7"
+    "@usejunior/email-core": "^0.1.8"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

Bumps the workspace, package, MCP registry, and Gemini extension versions from 0.1.7 to 0.1.8 for the next release.

## Included release value

- **feat(email-mcp)**: add `download_attachment` MCP tool for inline base64 retrieval (#67)
- **feat(cli)**: add `call` subcommand for one-shot tool invocation (#73)
- **fix(graph)**: preserve auto-quoted thread history in `update_draft` (#71) — every `update_draft` on a reply draft was wiping Graph's auto-quoted thread; now spliced via shared anatomy parser. Includes the follow-up bin-script fix that propagates non-zero exit codes from `runCli` to the shell.
- **fix(email-core)**: parse name-address strings in cc/to compose inputs (#64)
- **refactor(email-core, provider-microsoft, provider-gmail, email-mcp)**: harden `download_attachment` (#69)

## Validation

- npm run build (all 4 packages clean)
- npm run test:run (612 tests pass: 248 email-core + 133 provider-microsoft + 68 provider-gmail + 163 email-mcp)
- npm run lint
- npm run check:spec-coverage (196/196 scenarios)
- npm run check:server-json
- npm run check:gemini-extension-manifest
- live Microsoft mailbox smoke for `update_draft` quote preservation (create reply draft → update → verify quoted thread retained)
- live Microsoft mailbox smoke for `call` subcommand: `--list`, `--schema`, `--args`, `--args-file`, `--args-stdin`, jq pipe integration, all four exit codes (0/2/3/runtime), end-to-end create_draft → update_draft → read_email flow