### PR TITLE
fix(search): surface conversationId and threadId on search_emails results

### DIFF
--- a/packages/email-core/src/actions/search.test.ts
+++ b/packages/email-core/src/actions/search.test.ts
@@ -45,4 +45,65 @@ describe('email-read/Search Emails', () => {
     expect(mailboxNames).toContain('work');
     expect(mailboxNames).toContain('personal');
   });
+
+  it('Scenario: Multi-mailbox search surfaces conversationId and threadId when providers populate them', async () => {
+    const workProvider = new MockEmailProvider();
+    workProvider.addMessage({
+      id: 'work-1',
+      subject: 'Contract review needed',
+      from: { email: 'alice@corp.com' },
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: false,
+      hasAttachments: false,
+      conversationId: 'graph-conversation-abc',
+    });
+
+    const personalProvider = new MockEmailProvider();
+    personalProvider.addMessage({
+      id: 'personal-1',
+      subject: 'Contract review for home purchase',
+      from: { email: 'realtor@homes.com' },
+      receivedAt: '2024-03-15T11:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+      threadId: 'gmail-thread-xyz',
+    });
+
+    const allMailboxes: MailboxEntry[] = [
+      { name: 'work', provider: workProvider, providerType: 'microsoft', isDefault: true, status: 'connected' },
+      { name: 'personal', provider: personalProvider, providerType: 'gmail', isDefault: false, status: 'connected' },
+    ];
+
+    const ctx: ActionContext = { provider: workProvider, allMailboxes };
+
+    const result = await searchEmailsAction.run(ctx, { query: 'contract review', mailbox: null });
+
+    const work = result.emails.find(e => e.id === 'work-1');
+    const personal = result.emails.find(e => e.id === 'personal-1');
+    expect(work?.conversationId).toBe('graph-conversation-abc');
+    expect(work?.threadId).toBeUndefined();
+    expect(personal?.threadId).toBe('gmail-thread-xyz');
+    expect(personal?.conversationId).toBeUndefined();
+  });
+
+  it('Scenario: Single-provider search surfaces conversationId from the resolved provider', async () => {
+    const workProvider = new MockEmailProvider();
+    workProvider.addMessage({
+      id: 'work-1',
+      subject: 'Contract review needed',
+      from: { email: 'alice@corp.com' },
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: false,
+      hasAttachments: false,
+      conversationId: 'graph-conversation-abc',
+    });
+
+    const ctx: ActionContext = { provider: workProvider, mailboxName: 'work' };
+
+    const result = await searchEmailsAction.run(ctx, { query: 'contract review' });
+
+    expect(result.emails).toHaveLength(1);
+    expect(result.emails[0]?.conversationId).toBe('graph-conversation-abc');
+    expect(result.emails[0]?.threadId).toBeUndefined();
+  });
 });

--- a/packages/email-core/src/actions/search.ts
+++ b/packages/email-core/src/actions/search.ts
@@ -1,6 +1,27 @@
 // search_emails action — full-text search using provider's native query
 import { z } from 'zod';
 import type { EmailAction } from './registry.js';
+import type { EmailMessage } from '../types.js';
+
+/**
+ * Provider-native conversation handles surfaced on search results so MCP
+ * clients can group rows by thread without parsing subjects. Microsoft Graph
+ * populates `conversationId`; Gmail populates `threadId`. Both are optional
+ * because providers may legitimately produce neither (e.g. drafts).
+ */
+export const SearchEmailThreadFieldsSchema = z.object({
+  conversationId: z.string().optional(),
+  threadId: z.string().optional(),
+});
+
+export function getSearchEmailThreadFields(
+  message: Pick<EmailMessage, 'conversationId' | 'threadId'>,
+): z.infer<typeof SearchEmailThreadFieldsSchema> {
+  return {
+    ...(message.conversationId !== undefined ? { conversationId: message.conversationId } : {}),
+    ...(message.threadId !== undefined ? { threadId: message.threadId } : {}),
+  };
+}
 
 const SearchEmailsInput = z.object({
   query: z.string(),
@@ -20,9 +41,7 @@ const SearchEmailsOutput = z.object({
     hasAttachments: z.boolean(),
     mailbox: z.string().optional(),
     snippet: z.string().optional(),
-    conversationId: z.string().optional(),
-    threadId: z.string().optional(),
-  })),
+  }).extend(SearchEmailThreadFieldsSchema.shape)),
 });
 
 export const searchEmailsAction: EmailAction<
@@ -58,8 +77,7 @@ export const searchEmailsAction: EmailAction<
           hasAttachments: m.hasAttachments,
           mailbox: m.mailbox,
           snippet: m.snippet,
-          ...(m.conversationId !== undefined ? { conversationId: m.conversationId } : {}),
-          ...(m.threadId !== undefined ? { threadId: m.threadId } : {}),
+          ...getSearchEmailThreadFields(m),
         })),
       };
     }
@@ -75,8 +93,7 @@ export const searchEmailsAction: EmailAction<
         hasAttachments: m.hasAttachments,
         mailbox: ctx.mailboxName,
         snippet: m.snippet,
-        ...(m.conversationId !== undefined ? { conversationId: m.conversationId } : {}),
-        ...(m.threadId !== undefined ? { threadId: m.threadId } : {}),
+        ...getSearchEmailThreadFields(m),
       })),
     };
   },

--- a/packages/email-core/src/actions/search.ts
+++ b/packages/email-core/src/actions/search.ts
@@ -20,6 +20,8 @@ const SearchEmailsOutput = z.object({
     hasAttachments: z.boolean(),
     mailbox: z.string().optional(),
     snippet: z.string().optional(),
+    conversationId: z.string().optional(),
+    threadId: z.string().optional(),
   })),
 });
 
@@ -56,6 +58,8 @@ export const searchEmailsAction: EmailAction<
           hasAttachments: m.hasAttachments,
           mailbox: m.mailbox,
           snippet: m.snippet,
+          ...(m.conversationId !== undefined ? { conversationId: m.conversationId } : {}),
+          ...(m.threadId !== undefined ? { threadId: m.threadId } : {}),
         })),
       };
     }
@@ -71,6 +75,8 @@ export const searchEmailsAction: EmailAction<
         hasAttachments: m.hasAttachments,
         mailbox: ctx.mailboxName,
         snippet: m.snippet,
+        ...(m.conversationId !== undefined ? { conversationId: m.conversationId } : {}),
+        ...(m.threadId !== undefined ? { threadId: m.threadId } : {}),
       })),
     };
   },

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -38,6 +38,10 @@ export {
 export { WatchedAllowlist } from './security/watched-allowlist.js';
 export { htmlToMarkdown, transformEmailContent } from './content/sanitize.js';
 export { sendEmailAction } from './actions/send.js';
+export {
+  SearchEmailThreadFieldsSchema,
+  getSearchEmailThreadFields,
+} from './actions/search.js';
 export { replyToEmailAction } from './actions/reply.js';
 export { createDraftAction, sendDraftAction, updateDraftAction } from './actions/draft.js';
 export { getThreadAction } from './actions/conversation.js';

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -528,6 +528,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         receivedAt: '2026-04-09T10:00:00.000Z',
         isRead: false,
         hasAttachments: false,
+        conversationId: 'graph-conversation-abc',
       },
     ]);
     const personalSearch = vi.fn().mockResolvedValue([
@@ -538,6 +539,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         receivedAt: '2026-04-09T11:00:00.000Z',
         isRead: true,
         hasAttachments: true,
+        threadId: 'gmail-thread-xyz',
       },
     ]);
 
@@ -587,6 +589,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         isRead: true,
         hasAttachments: true,
         mailbox: 'personal',
+        threadId: 'gmail-thread-xyz',
       },
     ]);
   });
@@ -600,6 +603,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         receivedAt: '2026-04-09T10:00:00.000Z',
         isRead: false,
         hasAttachments: false,
+        conversationId: 'graph-conversation-abc',
       },
     ]);
     const personalSearch = vi.fn().mockResolvedValue([
@@ -610,6 +614,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         receivedAt: '2026-04-09T11:00:00.000Z',
         isRead: true,
         hasAttachments: true,
+        threadId: 'gmail-thread-xyz',
       },
     ]);
 
@@ -659,6 +664,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         isRead: true,
         hasAttachments: true,
         mailbox: 'personal',
+        threadId: 'gmail-thread-xyz',
       },
       {
         id: 'work-1',
@@ -668,6 +674,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         isRead: false,
         hasAttachments: false,
         mailbox: 'work',
+        conversationId: 'graph-conversation-abc',
       },
     ]);
   });

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -1,6 +1,10 @@
 // MCP server — thin transport adapter mapping action registry to MCP tools
 import { createRequire } from 'node:module';
-import type { EmailAction, EmailProvider } from '@usejunior/email-core';
+import type { EmailAction, EmailMessage, EmailProvider } from '@usejunior/email-core';
+import {
+  SearchEmailThreadFieldsSchema,
+  getSearchEmailThreadFields,
+} from '@usejunior/email-core';
 import { z } from 'zod';
 
 /**
@@ -837,29 +841,30 @@ export async function buildLazyActions(
       name: 'search_emails',
       description: 'Search emails using full-text query across one or all mailboxes. Use offset for pagination.',
       input: z.object({ query: z.string(), mailbox: z.string().nullable().optional(), limit: z.number().optional(), offset: z.number().optional() }),
-      output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean(), mailbox: z.string().optional(), conversationId: z.string().optional(), threadId: z.string().optional() })) }),
+      output: z.object({
+        emails: z.array(z.object({
+          id: z.string(),
+          subject: z.string(),
+          from: z.string(),
+          receivedAt: z.string(),
+          isRead: z.boolean(),
+          hasAttachments: z.boolean(),
+          mailbox: z.string().optional(),
+        }).extend(SearchEmailThreadFieldsSchema.shape)),
+      }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
         if (!getDefaultMailbox(state)) return { emails: [] };
         const inp = input as { query: string; mailbox?: string | null; limit?: number; offset?: number };
         const resolved = inp.mailbox === null ? null : resolveMailboxContext(state, inp.mailbox);
-        const results = resolved
+        const results: Array<EmailMessage & { mailbox: string }> = resolved
           ? (await resolved.mailbox.provider.searchMessages(
             inp.query,
             undefined,
             inp.limit ?? 25,
             inp.offset,
-          ) as Array<{
-            id: string;
-            subject: string;
-            from: { email: string; name?: string };
-            receivedAt: string;
-            isRead: boolean;
-            hasAttachments: boolean;
-            conversationId?: string;
-            threadId?: string;
-          }>).map(result => ({ ...result, mailbox: resolved.mailbox.name }))
+          )).map(result => ({ ...result, mailbox: resolved.mailbox.name }))
           : (await Promise.all(
             getConnectedMailboxes(state).map(async mailbox => {
               const mailboxResults = await mailbox.provider.searchMessages(inp.query, undefined);
@@ -878,8 +883,7 @@ export async function buildLazyActions(
             isRead: m.isRead,
             hasAttachments: m.hasAttachments,
             mailbox: m.mailbox,
-            ...(m.conversationId !== undefined ? { conversationId: m.conversationId } : {}),
-            ...(m.threadId !== undefined ? { threadId: m.threadId } : {}),
+            ...getSearchEmailThreadFields(m),
           })),
         };
       },

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -837,7 +837,7 @@ export async function buildLazyActions(
       name: 'search_emails',
       description: 'Search emails using full-text query across one or all mailboxes. Use offset for pagination.',
       input: z.object({ query: z.string(), mailbox: z.string().nullable().optional(), limit: z.number().optional(), offset: z.number().optional() }),
-      output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean(), mailbox: z.string().optional() })) }),
+      output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean(), mailbox: z.string().optional(), conversationId: z.string().optional(), threadId: z.string().optional() })) }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
@@ -857,6 +857,8 @@ export async function buildLazyActions(
             receivedAt: string;
             isRead: boolean;
             hasAttachments: boolean;
+            conversationId?: string;
+            threadId?: string;
           }>).map(result => ({ ...result, mailbox: resolved.mailbox.name }))
           : (await Promise.all(
             getConnectedMailboxes(state).map(async mailbox => {
@@ -876,6 +878,8 @@ export async function buildLazyActions(
             isRead: m.isRead,
             hasAttachments: m.hasAttachments,
             mailbox: m.mailbox,
+            ...(m.conversationId !== undefined ? { conversationId: m.conversationId } : {}),
+            ...(m.threadId !== undefined ? { threadId: m.threadId } : {}),
           })),
         };
       },


### PR DESCRIPTION
## Summary

Closes #77.

`search_emails` returned one row per message with no conversation grouping. Both providers already populate the relevant ID on `EmailMessage` upstream — Microsoft Graph sets `conversationId`, Gmail sets `threadId` — but the response-shaping layer dropped them. Callers were forced to parse subject lines to dedupe threads, which fails on subject changes mid-thread.

This is an **additive** change: include `conversationId` and `threadId` (whichever the provider populated) on each result row. No new API calls; no schema-breaking changes.

### Changes

- `packages/email-core/src/actions/search.ts` — export `SearchEmailThreadFieldsSchema` and `getSearchEmailThreadFields(message)` helper; extend the action's output row with the shared fragment; both mapping branches reuse the helper.
- `packages/email-core/src/index.ts` — re-export the shared schema/helper so `email-mcp` can consume them.
- `packages/email-mcp/src/server.ts` — mirror the schema via the shared fragment in the inline `search_emails` tool; replace the previous structural cast with a typed `Array<EmailMessage & { mailbox: string }>`; reuse the same helper for the row mapping.
- `packages/email-core/src/actions/search.test.ts` — add multi-mailbox and single-provider scenarios that assert the IDs surface on the correct provider's row.
- `packages/email-mcp/src/server.test.ts` — extend the two existing custom `search_emails` tests (routed and fan-out) so mocks seed `conversationId`/`threadId` and the assertions verify they pass through the MCP mapping.

The helper's conditional spread is keyed on `!== undefined` (not truthiness) so empty strings pass through and existing `toEqual` test expectations stay green for mocks that don't seed the IDs.

### Out of scope

- A `group_by_conversation: true` mode that returns one row per thread (deferred per the issue — `get_thread` already exists for the next-step navigation).
- Surfacing RFC `messageId` / `inReplyTo` / `references` on search rows.
- Unifying the duplicate `search_emails` definition between `email-core` and `email-mcp` (they already diverge on demo-mode handling, the `folder` input, and the `snippet` output — separate refactor).
- Surfacing the same fields on `list_emails` (tracked as a follow-up issue).

### Backwards compatibility

This is adapter-specific, not a blanket MCP claim. Within this server's current stdio adapter, the change is effectively an additive text-payload change:

- `tools/list` for this transport publishes only `inputSchema` today, not `outputSchema`, so the published MCP tool schema is unchanged.
- Tool results are returned as JSON text content rather than MCP `structuredContent`, so SDK-side `outputSchema` validation does not apply.

For reference, MCP spec revision `2025-06-18` standardizes optional `outputSchema` and clients `SHOULD` validate `structuredContent` against it when present (the official TypeScript and Python SDKs do). If/when this server starts emitting `structuredContent` with a published `outputSchema`, strict-validating consumers would automatically pick up the new optional fields without breakage; consumers that parse the JSON text payload today and assume an exact object shape would still need to widen their expectations.

## Test plan

- [x] `npm run lint` (all workspaces — `tsc --noEmit`)
- [x] `npm run build` (workspaces in dependency order)
- [x] `npm run test:run` — 656 tests across 5 packages, all green
- [ ] Manual smoke: hit a known multi-message thread on each provider via `search_emails` and confirm rows from the same thread share a `conversationId` (Graph) or `threadId` (Gmail). _Optional, requires real creds._