### PR TITLE
fix(email-core): unescape literal brackets/parens in read_email markdown (#79)

### DIFF
--- a/packages/email-core/src/content/sanitize.test.ts
+++ b/packages/email-core/src/content/sanitize.test.ts
@@ -295,6 +295,18 @@ describe('content-engine/Unescape Markdown Punctuation (issue #79)', () => {
     expect(unescapeMarkdownPunctuation(md)).toBe(md);
   });
 
+  it('preserves escapes inside 3-backtick code spans (CommonMark allows any run length)', () => {
+    // NHM emits 3-backtick delimiters (with surrounding spaces) when the inline
+    // code content itself contains 2 backticks. The escapes inside must survive.
+    const md = 'Use ``` ``\\[x\\]`` ``` literally';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves escapes inside 4-backtick code spans', () => {
+    const md = 'See ```` ```\\[x\\]``` ```` here';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
   it('preserves escapes inside fenced code blocks', () => {
     const md = 'Example:\n\n```\n\\[in fence\\]\n```\n';
     expect(unescapeMarkdownPunctuation(md)).toBe(md);

--- a/packages/email-core/src/content/sanitize.test.ts
+++ b/packages/email-core/src/content/sanitize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { htmlToMarkdown, normalizeEncoding, generateAttachmentSummary } from './sanitize.js';
+import { htmlToMarkdown, normalizeEncoding, generateAttachmentSummary, unescapeMarkdownPunctuation, transformEmailContent } from './sanitize.js';
 
 describe('content-engine/HTML to Token-Efficient Markdown', () => {
   it('Scenario: HTML with tracking pixel', () => {
@@ -239,5 +239,102 @@ describe('content-engine/Attachment Summary', () => {
     expect(result).toContain('logo.png (inline)');
     expect(result).toContain('data.xlsx (1.2MB)');
     expect(result).toMatch(/^Attachments: /);
+  });
+});
+
+describe('content-engine/Unescape Markdown Punctuation (issue #79)', () => {
+  it('unescapes footnote-style refs', () => {
+    expect(unescapeMarkdownPunctuation('See \\[1\\] and \\[2\\]')).toBe('See [1] and [2]');
+  });
+
+  it('unescapes URL obfuscation pattern', () => {
+    expect(unescapeMarkdownPunctuation('Visit nipsco\\[.\\]com today')).toBe('Visit nipsco[.]com today');
+  });
+
+  it('unescapes bare parens in prose', () => {
+    expect(unescapeMarkdownPunctuation('Note \\(important\\) detail')).toBe('Note (important) detail');
+  });
+
+  it('preserves inline links', () => {
+    const md = 'See [docs](https://example.com) for info';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves inline images', () => {
+    const md = '![Q1 Revenue](https://example.com/chart.png)';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves images with escaped brackets in alt text', () => {
+    const md = '![Revenue \\[Q1\\]](https://example.com/x.png)';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves images with angle-bracket destinations', () => {
+    const md = '![test](<https://example.com/a b(1).png>)';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves titled images with parens in title', () => {
+    const md = '![x](https://example.com/x.png "Q(1) chart")';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves links with depth-1 balanced parens in URL', () => {
+    const md = '[docs](https://example.com?a=(b))';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves reference-style links and definitions', () => {
+    const md = 'See [docs][1] for info\n\n[1]: https://example.com';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves escapes inside inline code spans', () => {
+    const md = 'Use `\\[escaped\\]` syntax';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves escapes inside fenced code blocks', () => {
+    const md = 'Example:\n\n```\n\\[in fence\\]\n```\n';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('preserves links containing code spans (nested constructs)', () => {
+    const md = '[`code`](https://example.com)';
+    expect(unescapeMarkdownPunctuation(md)).toBe(md);
+  });
+
+  it('handles mixed escaped prose and valid links', () => {
+    const md = 'See \\[1\\] at \\[example.com\\] for [docs](https://x.com)';
+    expect(unescapeMarkdownPunctuation(md)).toBe(
+      'See [1] at [example.com] for [docs](https://x.com)',
+    );
+  });
+
+  it('end-to-end: HTML with footnote-style brackets', () => {
+    const result = transformEmailContent(undefined, '<p>See [1] at nipsco[.]com</p>');
+    expect(result).toContain('See [1] at nipsco[.]com');
+    expect(result).not.toContain('\\[');
+    expect(result).not.toContain('\\]');
+  });
+
+  it('end-to-end: plain-text body passes through unchanged', () => {
+    // Plain-text bodies bypass the unescape pass — escapes typed by humans survive.
+    const plain = 'Literal \\[escape\\] in plain text';
+    expect(transformEmailContent(plain, undefined)).toBe(plain);
+  });
+
+  it('end-to-end: HTML with <a> tag does not introduce stray escapes', () => {
+    // Note: the repo's custom <a> postprocess (sanitize.ts) flattens anchors
+    // to their inner text — that's a separate pre-existing concern. This test
+    // just guards that the unescape pass doesn't introduce backslash artifacts.
+    const result = transformEmailContent(
+      undefined,
+      '<p>Read <a href="https://example.com">our docs</a> please</p>',
+    );
+    expect(result).toContain('our docs');
+    expect(result).not.toContain('\\[');
+    expect(result).not.toContain('\\]');
   });
 });

--- a/packages/email-core/src/content/sanitize.ts
+++ b/packages/email-core/src/content/sanitize.ts
@@ -165,6 +165,54 @@ export function htmlToMarkdown(html: string): string {
   return nhm.translate(html);
 }
 
+// node-html-markdown escapes literal `[`, `]`, `(`, `)` in prose even when they
+// aren't markdown syntax (e.g. footnote refs `[1]`, URL obfuscation `nipsco[.]com`).
+// This helper unescapes them outside code regions and link/image syntax so LLM
+// consumers see the literal characters from the source HTML.
+const FENCE_RE = /^(```|~~~)[^\n]*\n[\s\S]*?^\1\s*$/gm;
+const REF_DEF_RE = /^\[[^\]\n]+\]:\s+\S.*$/gm;
+// Link text disallows unescaped `[` and `]` so the regex can't greedily span
+// across escaped-bracket prose to a later real link.
+const LINK_TEXT = /(?:[^\[\]\\]|\\.)*/.source;
+const DEST = /\(\s*(?:<[^>\n]*>|(?:\([^)\n]*\)|[^\s()\\]|\\.)+)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/.source;
+const INLINE_IMG_RE = new RegExp(`!\\[${LINK_TEXT}\\]${DEST}`, 'g');
+const INLINE_LINK_RE = new RegExp(`\\[${LINK_TEXT}\\]${DEST}`, 'g');
+const REF_LINK_RE = new RegExp(`!?\\[${LINK_TEXT}\\]\\[[^\\]\\n]*\\]`, 'g');
+const CODE_SPAN_RE = /``(?:[^`]|`(?!`))+``|`[^`\n]+`/g;
+
+export function unescapeMarkdownPunctuation(md: string): string {
+  const tokens: string[] = [];
+  const protect = (m: string): string => {
+    const i = tokens.length;
+    tokens.push(m);
+    return `\x00${i}\x00`;
+  };
+
+  let s = md;
+  s = s.replace(FENCE_RE, protect);
+  s = s.replace(REF_DEF_RE, protect);
+  s = s.replace(INLINE_IMG_RE, protect);
+  s = s.replace(INLINE_LINK_RE, protect);
+  s = s.replace(REF_LINK_RE, protect);
+  s = s.replace(CODE_SPAN_RE, protect);
+
+  s = s
+    .replace(/\\\[/g, '[')
+    .replace(/\\\]/g, ']')
+    .replace(/\\\(/g, '(')
+    .replace(/\\\)/g, ')');
+
+  // Recurse until fixed point so nested placeholders (e.g. code span inside a
+  // protected link) resolve fully.
+  let prev: string;
+  do {
+    prev = s;
+    s = s.replace(/\x00(\d+)\x00/g, (_, i) => tokens[Number(i)] ?? '');
+  } while (s !== prev);
+
+  return s;
+}
+
 /**
  * Normalize character encoding to UTF-8.
  * Handles ISO-8859-1 and other common encodings.
@@ -222,7 +270,7 @@ export function transformEmailContent(
   let content = '';
 
   if (bodyHtml) {
-    content = htmlToMarkdown(bodyHtml);
+    content = unescapeMarkdownPunctuation(htmlToMarkdown(bodyHtml));
   } else if (body) {
     content = body;
   }

--- a/packages/email-core/src/content/sanitize.ts
+++ b/packages/email-core/src/content/sanitize.ts
@@ -178,7 +178,11 @@ const DEST = /\(\s*(?:<[^>\n]*>|(?:\([^)\n]*\)|[^\s()\\]|\\.)+)(?:\s+(?:"[^"\n]*
 const INLINE_IMG_RE = new RegExp(`!\\[${LINK_TEXT}\\]${DEST}`, 'g');
 const INLINE_LINK_RE = new RegExp(`\\[${LINK_TEXT}\\]${DEST}`, 'g');
 const REF_LINK_RE = new RegExp(`!?\\[${LINK_TEXT}\\]\\[[^\\]\\n]*\\]`, 'g');
-const CODE_SPAN_RE = /``(?:[^`]|`(?!`))+``|`[^`\n]+`/g;
+// Match CommonMark code spans of any backtick run length: opener and closer
+// must be backtick strings of equal length, content cannot contain that exact
+// run. Lazy `*?` lets empty spans (`` `` ``) match; `[^\n]` keeps the span
+// single-line, matching NHM output.
+const CODE_SPAN_RE = /(`+)(?:(?!\1)[^\n])*?\1/g;
 
 export function unescapeMarkdownPunctuation(md: string): string {
   const tokens: string[] = [];


### PR DESCRIPTION
## Summary

- `node-html-markdown@2.0.0` escapes `[`, `]`, `(`, `)` in prose even when they aren't markdown syntax — LLM consumers see `\[1\]` and `nipsco\[.\]com` instead of the literal characters from the source HTML.
- New `unescapeMarkdownPunctuation()` post-processes `htmlToMarkdown()` output: protects code regions, reference definitions, and link/image syntax with NUL-delimited placeholders; unescapes bracket/paren punctuation in the remainder; recursively restores protected segments so nested constructs (e.g. code spans inside links) round-trip cleanly.
- Plain-text bodies bypass the pass, preserving any author-typed escapes.
- Closes #79.

## Algorithm notes (refined via Codex + Gemini peer review)

Both reviewers caught real bugs in the v1 design:
- **Reference-style links** — repo config has `useInlineLinks: false`, so the default `<a>` translator emits `[text][1]` + `[1]: url`. Original inline-only regex would have missed these.
- **Escaped brackets in link/image text** — `[^\]]+` would stop mid-text and corrupt output like `![Q1 \[data\]](url)`. Fixed by allowing escape sequences in text and disallowing unescaped `[`/`]` (so the regex can't greedily span across escaped-bracket prose to a later real link).
- **NHM destination shapes** — angle-bracket URLs (`<https://example.com/a b(1).png>`), titled links (`"Q(1)"`), and URLs with balanced parens were truncated by `\([^)]+\)`. Destination regex now handles all three.
- **Nested placeholders** — ` ``[`code`](url)`` ` would leak a sentinel because the link placeholder embedded the inner code-span placeholder. Restore now loops to a fixed point.

## Test plan

Direct helper coverage:
- Footnote refs (`\[1\]` → `[1]`), URL obfuscation (`nipsco\[.\]com` → `nipsco[.]com`), bare paren prose
- Inline links/images preserved including: escaped brackets in alt text, angle-bracket destinations, titled images with parens, depth-1 paren URLs
- Reference-style links + definitions preserved
- Code-span and fenced-block escapes preserved
- Nested ` [`code`](url) ` regression
- Mixed escaped prose alongside a real link

End-to-end via `transformEmailContent`:
- HTML reproduction from the issue (`<p>See [1] at nipsco[.]com</p>`)
- Plain-text body passthrough (no unescape applied)
- HTML with `<a>` tag does not introduce stray escapes

- [x] `npm run test:run` (671 tests) — green
- [x] `npm run build` — green
- [x] `npm run lint` — green