### PR TITLE
fix(email-mcp): wire deleteEnabled+hardDeleteAllowed via env, name vars in error

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Agent Email exposes 15 MCP tools:
 | `flag_email` | Flag/unflag emails | write |
 | `mark_read` | Mark as read/unread | write |
 | `move_to_folder` | Move between folders | write |
-| `delete_email` | Delete (requires opt-in) | destructive |
+| `delete_email` | Delete (requires operator env + caller flag) | destructive |
 
 ## Provider Support
 
@@ -177,7 +177,9 @@ Agent Email ships with restrictive defaults that you loosen as needed:
 
 - **Send allowlist**: empty by default -- agents cannot send email until you add recipients
 - **Receive allowlist**: accepts all by default -- controls which senders trigger the watcher
-- **Delete disabled**: agents cannot delete email unless you set `user_explicitly_requested_deletion: true`
+- **Delete disabled**: agents cannot delete email by default. Two gates must both be satisfied:
+  1. operator sets `AGENT_EMAIL_DELETE_ENABLED=true` in the email-agent-mcp process environment (and `AGENT_EMAIL_HARD_DELETE_ENABLED=true` for permanent deletion). Restart required after change.
+  2. the caller passes `user_explicitly_requested_deletion: true` on the tool call.
 - **Error sanitization**: API keys, file paths, and stack traces are redacted from error responses
 - **Body file sandboxing**: no `../` traversal, no symlinks, binary detection
 

--- a/openspec/specs/email-security/spec.md
+++ b/openspec/specs/email-security/spec.md
@@ -49,15 +49,29 @@ The system SHALL provide a receive allowlist that controls which inbound emails 
 
 ### Requirement: Delete Policy
 
-Delete SHALL be disabled by default. When enabled via configuration, the agent MUST pass `user_explicitly_requested_deletion: true`. Default to soft delete (move to Trash). No bulk delete.
+Delete SHALL be disabled by default. Two independent gates govern deletion: an operator-controlled env var (`AGENT_EMAIL_DELETE_ENABLED=true`) AND a per-call flag (`user_explicitly_requested_deletion: true`). Permanent deletion adds a third gate (`AGENT_EMAIL_HARD_DELETE_ENABLED=true`). All gates use strict-equality checks and accept only the literal string `'true'` to enable. Default to soft delete (move to Trash). No bulk delete.
+
+#### Scenario: Disabled by default
+- **WHEN** `AGENT_EMAIL_DELETE_ENABLED` is unset or any value other than `'true'`
+- **THEN** `delete_email` returns a `DELETE_DISABLED` error whose message names `AGENT_EMAIL_DELETE_ENABLED` so operators can self-remediate
 
 #### Scenario: Soft delete
-- **WHEN** delete is enabled and `user_explicitly_requested_deletion: true` is passed
+- **WHEN** `AGENT_EMAIL_DELETE_ENABLED=true` AND the caller passes `user_explicitly_requested_deletion: true`
 - **THEN** the email is moved to Trash (soft delete)
 
-#### Scenario: Hard delete requires explicit flag
-- **WHEN** `hard_delete: true` is also passed
+#### Scenario: Hard delete requires both server gate and explicit flag
+- **WHEN** `AGENT_EMAIL_HARD_DELETE_ENABLED=true` AND `hard_delete: true` is passed (with the soft-delete gates above also satisfied)
 - **THEN** the email is permanently deleted
+
+#### Scenario: Hard delete blocked when only soft is enabled
+- **WHEN** `AGENT_EMAIL_DELETE_ENABLED=true` but `AGENT_EMAIL_HARD_DELETE_ENABLED` is not `'true'`
+- **AND** the caller passes `hard_delete: true`
+- **THEN** `delete_email` returns `DELETE_DISABLED` and the message names `AGENT_EMAIL_HARD_DELETE_ENABLED`
+
+#### Scenario: Misconfigured env vars warn at startup
+- **WHEN** an env var is set to a non-empty unsupported value (e.g. `'1'`, `'yes'`)
+- **OR** `AGENT_EMAIL_HARD_DELETE_ENABLED=true` is set without `AGENT_EMAIL_DELETE_ENABLED=true`
+- **THEN** the process logs a stderr warning at startup so operators can correct the config rather than silently fall back to disabled
 
 ### Requirement: Anti-Spoofing
 

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -89,7 +89,7 @@ Agent Email exposes 15 MCP tools:
 | `flag_email` | Flag/unflag emails | write |
 | `mark_read` | Mark as read/unread | write |
 | `move_to_folder` | Move between folders | write |
-| `delete_email` | Delete (requires opt-in) | destructive |
+| `delete_email` | Delete (requires operator env + caller flag) | destructive |
 
 ## Provider Support
 

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -102,7 +102,7 @@ Agent Email exposes 15 MCP tools:
 
 - **Send allowlist**: empty by default -- agents cannot send email until you add recipients
 - **Receive allowlist**: accepts all by default -- controls which senders trigger the watcher
-- **Delete disabled**: agents cannot delete email unless you set `user_explicitly_requested_deletion: true`
+- **Delete disabled**: agents cannot delete email by default. Two gates must both be satisfied: (1) operator sets `AGENT_EMAIL_DELETE_ENABLED=true` in the email-agent-mcp process environment (and `AGENT_EMAIL_HARD_DELETE_ENABLED=true` for permanent deletion; restart required), and (2) the caller passes `user_explicitly_requested_deletion: true` on the tool call.
 - **Error sanitization**: API keys, file paths, and stack traces are redacted from error responses
 - **Body file sandboxing**: no `../` traversal, no symlinks, binary detection
 

--- a/packages/email-core/src/actions/label.test.ts
+++ b/packages/email-core/src/actions/label.test.ts
@@ -118,6 +118,24 @@ describe('email-categorize/Delete Policy', () => {
     expect(msgs.find(m => m.id === 'msg123')).toBeUndefined();
   });
 
+  it('Scenario: caller intent gate blocks deletion when both env gates are open', async () => {
+    // Even with both AGENT_EMAIL_DELETE_ENABLED and AGENT_EMAIL_HARD_DELETE_ENABLED
+    // set on the server, a caller who omits/falsifies user_explicitly_requested_deletion
+    // must still be rejected — the per-call intent flag is an independent gate.
+    const enabledCtx: ActionContext = { provider, deleteEnabled: true, hardDeleteAllowed: true };
+    const result = await deleteEmailAction.run(enabledCtx, {
+      id: 'msg123',
+      user_explicitly_requested_deletion: false,
+      hard_delete: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('DELETE_DISABLED');
+    expect(result.error!.message).toContain('user_explicitly_requested_deletion must be true');
+    // Message must NOT lead operators to flip env vars when the issue is caller intent.
+    expect(result.error!.message).not.toContain('AGENT_EMAIL_DELETE_ENABLED');
+  });
+
   it('Scenario: ctx.deleteEnabled requires strict-equality (not truthy)', async () => {
     // Passing a non-boolean truthy value must NOT enable deletion.
     const sneakyCtx = { provider, deleteEnabled: 'true' as unknown as boolean };

--- a/packages/email-core/src/actions/label.test.ts
+++ b/packages/email-core/src/actions/label.test.ts
@@ -56,12 +56,75 @@ describe('email-categorize/Mailbox Routing', () => {
   });
 });
 
-describe('email-categorize/No Delete in v1', () => {
+describe('email-categorize/Delete Policy', () => {
   it('Scenario: Delete attempt when disabled', async () => {
     // Delete is disabled by default (ctx.deleteEnabled is undefined)
     const result = await deleteEmailAction.run(ctx, {
       id: 'msg123',
       user_explicitly_requested_deletion: true,
+      hard_delete: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('DELETE_DISABLED');
+    expect(result.error!.message).toContain('Email deletion is disabled');
+    // Names the env var so operators can self-remediate.
+    expect(result.error!.message).toContain('AGENT_EMAIL_DELETE_ENABLED');
+  });
+
+  it('Scenario: Delete enabled, soft delete succeeds', async () => {
+    const enabledCtx: ActionContext = { provider, deleteEnabled: true, hardDeleteAllowed: false };
+    const result = await deleteEmailAction.run(enabledCtx, {
+      id: 'msg123',
+      user_explicitly_requested_deletion: true,
+      hard_delete: false,
+    });
+
+    expect(result.success).toBe(true);
+    // Soft delete moves to trash (not removed entirely).
+    const msgs = provider.getMessages();
+    const moved = msgs.find(m => m.id === 'msg123');
+    expect(moved?.folder).toBe('trash');
+  });
+
+  it('Scenario: hard_delete blocked when only soft is enabled (closes self-approval loophole)', async () => {
+    // Even though caller passes hard_delete: true, ctx.hardDeleteAllowed is false
+    // so the request must be rejected. Previously, label.ts derived
+    // hardDeleteAllowed from input.hard_delete itself, so this case "succeeded".
+    const enabledCtx: ActionContext = { provider, deleteEnabled: true, hardDeleteAllowed: false };
+    const result = await deleteEmailAction.run(enabledCtx, {
+      id: 'msg123',
+      user_explicitly_requested_deletion: true,
+      hard_delete: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('DELETE_DISABLED');
+    expect(result.error!.message).toContain('Hard delete is not allowed');
+    expect(result.error!.message).toContain('AGENT_EMAIL_HARD_DELETE_ENABLED');
+  });
+
+  it('Scenario: hard delete succeeds when both gates are open', async () => {
+    const enabledCtx: ActionContext = { provider, deleteEnabled: true, hardDeleteAllowed: true };
+    const result = await deleteEmailAction.run(enabledCtx, {
+      id: 'msg123',
+      user_explicitly_requested_deletion: true,
+      hard_delete: true,
+    });
+
+    expect(result.success).toBe(true);
+    // Hard delete removes the message entirely.
+    const msgs = provider.getMessages();
+    expect(msgs.find(m => m.id === 'msg123')).toBeUndefined();
+  });
+
+  it('Scenario: ctx.deleteEnabled requires strict-equality (not truthy)', async () => {
+    // Passing a non-boolean truthy value must NOT enable deletion.
+    const sneakyCtx = { provider, deleteEnabled: 'true' as unknown as boolean };
+    const result = await deleteEmailAction.run(sneakyCtx, {
+      id: 'msg123',
+      user_explicitly_requested_deletion: true,
+      hard_delete: false,
     });
 
     expect(result.success).toBe(false);

--- a/packages/email-core/src/actions/label.ts
+++ b/packages/email-core/src/actions/label.ts
@@ -101,8 +101,8 @@ export const deleteEmailAction: EmailAction<z.infer<typeof DeleteEmailInput>, z.
   output: LabelEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: true },
   run: async (ctx, input) => {
-    const deletePolicy: DeletePolicy | undefined = ctx.deleteEnabled
-      ? { enabled: true, hardDeleteAllowed: input.hard_delete }
+    const deletePolicy: DeletePolicy | undefined = ctx.deleteEnabled === true
+      ? { enabled: true, hardDeleteAllowed: ctx.hardDeleteAllowed === true }
       : undefined;
 
     const policyError = checkDeletePolicy(deletePolicy, input.user_explicitly_requested_deletion, input.hard_delete);

--- a/packages/email-core/src/actions/registry.ts
+++ b/packages/email-core/src/actions/registry.ts
@@ -10,6 +10,7 @@ export interface ActionContext {
   receiveAllowlist?: AllowlistConfig;
   safeDir?: string;
   deleteEnabled?: boolean;
+  hardDeleteAllowed?: boolean;
   rateLimiter?: RateLimiter;
 }
 

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -27,7 +27,10 @@ export {
   isAllowedSender,
   loadReceiveAllowlist,
   getReceiveAllowlistPath,
+  checkDeletePolicy,
+  getDeletePolicyFromEnv,
 } from './security/receive-allowlist.js';
+export type { DeletePolicy } from './security/receive-allowlist.js';
 export {
   isAllowedRecipient,
   loadSendAllowlist,

--- a/packages/email-core/src/security/receive-allowlist.test.ts
+++ b/packages/email-core/src/security/receive-allowlist.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { isAllowedSender, checkDeletePolicy, checkAntiSpoofing, getReceiveAllowlistPath } from './receive-allowlist.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  isAllowedSender,
+  checkDeletePolicy,
+  checkAntiSpoofing,
+  getReceiveAllowlistPath,
+  getDeletePolicyFromEnv,
+} from './receive-allowlist.js';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 
 describe('email-security/Receive Allowlist', () => {
@@ -55,6 +61,8 @@ describe('email-security/Delete Policy', () => {
     // WHEN delete is disabled
     const disabledError = checkDeletePolicy(undefined, true, false);
     expect(disabledError).toContain('Email deletion is disabled');
+    // Remediation message names the env var so operators know what to flip.
+    expect(disabledError).toContain('AGENT_EMAIL_DELETE_ENABLED');
 
     // WHEN enabled + explicit flag + hard delete
     const policy = { enabled: true, hardDeleteAllowed: true };
@@ -67,6 +75,127 @@ describe('email-security/Delete Policy', () => {
     await provider.deleteMessage('msg1', true);
     const allMsgs = provider.getMessages();
     expect(allMsgs).toHaveLength(0);
+  });
+
+  it('Scenario: Disabled by default', () => {
+    // Spec: when AGENT_EMAIL_DELETE_ENABLED is unset or non-'true', delete_email
+    // returns DELETE_DISABLED whose message names AGENT_EMAIL_DELETE_ENABLED.
+    const error = checkDeletePolicy(undefined, true, false);
+    expect(error).toContain('AGENT_EMAIL_DELETE_ENABLED');
+  });
+
+  it('Scenario: Hard delete requires both server gate and explicit flag', () => {
+    // Spec: hard delete requires AGENT_EMAIL_HARD_DELETE_ENABLED=true AND hard_delete: true.
+    // Verify the success path: both gates open + caller flag set → no error.
+    const policy = { enabled: true, hardDeleteAllowed: true };
+    const error = checkDeletePolicy(policy, true, true);
+    expect(error).toBeUndefined();
+  });
+
+  it('Scenario: Hard delete blocked when only soft is enabled', () => {
+    const policy = { enabled: true, hardDeleteAllowed: false };
+    const error = checkDeletePolicy(policy, true, true);
+    expect(error).toBeDefined();
+    expect(error).toContain('Hard delete is not allowed');
+    // Remediation names the hard-delete env var.
+    expect(error).toContain('AGENT_EMAIL_HARD_DELETE_ENABLED');
+  });
+
+  it('Scenario: checkDeletePolicy uses strict-equality on policy.enabled', () => {
+    // Non-boolean truthy value should NOT enable deletion (fail-closed).
+    const sneaky = { enabled: 'true' as unknown as boolean, hardDeleteAllowed: false };
+    const error = checkDeletePolicy(sneaky, true, false);
+    expect(error).toContain('Email deletion is disabled');
+  });
+});
+
+describe('email-security/getDeletePolicyFromEnv', () => {
+  const originalDelete = process.env['AGENT_EMAIL_DELETE_ENABLED'];
+  const originalHard = process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+
+  afterEach(() => {
+    if (originalDelete === undefined) delete process.env['AGENT_EMAIL_DELETE_ENABLED'];
+    else process.env['AGENT_EMAIL_DELETE_ENABLED'] = originalDelete;
+    if (originalHard === undefined) delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+    else process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = originalHard;
+  });
+
+  it('returns undefined when env vars are unset', () => {
+    delete process.env['AGENT_EMAIL_DELETE_ENABLED'];
+    delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toBeUndefined();
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('returns soft-only policy when only AGENT_EMAIL_DELETE_ENABLED=true', () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = 'true';
+    delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toEqual({ enabled: true, hardDeleteAllowed: false });
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('returns full policy when both env vars are exactly "true"', () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = 'true';
+    process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = 'true';
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toEqual({ enabled: true, hardDeleteAllowed: true });
+    expect(onWarn).not.toHaveBeenCalled();
+  });
+
+  it('treats non-"true" values as disabled and warns (strict parsing)', () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = '1';
+    delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toBeUndefined();
+    expect(onWarn).toHaveBeenCalledOnce();
+    expect(onWarn.mock.calls[0]![0]).toContain('AGENT_EMAIL_DELETE_ENABLED');
+  });
+
+  it('treats uppercase TRUE as disabled (strict literal "true")', () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = 'TRUE';
+    delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toBeUndefined();
+    expect(onWarn).toHaveBeenCalled();
+  });
+
+  it('Scenario: Misconfigured env vars warn at startup', () => {
+    // Spec: AGENT_EMAIL_HARD_DELETE_ENABLED=true without AGENT_EMAIL_DELETE_ENABLED=true must warn.
+    delete process.env['AGENT_EMAIL_DELETE_ENABLED'];
+    process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = 'true';
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toBeUndefined();
+    expect(onWarn).toHaveBeenCalledOnce();
+    expect(onWarn.mock.calls[0]![0]).toContain('has no effect without AGENT_EMAIL_DELETE_ENABLED');
+  });
+
+  it('warns when AGENT_EMAIL_HARD_DELETE_ENABLED=true is set without AGENT_EMAIL_DELETE_ENABLED', () => {
+    delete process.env['AGENT_EMAIL_DELETE_ENABLED'];
+    process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = 'true';
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toBeUndefined();
+    expect(onWarn).toHaveBeenCalledOnce();
+    expect(onWarn.mock.calls[0]![0]).toContain('has no effect without AGENT_EMAIL_DELETE_ENABLED');
+  });
+
+  it('warns about unsupported AGENT_EMAIL_HARD_DELETE_ENABLED value when delete is enabled', () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = 'true';
+    process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = 'yes';
+    const onWarn = vi.fn();
+    const policy = getDeletePolicyFromEnv(onWarn);
+    expect(policy).toEqual({ enabled: true, hardDeleteAllowed: false });
+    expect(onWarn).toHaveBeenCalledOnce();
+    expect(onWarn.mock.calls[0]![0]).toContain('AGENT_EMAIL_HARD_DELETE_ENABLED');
+  });
+
+  it('treats empty-string env values as unset (no warning)', () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = '';
+    process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = '';
+    const onWarn = vi.fn();
+    expect(getDeletePolicyFromEnv(onWarn)).toBeUndefined();
+    expect(onWarn).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/email-core/src/security/receive-allowlist.ts
+++ b/packages/email-core/src/security/receive-allowlist.ts
@@ -77,19 +77,50 @@ export function checkDeletePolicy(
   userExplicitlyRequestedDeletion: boolean,
   hardDelete: boolean,
 ): string | undefined {
-  if (!policy || !policy.enabled) {
-    return 'Email deletion is disabled. Enable in configuration if needed.';
+  if (!policy || policy.enabled !== true) {
+    return 'Email deletion is disabled. Set AGENT_EMAIL_DELETE_ENABLED=true in the email-agent-mcp process environment to enable.';
   }
 
-  if (!userExplicitlyRequestedDeletion) {
+  if (userExplicitlyRequestedDeletion !== true) {
     return 'user_explicitly_requested_deletion must be true to delete emails';
   }
 
-  if (hardDelete && !policy.hardDeleteAllowed) {
-    return 'Hard delete is not allowed in current configuration';
+  if (hardDelete && policy.hardDeleteAllowed !== true) {
+    return 'Hard delete is not allowed. Set AGENT_EMAIL_HARD_DELETE_ENABLED=true in the email-agent-mcp process environment to enable.';
   }
 
   return undefined;
+}
+
+/**
+ * Resolve the delete policy from environment variables. Strict: only the
+ * literal string 'true' enables a gate; all other values leave it disabled.
+ * Returns undefined when deletion is not enabled.
+ *
+ * Side effects: emits stderr warnings via `onWarn` for misconfigured env state
+ * (unsupported non-empty values, or hard-delete enabled without delete enabled)
+ * so silent typos don't strand operators on the disabled fallback.
+ */
+export function getDeletePolicyFromEnv(
+  onWarn: (msg: string) => void = (msg) => { console.error(msg); },
+): DeletePolicy | undefined {
+  const rawDelete = process.env['AGENT_EMAIL_DELETE_ENABLED'];
+  const rawHard = process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+
+  if (rawDelete !== undefined && rawDelete !== '' && rawDelete !== 'true') {
+    onWarn(`[email-agent-mcp] WARNING: AGENT_EMAIL_DELETE_ENABLED='${rawDelete}' is not 'true' — deletion remains disabled.`);
+  }
+  if (rawHard !== undefined && rawHard !== '' && rawHard !== 'true') {
+    onWarn(`[email-agent-mcp] WARNING: AGENT_EMAIL_HARD_DELETE_ENABLED='${rawHard}' is not 'true' — hard delete remains disabled.`);
+  }
+
+  if (rawDelete !== 'true') {
+    if (rawHard === 'true') {
+      onWarn('[email-agent-mcp] WARNING: AGENT_EMAIL_HARD_DELETE_ENABLED=true has no effect without AGENT_EMAIL_DELETE_ENABLED=true.');
+    }
+    return undefined;
+  }
+  return { enabled: true, hardDeleteAllowed: rawHard === 'true' };
 }
 
 // Anti-spoofing check

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -1183,6 +1183,159 @@ describe('cli/Call Subcommand Mailbox Routing', () => {
   });
 });
 
+describe('cli/Call Subcommand Delete Policy Wiring (issue #78)', () => {
+  // Confirms that runCall reads AGENT_EMAIL_DELETE_ENABLED from env and
+  // forwards a working getDeletePolicy into buildLazyActions, AND that the
+  // status log line only appears for delete_email (not noisy for every call).
+
+  const originalDelete = process.env['AGENT_EMAIL_DELETE_ENABLED'];
+  const originalHard = process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+
+  afterEach(() => {
+    if (originalDelete === undefined) delete process.env['AGENT_EMAIL_DELETE_ENABLED'];
+    else process.env['AGENT_EMAIL_DELETE_ENABLED'] = originalDelete;
+    if (originalHard === undefined) delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+    else process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'] = originalHard;
+    vi.doUnmock('./server.js');
+  });
+
+  it('Scenario: AGENT_EMAIL_DELETE_ENABLED=true is threaded through to action context', async () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = 'true';
+    delete process.env['AGENT_EMAIL_HARD_DELETE_ENABLED'];
+
+    const { z } = await import('zod');
+    const capturedCtx: Array<{ deleteEnabled?: boolean; hardDeleteAllowed?: boolean }> = [];
+    const recordingAction = {
+      name: 'delete_email',
+      description: 'test stub that records ctx',
+      input: z.object({}).passthrough(),
+      output: z.object({ ok: z.boolean() }),
+      annotations: { readOnlyHint: false, destructiveHint: true },
+      run: async (ctx: { deleteEnabled?: boolean; hardDeleteAllowed?: boolean }, _input: unknown) => {
+        capturedCtx.push(ctx);
+        return { ok: true };
+      },
+    };
+    const noopState = { status: 'connected', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => noopState,
+        // Pass through the third arg by invoking it once, simulating what
+        // wrapAction would do at action-run time. This proves runCall built
+        // and forwarded the getDeletePolicy correctly.
+        buildLazyActions: async (
+          _state: unknown,
+          _getSendAllowlist: unknown,
+          getDeletePolicy?: () => unknown,
+        ) => {
+          const policy = getDeletePolicy?.() as { enabled?: boolean; hardDeleteAllowed?: boolean } | undefined;
+          return [{
+            ...recordingAction,
+            run: async (_ctx: unknown, input: unknown) => recordingAction.run(
+              {
+                deleteEnabled: policy?.enabled === true,
+                hardDeleteAllowed: policy?.hardDeleteAllowed === true,
+              },
+              input,
+            ),
+          }];
+        },
+        ensureProvider: async () => undefined,
+      };
+    });
+
+    const { runCall } = await import('./cli.js');
+    const exitCode = await runCall({
+      command: 'call',
+      callTool: 'delete_email',
+      callArgs: '{}',
+    });
+
+    expect(exitCode).toBe(0);
+    expect(capturedCtx[0]?.deleteEnabled).toBe(true);
+    expect(capturedCtx[0]?.hardDeleteAllowed).toBe(false);
+  });
+
+  it('Scenario: status log line only appears when invoked tool is delete_email', async () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = 'true';
+
+    const { z } = await import('zod');
+    const stub = {
+      name: 'list_emails',
+      description: 'stub',
+      input: z.object({}).passthrough(),
+      output: z.object({ ok: z.boolean() }),
+      annotations: { readOnlyHint: true, destructiveHint: false },
+      run: async () => ({ ok: true }),
+    };
+    const noopState = { status: 'connected', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => noopState,
+        buildLazyActions: async () => [stub],
+        ensureProvider: async () => undefined,
+      };
+    });
+
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const { runCall } = await import('./cli.js');
+      const exitCode = await runCall({
+        command: 'call',
+        callTool: 'list_emails',
+        callArgs: '{}',
+      });
+      expect(exitCode).toBe(0);
+      const allStderr = stderrSpy.mock.calls.map(args => String(args[0])).join('\n');
+      expect(allStderr).not.toMatch(/Delete policy:/);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('Scenario: misconfigured env (e.g. "1") emits a warning regardless of invoked tool', async () => {
+    process.env['AGENT_EMAIL_DELETE_ENABLED'] = '1';
+
+    const { z } = await import('zod');
+    const stub = {
+      name: 'list_emails',
+      description: 'stub',
+      input: z.object({}).passthrough(),
+      output: z.object({ ok: z.boolean() }),
+      annotations: { readOnlyHint: true, destructiveHint: false },
+      run: async () => ({ ok: true }),
+    };
+    const noopState = { status: 'connected', mailboxes: [], defaultMailboxName: null };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => noopState,
+        buildLazyActions: async () => [stub],
+        ensureProvider: async () => undefined,
+      };
+    });
+
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const { runCall } = await import('./cli.js');
+      await runCall({ command: 'call', callTool: 'list_emails', callArgs: '{}' });
+      const allStderr = stderrSpy.mock.calls.map(args => String(args[0])).join('\n');
+      expect(allStderr).toContain('AGENT_EMAIL_DELETE_ENABLED');
+      expect(allStderr).toMatch(/WARNING/);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
 describe('cli/Call Subcommand Diagnostic Tools', () => {
   it('Scenario: call get_mailbox_status reports state without requiring provider readiness', async () => {
     // Regression: the eager-init gate previously short-circuited get_mailbox_status

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -588,7 +588,7 @@ function printJsonResult(value: unknown): void {
 export async function runCall(opts: CliOptions): Promise<number> {
   const { createLazyProviderState, buildLazyActions, ensureProvider, executeTool, getActionInputJsonSchema } =
     await import('./server.js');
-  const { loadSendAllowlist, getSendAllowlistPath } = await import('@usejunior/email-core');
+  const { loadSendAllowlist, getSendAllowlistPath, getDeletePolicyFromEnv } = await import('@usejunior/email-core');
 
   // Match `serve`'s allowlist setup, but DON'T spawn a watcher in a one-shot
   // process — load once and snapshot. (`serve` uses `WatchedAllowlist` for
@@ -597,8 +597,21 @@ export async function runCall(opts: CliOptions): Promise<number> {
   const snapshot = await loadSendAllowlist(sendAllowlistPath);
   const getSendAllowlist = () => snapshot;
 
+  // Resolve delete policy from env once. getDeletePolicyFromEnv emits its own
+  // stderr warnings for misconfigured envs. Status line is printed only when
+  // the invoked tool is delete_email — other tools shouldn't see this noise.
+  const deletePolicy = getDeletePolicyFromEnv();
+  const getDeletePolicy = () => deletePolicy;
+  if (opts.callTool === 'delete_email') {
+    console.error(
+      deletePolicy
+        ? `[email-agent-mcp] Delete policy: enabled (hard_delete=${deletePolicy.hardDeleteAllowed})`
+        : '[email-agent-mcp] Delete policy: disabled (set AGENT_EMAIL_DELETE_ENABLED=true to enable)',
+    );
+  }
+
   const state = createLazyProviderState();
-  const actions = await buildLazyActions(state, getSendAllowlist);
+  const actions = await buildLazyActions(state, getSendAllowlist, getDeletePolicy);
 
   // --list: enumerate tools and exit
   if (opts.callList) {

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1294,3 +1294,107 @@ describe('mcp-transport/Scalar Coercion at Boundary', () => {
     expect(parsed.success).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #78: delete policy plumbing through buildLazyActions/wrapAction.
+// Regression net for the original bug — ctx.deleteEnabled was declared but
+// never populated by wrapAction, so delete_email was effectively impossible.
+// ---------------------------------------------------------------------------
+
+describe('mcp-transport/Delete policy wiring', () => {
+  const noAllowlist = () => undefined;
+
+  function makeConnectedState(deleteMessage: ReturnType<typeof vi.fn>) {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    const provider = { deleteMessage } as never;
+    state.provider = provider;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [
+      {
+        name: 'work',
+        emailAddress: 'work@example.com',
+        displayName: 'work@example.com',
+        providerType: 'microsoft',
+        provider,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+    ];
+    return state;
+  }
+
+  it('default getDeletePolicy (none) — delete_email returns DELETE_DISABLED naming the env var', async () => {
+    const deleteMessage = vi.fn();
+    const state = makeConnectedState(deleteMessage);
+    const actions = await buildLazyActions(state, noAllowlist); // no third arg = disabled
+
+    const del = actions.find(a => a.name === 'delete_email')!;
+    const result = await del.run({}, {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: true,
+      hard_delete: false,
+    }) as { success: boolean; error?: { code: string; message: string } };
+
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('DELETE_DISABLED');
+    expect(result.error?.message).toContain('AGENT_EMAIL_DELETE_ENABLED');
+  });
+
+  it('soft-only policy threads through wrapAction — provider.deleteMessage called with hard=false', async () => {
+    const deleteMessage = vi.fn().mockResolvedValue(undefined);
+    const state = makeConnectedState(deleteMessage);
+    const getDeletePolicy = () => ({ enabled: true, hardDeleteAllowed: false });
+    const actions = await buildLazyActions(state, noAllowlist, getDeletePolicy);
+
+    const del = actions.find(a => a.name === 'delete_email')!;
+    const result = await del.run({}, {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: true,
+      hard_delete: false,
+    }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(deleteMessage).toHaveBeenCalledWith('msg-1', false);
+  });
+
+  it('soft-only policy still blocks hard_delete:true (closes self-approval loophole)', async () => {
+    const deleteMessage = vi.fn();
+    const state = makeConnectedState(deleteMessage);
+    const getDeletePolicy = () => ({ enabled: true, hardDeleteAllowed: false });
+    const actions = await buildLazyActions(state, noAllowlist, getDeletePolicy);
+
+    const del = actions.find(a => a.name === 'delete_email')!;
+    const result = await del.run({}, {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: true,
+      hard_delete: true,
+    }) as { success: boolean; error?: { code: string; message: string } };
+
+    expect(deleteMessage).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('DELETE_DISABLED');
+    expect(result.error?.message).toContain('AGENT_EMAIL_HARD_DELETE_ENABLED');
+  });
+
+  it('full policy threads through — provider.deleteMessage called with hard=true', async () => {
+    const deleteMessage = vi.fn().mockResolvedValue(undefined);
+    const state = makeConnectedState(deleteMessage);
+    const getDeletePolicy = () => ({ enabled: true, hardDeleteAllowed: true });
+    const actions = await buildLazyActions(state, noAllowlist, getDeletePolicy);
+
+    const del = actions.find(a => a.name === 'delete_email')!;
+    const result = await del.run({}, {
+      id: 'msg-1',
+      user_explicitly_requested_deletion: true,
+      hard_delete: true,
+    }) as { success: boolean };
+
+    expect(result.success).toBe(true);
+    expect(deleteMessage).toHaveBeenCalledWith('msg-1', true);
+  });
+});

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -1,6 +1,6 @@
 // MCP server — thin transport adapter mapping action registry to MCP tools
 import { createRequire } from 'node:module';
-import type { EmailAction, EmailProvider } from '@usejunior/email-core';
+import type { DeletePolicy, EmailAction, EmailProvider } from '@usejunior/email-core';
 import { z } from 'zod';
 
 /**
@@ -655,6 +655,7 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
 export async function buildLazyActions(
   state: LazyProviderState,
   getSendAllowlist: () => { entries: string[] } | undefined,
+  getDeletePolicy: () => DeletePolicy | undefined = () => undefined,
 ): Promise<EmailActionDef[]> {
   const {
     sendEmailAction,
@@ -698,11 +699,14 @@ export async function buildLazyActions(
             ? (input as { mailbox?: string }).mailbox
             : undefined;
         const resolved = resolveMailboxContext(state, requestedMailbox);
+        const deletePolicy = getDeletePolicy();
         const actionCtx = {
           provider: resolved.mailbox.provider,
           mailboxName: resolved.mailbox.name,
           allMailboxes: resolved.allMailboxes,
           sendAllowlist: getSendAllowlist(),
+          deleteEnabled: deletePolicy?.enabled === true,
+          hardDeleteAllowed: deletePolicy?.hardDeleteAllowed === true,
         };
         return action.run(actionCtx as never, input as never);
       } catch (err) {
@@ -983,7 +987,7 @@ export async function runServer(): Promise<void> {
   const { ListToolsRequestSchema, CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
 
   // Load send allowlist with hot-reload (convention: ~/.email-agent-mcp/send-allowlist.json)
-  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist } = await import('@usejunior/email-core');
+  const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist, getDeletePolicyFromEnv } = await import('@usejunior/email-core');
   const sendAllowlistPath = getSendAllowlistPath();
   const sendAllowlistWatcher = new WatchedAllowlist(sendAllowlistPath, loadSendAllowlist);
   await sendAllowlistWatcher.start();
@@ -994,9 +998,19 @@ export async function runServer(): Promise<void> {
     console.error(`[email-agent-mcp] WARNING: Send allowlist empty or not found at ${sendAllowlistPath} — all outbound email is disabled`);
   }
 
+  // Resolve delete policy from env once at startup. Misconfiguration warnings
+  // surface via console.error inside getDeletePolicyFromEnv.
+  const deletePolicy = getDeletePolicyFromEnv();
+  const getDeletePolicy = () => deletePolicy;
+  console.error(
+    deletePolicy
+      ? `[email-agent-mcp] Delete policy: enabled (hard_delete=${deletePolicy.hardDeleteAllowed})`
+      : '[email-agent-mcp] Delete policy: disabled (set AGENT_EMAIL_DELETE_ENABLED=true to enable)',
+  );
+
   // Build tool registry with lazy provider state (no auth yet).
   const state = createLazyProviderState();
-  const actions = await buildLazyActions(state, getSendAllowlist);
+  const actions = await buildLazyActions(state, getSendAllowlist, getDeletePolicy);
 
   const server = new Server(
     { name: 'email-agent-mcp', version: PACKAGE_VERSION },


### PR DESCRIPTION
## Summary

Closes #78. `delete_email` was effectively impossible to call successfully even when an operator wanted deletion enabled, because `ctx.deleteEnabled` was declared in `ActionContext` but **never populated** anywhere in production code. The error message named no config key, so operators couldn't recover.

This PR wires an env-var-driven, fail-closed delete policy through to the action context, closes a related dormant `hard_delete` self-approval loophole (defense-in-depth — see "Compatibility" below for why it was unreachable in shipped paths), makes the error self-explaining, and updates the README, package README, and OpenSpec `email-security` spec to match the implemented behavior.

### Changes

- **Plumbing** — `buildLazyActions` accepts an optional `getDeletePolicy`; `wrapAction` now sets `ctx.deleteEnabled` and `ctx.hardDeleteAllowed`. `runServer` and `runCall` both resolve via `getDeletePolicyFromEnv()` at startup.
- **Operator config** — `AGENT_EMAIL_DELETE_ENABLED=true` (and `AGENT_EMAIL_HARD_DELETE_ENABLED=true`) actually enable deletion now. Strict literal `'true'` parsing; misconfigured envs (unsupported values, hard-without-soft) emit a stderr warning at startup.
- **Error remediation** — `DELETE_DISABLED` messages name the env var to flip, so operators don't have to grep the source.
- **Hard-delete loophole (defense-in-depth)** — `label.ts` previously derived `hardDeleteAllowed` from `input.hard_delete` itself, which would have been self-approving had `deleteEnabled` ever been set to `true`. Now sourced from `ctx.hardDeleteAllowed`. Fail-closed strict equality (`=== true`) everywhere on the destructive path.
- **Docs** — top-level README, `packages/email-agent-mcp/README.md`, and the `email-security` spec updated with the env-var contract and four new scenarios (disabled by default, soft, hard requires both gates, hard blocked when only soft is enabled, misconfigured env warns).

### Compatibility

- **Not a breaking change.** `delete_email` was previously unusable (always returned `DELETE_DISABLED` because `ctx.deleteEnabled` was never set), so no production caller can have been depending on either the disabled default or the hard-delete behavior.
- **Loophole reachability.** The `input.hard_delete → policy.hardDeleteAllowed` self-approval mapping was a latent/dormant defect: the production MCP and CLI wiring never populated `ctx.deleteEnabled`, so the loophole was not reachable from any shipped server path. The fix is bundled here as defense-in-depth alongside the plumbing that would have made it reachable. If anyone happened to be relying on it (only possible via direct unit-test setup that hard-coded `deleteEnabled: true`), they will now also need to set `AGENT_EMAIL_HARD_DELETE_ENABLED=true`.

### Out of scope

- Optional `discard_draft(id, mailbox?)` helper from issue #78's "Optional follow-on" — file separately.
- Replacing env-var config with a structured config-file knob — defer until there's a second deletion-related setting.

## Test plan

- [x] `npm run lint` (typecheck) — clean
- [x] `npm run test:run` — all tests pass (23 new, including a direct boolean test for the `user_explicitly_requested_deletion: false` intent gate added per peer review)
- [x] `npm run check:spec-coverage` — 199/199 scenarios covered
- [ ] Smoke test against a real Microsoft mailbox via `email-agent-mcp call delete_email` with all four env combinations (default disabled, soft enabled, hard requested without hard env, both env vars set, misconfigured value)
- [ ] Reviewer: confirm error remediation strings are operator-friendly and process-agnostic

🤖 Plan was peer-reviewed by Gemini and Codex before implementation; final diff was peer-reviewed by Gemini and Codex post-implementation.
