### PR TITLE
Add strip_quoted_history to read_email (#76)

### DIFF
--- a/openspec/changes/add-strip-quoted-history/proposal.md
+++ b/openspec/changes/add-strip-quoted-history/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+`read_email` returns the full MIME body including all nested reply chains. A 3-line reply in a long thread can return ~12 KB where ~99% is `>>>>>>>>>>>` history the LLM caller already has from earlier turns. There is no opt-in to strip quoted history today, even though the cost of the wasted context is borne entirely by the agent consumer.
+
+## What Changes
+
+- Add an opt-in `strip_quoted_history: boolean` parameter (default `false`) to the `read_email` action and MCP tool.
+- When `true`, detect a **terminal** quoted-history block — Gmail/Apple "On … wrote:" preamble, Outlook header cluster, or terminal `>`-prefix run — and replace it with a `[...prior thread truncated]` marker.
+- Operate on already-normalized text emitted by the existing content engine (`transformEmailContent`); do not re-process raw HTML.
+- Refactor the MCP `read_email` tool from a hand-rolled duplicate into a thin adapter that delegates to `readEmailAction.run(...)`, restoring the "actions are the single source of truth, MCP is a thin adapter" convention.
+
+## Impact
+
+- Affected specs: `email-read`
+- Affected code: `packages/email-core/src/content/`, `packages/email-core/src/actions/read.ts`, `packages/email-core/src/index.ts`, `packages/email-mcp/src/server.ts`
+- User-visible behavior: callers that pass `strip_quoted_history: true` receive a body with the terminal quoted-history block replaced by a short marker. Default behavior is unchanged. Inline blockquotes the user wrote in their latest reply are preserved.

--- a/openspec/changes/add-strip-quoted-history/specs/email-read/spec.md
+++ b/openspec/changes/add-strip-quoted-history/specs/email-read/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Optional Quoted-History Stripping
+
+The `read_email` action SHALL accept an optional `strip_quoted_history` boolean parameter. When `true`, the system SHALL detect a terminal quoted-history block — Gmail/Apple "On … wrote:" preambles, Outlook `From:/Sent:/To:/Subject:` header clusters, or a terminal run of `>`-prefix lines — and replace it with a single short marker (e.g. `[...prior thread truncated]`). When omitted or `false`, the body SHALL be returned unchanged from current behavior. Inline blockquotes appearing within the latest reply SHALL be preserved; only a terminal quoted-history block SHALL be stripped.
+
+#### Scenario: Strip quoted history when flag is true
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` and the email body contains a Gmail "On … wrote:" preamble followed by a multi-line `>`-prefix quoted reply
+- **THEN** the returned body has the preamble and quoted reply replaced with the marker `[...prior thread truncated]`
+- **AND** the latest reply text and any non-quoted user content above the preamble are preserved
+
+#### Scenario: Default behavior is unchanged
+- **WHEN** `read_email` is called with `{id: "msg123"}` (flag omitted) on the same email
+- **THEN** the returned body is identical to current behavior — full quoted history is included
+
+#### Scenario: Inline blockquote in latest reply is preserved
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on an email whose latest reply contains a markdown blockquote (`> note:` line) followed by more user-authored text and no terminal quoted-history block
+- **THEN** the returned body is unchanged and no marker is inserted

--- a/openspec/changes/add-strip-quoted-history/specs/email-read/spec.md
+++ b/openspec/changes/add-strip-quoted-history/specs/email-read/spec.md
@@ -2,7 +2,9 @@
 
 ### Requirement: Optional Quoted-History Stripping
 
-The `read_email` action SHALL accept an optional `strip_quoted_history` boolean parameter. When `true`, the system SHALL detect a terminal quoted-history block — Gmail/Apple "On … wrote:" preambles, Outlook `From:/Sent:/To:/Subject:` header clusters, or a terminal run of `>`-prefix lines — and replace it with a single short marker (e.g. `[...prior thread truncated]`). When omitted or `false`, the body SHALL be returned unchanged from current behavior. Inline blockquotes appearing within the latest reply SHALL be preserved; only a terminal quoted-history block SHALL be stripped.
+The `read_email` action SHALL accept an optional `strip_quoted_history` boolean parameter. When `true`, the system SHALL detect a terminal quoted-history block — Gmail/Apple "On … wrote:" preambles, Outlook `From:/Sent:/Date:/To:/Subject:` header clusters, an Outlook-2003 `-----Original Message-----` separator followed by an Outlook header cluster, or a terminal run of `>`-prefix lines — and replace it with a single short marker (e.g. `[...prior thread truncated]`). The candidate block SHALL only be stripped when it is genuinely terminal: an inline `On … wrote:` quote followed by user-authored prose SHALL NOT be stripped. When omitted or `false`, the body SHALL be returned unchanged from current behavior. Inline blockquotes appearing within the latest reply SHALL be preserved; only a terminal quoted-history block SHALL be stripped.
+
+The detector is English-only: localized "On … wrote:" preambles (German "Am … schrieb …", French "Le … a écrit", Japanese "送信者:" headers, etc.) are NOT matched. Threads from non-English clients SHALL be returned with full quoted history.
 
 #### Scenario: Strip quoted history when flag is true
 - **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` and the email body contains a Gmail "On … wrote:" preamble followed by a multi-line `>`-prefix quoted reply
@@ -15,4 +17,8 @@ The `read_email` action SHALL accept an optional `strip_quoted_history` boolean 
 
 #### Scenario: Inline blockquote in latest reply is preserved
 - **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on an email whose latest reply contains a markdown blockquote (`> note:` line) followed by more user-authored text and no terminal quoted-history block
+- **THEN** the returned body is unchanged and no marker is inserted
+
+#### Scenario: Inline "On … wrote:" with user prose after is preserved
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on a body that contains an `On … wrote:` preamble and `>`-quoted block in the middle, followed by additional user-authored prose
 - **THEN** the returned body is unchanged and no marker is inserted

--- a/openspec/changes/add-strip-quoted-history/tasks.md
+++ b/openspec/changes/add-strip-quoted-history/tasks.md
@@ -1,0 +1,10 @@
+- [x] Add `stripQuotedHistory` helper in `packages/email-core/src/content/quotes.ts` with terminal-block detection and attachments-summary preservation
+- [x] Add unit tests in `packages/email-core/src/content/quotes.test.ts` covering Gmail, Outlook (plain + bolded + Apple Mail Date variant), Outlook-2003 separator, wrapped preambles, deep-nested, CRLF, idempotency, false-positive guards, and attachments preservation
+- [x] Wire `strip_quoted_history` flag into `readEmailAction` in `packages/email-core/src/actions/read.ts`; run order is `transformEmailContent` → `stripQuotedHistory` → `stripSignature`
+- [x] Add optional `contentId?: string` to `ReadEmailOutput.attachments` so MCP and action output shapes align
+- [x] Re-export `readEmailAction` from `packages/email-core/src/index.ts`
+- [x] Refactor MCP `read_email` tool in `packages/email-mcp/src/server.ts` to delegate the connected-provider path to `readEmailAction.run(...)`, keeping demo-mode handling local and exposing the new flag
+- [x] Extend `packages/email-core/src/actions/read.test.ts` with omitted/true/HTML-body/dual-flag/contentId scenarios
+- [x] Extend `packages/email-mcp/src/server.test.ts` `read_email` tests with input-schema, connected-path, demo-path, and no-signature-stripping scenarios
+- [x] Run `openspec validate add-strip-quoted-history --strict`
+- [x] Run `npm run test:run --workspaces` and `npm run lint --workspaces`

--- a/packages/email-core/src/actions/read.test.ts
+++ b/packages/email-core/src/actions/read.test.ts
@@ -11,6 +11,8 @@ beforeEach(() => {
   ctx = { provider };
 });
 
+const QUOTE_MARKER = '[...prior thread truncated]';
+
 describe('email-read/Read Email', () => {
   it('Scenario: Read email with body and metadata', async () => {
     provider.addMessage({
@@ -38,5 +40,122 @@ describe('email-read/Read Email', () => {
     expect(result.body).toContain('Please review the attached contract');
     expect(result.attachments).toHaveLength(1);
     expect(result.attachments![0]!.filename).toBe('contract.pdf');
+  });
+
+  it('Scenario: strip_quoted_history omitted preserves full thread', async () => {
+    provider.addMessage({
+      id: 'msg-thread',
+      body: [
+        'Sounds good — see you Wednesday.',
+        '',
+        'On Tue, Mar 12, 2024 at 4:00 PM Alice <alice@corp.com> wrote:',
+        '> Can we sync at 10am?',
+        '> Talk soon.',
+      ].join('\n'),
+    });
+
+    const result = await readEmailAction.run(ctx, { id: 'msg-thread' });
+
+    expect(result.body).toContain('Sounds good');
+    expect(result.body).toContain('Can we sync at 10am?');
+    expect(result.body).not.toContain(QUOTE_MARKER);
+  });
+
+  it('Scenario: strip_quoted_history true removes terminal Gmail-style chain', async () => {
+    provider.addMessage({
+      id: 'msg-thread',
+      body: [
+        'Sounds good — see you Wednesday.',
+        '',
+        'On Tue, Mar 12, 2024 at 4:00 PM Alice <alice@corp.com> wrote:',
+        '> Can we sync at 10am?',
+        '> Talk soon.',
+      ].join('\n'),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-thread',
+      strip_quoted_history: true,
+    });
+
+    expect(result.body).toContain('Sounds good');
+    expect(result.body).toContain(QUOTE_MARKER);
+    expect(result.body).not.toContain('Can we sync at 10am?');
+  });
+
+  it('Scenario: strip_quoted_history true on Gmail-style HTML body', async () => {
+    provider.addMessage({
+      id: 'msg-html',
+      bodyHtml: [
+        '<p>Confirmed — 10am works.</p>',
+        '<div class="gmail_quote">',
+        '<div>On Wed, Mar 13, 2024 at 9:30 AM Alice &lt;alice@corp.com&gt; wrote:</div>',
+        '<blockquote>Can we move it to 10am?</blockquote>',
+        '</div>',
+      ].join(''),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-html',
+      strip_quoted_history: true,
+    });
+
+    expect(result.body).toContain('Confirmed');
+    expect(result.body).toContain(QUOTE_MARKER);
+    expect(result.body).not.toContain('Can we move it to 10am?');
+  });
+
+  it('Scenario: both flags applied — RFC signature delimiter cuts marker too (documents real behavior)', async () => {
+    // When the latest reply uses the RFC 3676 "-- \n" signature delimiter, signature
+    // stripping unconditionally cuts everything after that delimiter. Quote stripping
+    // runs first and inserts the marker, but the marker sits past the delimiter, so
+    // the signature pass removes it. The end result is a clean reply, which is the
+    // correct outcome — we just don't expect the marker to survive in this shape.
+    const quotedTail = Array.from({ length: 40 }, (_, i) => `> historical line ${i + 1}`).join('\n');
+    provider.addMessage({
+      id: 'msg-both-rfc',
+      body: [
+        'Approved.',
+        '',
+        '-- ',
+        'Bob Jones',
+        'Senior Partner',
+        '',
+        'On Wed, Mar 13, 2024 at 9:30 AM Alice <alice@corp.com> wrote:',
+        quotedTail,
+      ].join('\n'),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-both-rfc',
+      strip_quoted_history: true,
+      strip_signatures: true,
+    });
+
+    expect(result.body).toContain('Approved.');
+    expect(result.body).not.toContain('Bob Jones');
+    expect(result.body).not.toContain('historical line 1');
+  });
+
+  it('Scenario: attachment shape includes contentId when provider returns it', async () => {
+    provider.addMessage({
+      id: 'msg-inline',
+      bodyHtml: '<p>see image</p>',
+      attachments: [
+        {
+          id: 'inline-1',
+          filename: 'logo.png',
+          mimeType: 'image/png',
+          size: 1024,
+          isInline: true,
+          contentId: 'cid:logo@example.com',
+        },
+      ],
+    });
+
+    const result = await readEmailAction.run(ctx, { id: 'msg-inline' });
+
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments![0]!.contentId).toBe('cid:logo@example.com');
   });
 });

--- a/packages/email-core/src/actions/read.test.ts
+++ b/packages/email-core/src/actions/read.test.ts
@@ -137,6 +137,119 @@ describe('email-read/Read Email', () => {
     expect(result.body).not.toContain('historical line 1');
   });
 
+  it('Scenario: strip_quoted_history true on Outlook-style HTML body with header cluster', async () => {
+    // Real Outlook web/365 reply HTML uses `<div>From:</div>` blocks for the header
+    // cluster. This test exercises the path from raw HTML through transformEmailContent
+    // to the detector — i.e. it covers normalization, not just pre-rendered markdown.
+    provider.addMessage({
+      id: 'msg-outlook-html',
+      bodyHtml: [
+        '<p>Confirmed — 10am tomorrow.</p>',
+        '<div>',
+        '<div>From: Alice &lt;alice@corp.com&gt;</div>',
+        '<div>Sent: Wednesday, March 13, 2024 9:30 AM</div>',
+        '<div>To: Bob &lt;bob@corp.com&gt;</div>',
+        '<div>Subject: RE: Contract review</div>',
+        '</div>',
+        '<p>Can we move the call to 10am?</p>',
+      ].join(''),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-outlook-html',
+      strip_quoted_history: true,
+    });
+
+    expect(result.body).toContain('Confirmed');
+    expect(result.body).toContain(QUOTE_MARKER);
+    expect(result.body).not.toContain('Can we move the call to 10am?');
+    expect(result.body).not.toContain('alice@corp.com');
+  });
+
+  it('Scenario: strip_quoted_history true on bolded-Outlook HTML body (Outlook-365 / OWA shape)', async () => {
+    // Outlook-on-the-web wraps the field labels in `<strong>` / `<b>`. node-html-markdown
+    // emits these as `**From:**` (or sometimes `**From**:`) — the detector must handle
+    // both, end-to-end from HTML.
+    provider.addMessage({
+      id: 'msg-outlook-bold-html',
+      bodyHtml: [
+        '<p>Yes.</p>',
+        '<div>',
+        '<div><strong>From:</strong> Alice &lt;alice@corp.com&gt;</div>',
+        '<div><strong>Sent:</strong> Wednesday, May 6, 2026 11:38 AM</div>',
+        '<div><strong>To:</strong> Bob &lt;bob@corp.com&gt;</div>',
+        '<div><strong>Subject:</strong> RE: Symposium logistics</div>',
+        '</div>',
+        '<p>Original body — could we move it to 10am?</p>',
+      ].join(''),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-outlook-bold-html',
+      strip_quoted_history: true,
+    });
+
+    expect(result.body).toContain('Yes.');
+    expect(result.body).toContain(QUOTE_MARKER);
+    expect(result.body).not.toContain('Original body — could we move it to 10am?');
+    expect(result.body).not.toContain('alice@corp.com');
+  });
+
+  it('Scenario: strip_quoted_history true preserves user prose after an inline Gmail quote (HTML input)', async () => {
+    // Regression for the terminal-validation fix: an inline `On … wrote:` quote
+    // followed by additional user-authored prose must NOT collapse the user's
+    // continuation into the marker.
+    provider.addMessage({
+      id: 'msg-inline-html',
+      bodyHtml: [
+        '<p>Including for context:</p>',
+        '<div class="gmail_quote">',
+        '<div>On Wed, Mar 13, 2024 at 9:30 AM Alice &lt;alice@corp.com&gt; wrote:</div>',
+        '<blockquote>Want to push standup to 10am?</blockquote>',
+        '</div>',
+        '<p>My take: 10am is fine but conflicts with Bob — let me check.</p>',
+      ].join(''),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-inline-html',
+      strip_quoted_history: true,
+    });
+
+    expect(result.body).toContain('Including for context');
+    expect(result.body).toContain('My take');
+    expect(result.body).toContain('let me check');
+    expect(result.body).not.toContain(QUOTE_MARKER);
+  });
+
+  it('Scenario: strip_quoted_history true with mobile (non-RFC) signature above marker', async () => {
+    // Many mobile clients use a non-RFC signature like "Sent from my iPhone" without
+    // the "-- " delimiter. The signature heuristic strips by length-percentage on this
+    // shape, which can run after quote stripping has inserted the marker. Confirm the
+    // marker survives.
+    provider.addMessage({
+      id: 'msg-mobile-sig',
+      body: [
+        'Approved.',
+        '',
+        'Sent from my iPhone',
+        '',
+        'On Wed, Mar 13, 2024 at 9:30 AM Alice <alice@corp.com> wrote:',
+        '> earlier draft of the contract',
+      ].join('\n'),
+    });
+
+    const result = await readEmailAction.run(ctx, {
+      id: 'msg-mobile-sig',
+      strip_quoted_history: true,
+      strip_signatures: true,
+    });
+
+    expect(result.body).toContain('Approved.');
+    expect(result.body).toContain(QUOTE_MARKER);
+    expect(result.body).not.toContain('earlier draft');
+  });
+
   it('Scenario: attachment shape includes contentId when provider returns it', async () => {
     provider.addMessage({
       id: 'msg-inline',

--- a/packages/email-core/src/actions/read.ts
+++ b/packages/email-core/src/actions/read.ts
@@ -3,11 +3,13 @@ import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { transformEmailContent } from '../content/sanitize.js';
 import { stripSignature } from '../content/signatures.js';
+import { stripQuotedHistory } from '../content/quotes.js';
 
 const ReadEmailInput = z.object({
   id: z.string(),
   mailbox: z.string().optional(),
   strip_signatures: z.boolean().optional().default(true),
+  strip_quoted_history: z.boolean().optional().default(false),
 });
 
 const ReadEmailOutput = z.object({
@@ -23,6 +25,7 @@ const ReadEmailOutput = z.object({
     filename: z.string(),
     mimeType: z.string(),
     size: z.number(),
+    contentId: z.string().optional(),
     isInline: z.boolean(),
   })).optional(),
 });
@@ -40,6 +43,12 @@ export const readEmailAction: EmailAction<
     const msg = await ctx.provider.getMessage(input.id);
 
     let body = transformEmailContent(msg.body, msg.bodyHtml, msg.attachments);
+    // Quote stripping runs first: shrinking the body lets the signature heuristic
+    // (signatures.ts:33-39 uses a 30%-of-body-length threshold) actually fire on
+    // signatures in the latest reply, which would otherwise be dwarfed by the thread tail.
+    if (input.strip_quoted_history) {
+      body = stripQuotedHistory(body);
+    }
     if (input.strip_signatures) {
       body = stripSignature(body);
     }
@@ -57,6 +66,7 @@ export const readEmailAction: EmailAction<
         filename: a.filename,
         mimeType: a.mimeType,
         size: a.size,
+        contentId: a.contentId,
         isInline: a.isInline,
       })),
     };

--- a/packages/email-core/src/content/quotes.test.ts
+++ b/packages/email-core/src/content/quotes.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect } from 'vitest';
+import { stripQuotedHistory } from './quotes.js';
+
+const MARKER = '[...prior thread truncated]';
+
+describe('content-engine/Quoted-History Stripping', () => {
+  it('Scenario: Strip Gmail "On … wrote:" preamble with quoted reply', () => {
+    const body = [
+      "Thanks, that works for me.",
+      "",
+      "On Wed, Mar 13, 2024 at 9:30 AM Alice <alice@corp.com> wrote:",
+      "> Can we move the call to 10am?",
+      "> Let me know if that works.",
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Thanks, that works for me.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Can we move the call');
+    expect(result).not.toContain('On Wed, Mar 13');
+  });
+
+  it('Scenario: Strip Outlook From/Sent/To/Subject header cluster', () => {
+    const body = [
+      "Confirmed — 10am tomorrow.",
+      "",
+      "From: Alice <alice@corp.com>",
+      "Sent: Wednesday, March 13, 2024 9:30 AM",
+      "To: Bob <bob@corp.com>",
+      "Subject: RE: Contract review",
+      "",
+      "Can we move the call to 10am?",
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Confirmed — 10am tomorrow.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('From: Alice');
+    expect(result).not.toContain('Can we move the call');
+  });
+
+  it('Scenario: Strip 11-level nested terminal `>` quote block', () => {
+    const deepLines: string[] = [];
+    for (let depth = 1; depth <= 11; depth++) {
+      deepLines.push(`${'>'.repeat(depth)} reply at depth ${depth}`);
+    }
+    const body = ['Short reply.', '', ...deepLines].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Short reply.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('reply at depth 11');
+    expect(result).not.toContain('reply at depth 1');
+  });
+
+  it('Scenario: Idempotent — calling twice yields same result', () => {
+    const body = [
+      "Got it.",
+      "",
+      "On Wed, Mar 13 Alice wrote:",
+      "> hello",
+    ].join('\n');
+
+    const once = stripQuotedHistory(body);
+    const twice = stripQuotedHistory(once);
+    expect(twice).toBe(once);
+  });
+
+  it('Scenario: Inline markdown blockquote followed by user text is preserved', () => {
+    const body = [
+      "Hey team,",
+      "",
+      "> Quick reminder from the offsite notes:",
+      "",
+      "We agreed to ship on Friday. Anything blocking?",
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+    expect(result).not.toContain(MARKER);
+  });
+
+  it('Scenario: "On X, I wrote:" line not followed by quotes is preserved', () => {
+    const body = [
+      'On vacation last week, I wrote:',
+      'a few notes that I want to share with the team about the new process.',
+      'No quotes follow.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+  });
+
+  it('Scenario: Single bare "From:" line in user content is preserved', () => {
+    const body = [
+      'Update on the proposal:',
+      '',
+      'From: the legal team, we got pushback on clause 4.',
+      'Not a real header — just narrative.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+  });
+
+  it('Scenario: Attachments summary is preserved when quoted block is between body and summary', () => {
+    const body = [
+      'See the attached.',
+      '',
+      'On Wed Alice wrote:',
+      '> earlier draft',
+      '',
+      'Attachments: contract.pdf (245KB)',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('See the attached.');
+    expect(result).toContain(MARKER);
+    expect(result).toContain('Attachments: contract.pdf (245KB)');
+    expect(result).not.toContain('earlier draft');
+    // Marker should appear before the attachments summary, not after.
+    const markerIdx = result.indexOf(MARKER);
+    const attachIdx = result.indexOf('Attachments:');
+    expect(markerIdx).toBeLessThan(attachIdx);
+  });
+
+  it('Scenario: No-quote pass-through is identity', () => {
+    const body = 'Just a short message with no quoted history at all.\n\nThanks.';
+    expect(stripQuotedHistory(body)).toBe(body);
+  });
+
+  it('Scenario: Empty body returns empty', () => {
+    expect(stripQuotedHistory('')).toBe('');
+  });
+
+  it('Scenario: Strip markdown-bolded Outlook header cluster (Outlook-365 / OWA shape)', () => {
+    // node-html-markdown emits **From:** for bolded `<strong>From:</strong>` source HTML
+    // — the common Outlook-on-the-web / Outlook-365 reply-header shape.
+    const body = [
+      'Yes.',
+      '',
+      '**From:** Alice <alice@corp.com>',
+      '**Sent:** Wednesday, May 6, 2026 11:38 AM',
+      '**To:** Bob <bob@corp.com>',
+      '**Cc:** Carol <carol@corp.com>',
+      '**Subject:** RE: Symposium logistics',
+      '',
+      'Hi Bob — could we move it to 10am?',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Yes.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Alice');
+    expect(result).not.toContain('Hi Bob — could we move it to 10am?');
+  });
+
+  it('Scenario: Apple Mail "On <date>, at <time>, <name> wrote:" preamble (comma+at form)', () => {
+    const body = [
+      'Confirmed.',
+      '',
+      'On Apr 29, 2026, at 1:14 AM, Alice <alice@corp.com> wrote:',
+      '> Want to grab coffee?',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Confirmed.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Want to grab coffee?');
+  });
+
+  it('Scenario: ISO-8601 "On YYYY-MM-DD HH:MM, <name> wrote:" preamble', () => {
+    const body = [
+      'Got it.',
+      '',
+      'On 2026-05-08 17:26, Alice White wrote:',
+      '> Original message body.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Got it.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Original message body.');
+  });
+
+  it('Scenario: Mixed bold and plain Outlook fields still satisfies cluster check', () => {
+    // Some clients only bold a subset of the field labels.
+    const body = [
+      'Approved.',
+      '',
+      '**From:** Alice <alice@corp.com>',
+      'Sent: Wednesday, May 6, 2026 11:38 AM',
+      '**To:** Bob <bob@corp.com>',
+      'Subject: RE: Symposium logistics',
+      '',
+      'Original body text here.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Approved.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Original body text here.');
+  });
+
+  it('Scenario: Apple-Mail forward header uses Date instead of Sent', () => {
+    // Apple Mail (and iPhone Mail) emit "Date:" in their quoted-message header block
+    // where Outlook would emit "Sent:". The detector must recognize either.
+    const body = [
+      'Forwarding for awareness.',
+      '',
+      '**From:** Alice <alice@corp.com>',
+      '**Date:** May 6, 2026 at 11:41:27 AM EDT',
+      '**To:** Bob <bob@corp.com>',
+      '**Subject:** Q2 plan',
+      '',
+      'Original Q2 plan content here.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Forwarding for awareness.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Original Q2 plan content here.');
+  });
+
+  it('Scenario: CRLF line endings are tolerated', () => {
+    // Some providers (including older Exchange) deliver bodies with CRLF separators.
+    // Detection must still work. Note: lines retain trailing \r after split('\n');
+    // regex anchors and trim() handle this.
+    const body = [
+      'Approved.',
+      '',
+      'On Wed Alice wrote:',
+      '> earlier',
+    ].join('\r\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Approved.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('earlier');
+  });
+
+  it('Scenario: Outlook-2003 "-----Original Message-----" separator', () => {
+    // Plaintext separator emitted by older Outlook (and many corporate clients still).
+    // Confirmed by McDermott-style forwards in real mailbox samples.
+    const body = [
+      'Forwarding for review.',
+      '',
+      '-----Original Message-----',
+      'From: Alice <alice@corp.com>',
+      'Sent: Tuesday, April 28, 2026 5:34 PM',
+      'To: Bob <bob@corp.com>',
+      'Subject: Q2 plan',
+      '',
+      'Original body content here.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Forwarding for review.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Original body content here.');
+    expect(result).not.toContain('Original Message');
+  });
+
+  it('Scenario: Wrapped "On … wrote:" preamble (multi-line)', () => {
+    // github/email_reply_parser test/emails/email_1_3.txt exercises wrapped preambles
+    // where the "wrote:" tail spills onto the next line because of long sender info.
+    const body = [
+      'Thanks!',
+      '',
+      'On Thu, Jul 14, 2011 at 4:55 PM, Alice',
+      '<alice@long-domain-example.com> wrote:',
+      '> Original message body.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Thanks!');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Original message body.');
+  });
+
+  it('Scenario: "On" line that does not wrap to "wrote:" is NOT mistaken for preamble', () => {
+    // Important false-positive guard: lines starting with "On" must not trigger the
+    // wrapped-preamble detector unless "wrote:" actually appears within 2 lines.
+    const body = [
+      'Quick update:',
+      '',
+      'On Friday I wrapped up the proposal. Sending the draft Monday.',
+      '',
+      'Feedback welcome.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+  });
+
+  it('Scenario: Custom marker is honored', () => {
+    const body = [
+      'Reply text.',
+      '',
+      'On Wed Alice wrote:',
+      '> earlier',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body, { marker: '[trimmed]' });
+    expect(result).toContain('[trimmed]');
+    expect(result).not.toContain(MARKER);
+  });
+});

--- a/packages/email-core/src/content/quotes.test.ts
+++ b/packages/email-core/src/content/quotes.test.ts
@@ -288,6 +288,12 @@ describe('content-engine/Quoted-History Stripping', () => {
     expect(result).toContain('Thanks!');
     expect(result).toContain(MARKER);
     expect(result).not.toContain('Original message body.');
+    // Regression: the wrapped preamble lines themselves must also be removed —
+    // the previous detector cut at the `>` line and left the `On …\n<email> wrote:`
+    // pair in the output.
+    expect(result).not.toContain('On Thu, Jul 14, 2011');
+    expect(result).not.toContain('alice@long-domain-example.com');
+    expect(result).not.toMatch(/wrote:\s*$/m);
   });
 
   it('Scenario: "On" line that does not wrap to "wrote:" is NOT mistaken for preamble', () => {
@@ -315,6 +321,148 @@ describe('content-engine/Quoted-History Stripping', () => {
 
     const result = stripQuotedHistory(body, { marker: '[trimmed]' });
     expect(result).toContain('[trimmed]');
+    expect(result).not.toContain(MARKER);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Terminal-validation regression tests — added in response to peer review.
+  // Pre-fix, the detector cut on the FIRST recognized pattern without verifying
+  // the candidate was actually at the bottom of the body, so an inline quote
+  // followed by user prose would collapse the user's reply to the marker only.
+  // ---------------------------------------------------------------------------
+
+  it('Scenario: Inline Gmail "On … wrote:" with user prose after is preserved', () => {
+    const body = [
+      'Hi team,',
+      '',
+      'Including the earlier exchange below for reference.',
+      '',
+      'On Wed, Mar 13, 2024 at 9:30 AM Alice <alice@corp.com> wrote:',
+      '> Want to push standup to 10am?',
+      '> Talk soon.',
+      '',
+      'My take: 10am is fine for me but conflicts with Bob — let me check.',
+      'Will follow up tomorrow.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+    expect(result).not.toContain(MARKER);
+  });
+
+  it('Scenario: Inline wrapped "On …" preamble with user prose after is preserved', () => {
+    const body = [
+      'Including for context:',
+      '',
+      'On Thu, Jul 14, 2011 at 4:55 PM, Alice',
+      '<alice@long-domain-example.com> wrote:',
+      '> Earlier note.',
+      '',
+      'And here is my actual response: I disagree with point 3.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+    expect(result).not.toContain(MARKER);
+  });
+
+  it('Scenario: "-----Original Message-----" without an Outlook cluster is preserved', () => {
+    // Without a real header block following, "-----Original Message-----" might be
+    // user-authored (e.g. a literary section divider, a copy-pasted plaintext snippet).
+    // We require a real cluster to commit to stripping.
+    const body = [
+      'Note from the meeting:',
+      '',
+      '-----Original Message-----',
+      '',
+      'Per the discussion, we agreed to ship Friday.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
+    expect(result).not.toContain(MARKER);
+  });
+
+  it('Scenario: Multiple "On … wrote:" levels — cut at the first', () => {
+    const body = [
+      'Latest reply.',
+      '',
+      'On Wed, Mar 13, 2024 at 9:30 AM Alice <alice@corp.com> wrote:',
+      '> Reply level 1',
+      '>',
+      '> On Tue, Mar 12, 2024 Bob <bob@corp.com> wrote:',
+      '> > Reply level 2',
+      '> >',
+      '> > On Mon, Mar 11, 2024 Carol <carol@corp.com> wrote:',
+      '> > > Original message',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Latest reply.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Reply level 1');
+    expect(result).not.toContain('Reply level 2');
+    expect(result).not.toContain('Original message');
+    // Cut should be at the first "On … wrote:" — the marker should appear right after
+    // the latest reply, with no intermediate preamble lines lingering.
+    const lines = result.split('\n');
+    const lastNonBlank = [...lines].reverse().find(l => l.trim() !== '');
+    expect(lastNonBlank).toBe(MARKER);
+  });
+
+  it('Scenario: Body starting with Outlook From: cluster (no leading user text) collapses to marker only', () => {
+    const body = [
+      'From: Alice <alice@corp.com>',
+      'Sent: Wednesday, March 13, 2024 9:30 AM',
+      'To: Bob <bob@corp.com>',
+      'Subject: RE: Contract review',
+      '',
+      'Original body text here.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toBe(MARKER);
+    expect(result).not.toContain('Alice');
+    expect(result).not.toContain('Original body text here.');
+  });
+
+  it('Scenario: Bolded Outlook headers with colon outside asterisks (`**From**:`) are detected', () => {
+    // Some markdown converters emit `**From**:` (colon outside the bold) instead of
+    // `**From:**` (colon inside). The detector must handle both shapes.
+    const body = [
+      'Yes.',
+      '',
+      '**From**: Alice <alice@corp.com>',
+      '**Sent**: Wednesday, May 6, 2026 11:38 AM',
+      '**To**: Bob <bob@corp.com>',
+      '**Subject**: RE: Symposium logistics',
+      '',
+      'Hi Bob — could we move it to 10am?',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+
+    expect(result).toContain('Yes.');
+    expect(result).toContain(MARKER);
+    expect(result).not.toContain('Alice');
+    expect(result).not.toContain('Hi Bob — could we move it to 10am?');
+  });
+
+  it('Scenario: Real-world `>`-prefix shell prompt at EOF (with trailing user text after) is preserved', () => {
+    // A markdown code block in a reply that uses `>` as a shell prompt should not
+    // be mistaken for a quoted-history terminal block, IF user text follows.
+    const body = [
+      'I tested the command:',
+      '',
+      '> ls -la /tmp',
+      '',
+      'It returned the expected output, so we are good to ship.',
+    ].join('\n');
+
+    const result = stripQuotedHistory(body);
+    expect(result).toBe(body);
     expect(result).not.toContain(MARKER);
   });
 });

--- a/packages/email-core/src/content/quotes.ts
+++ b/packages/email-core/src/content/quotes.ts
@@ -1,6 +1,11 @@
 // Quoted-history stripping — heuristic detection of terminal reply chains in already-normalized
 // markdown text emitted by the content engine. Operates after htmlToMarkdown, so blockquotes have
 // already been flattened to `> ` lines, gmail_quote/Outlook header divs to plain text.
+//
+// The detector is English-only: "On … wrote:" preambles and "From:/Sent:/Date:/To:/Subject:"
+// header clusters are matched by their English labels. Localized clients ("Am … schrieb …",
+// "Le … a écrit", "送信者:") are NOT detected and their threads will be returned with full
+// quoted history. This is an explicit scope cut.
 
 const DEFAULT_MARKER = '[...prior thread truncated]';
 
@@ -12,12 +17,15 @@ const ON_WROTE_RE = /^On\b.+\bwrote:\s*$/;
 // this in `test/emails/email_1_3.txt`. Match an "On" line that does NOT contain "wrote:" yet,
 // confirmed only when "wrote:" appears within the next 2 lines.
 const ON_LINE_PREFIX_RE = /^On\b/;
+// Bare "wrote:" tail of a wrapped preamble (e.g. `<alice@long.example> wrote:`).
+const WROTE_TAIL_RE = /\bwrote:\s*$/;
 // Outlook reply headers come through node-html-markdown either as plain `From: …`
 // or as markdown-bolded `**From:** …` (when the source HTML uses <strong>/<b>,
-// which is the common case in Outlook-365 / Outlook-on-the-web). Match both shapes.
+// which is the common case in Outlook-365 / Outlook-on-the-web). Match both shapes,
+// including the colon-outside-bold variant `**From**: …` that some markdown converters emit.
 // `Date:` covers Apple Mail's quoted-message header where Apple uses Date instead of Sent.
-const OUTLOOK_FROM_RE = /^(?:\*\*)?From:(?:\*\*)?\s/;
-const OUTLOOK_FIELD_RE = /^(?:\*\*)?(?:Sent|Date|To|Subject|Cc|Bcc):(?:\*\*)?\s/;
+const OUTLOOK_FROM_RE = /^(?:\*\*)?From(?:\*\*)?\s*:(?:\*\*)?\s/;
+const OUTLOOK_FIELD_RE = /^(?:\*\*)?(?:Sent|Date|To|Subject|Cc|Bcc)(?:\*\*)?\s*:(?:\*\*)?\s/;
 // Outlook 2003-era plaintext separator. Outlook used "-----Original Message-----" before
 // switching to the From:/Sent:/To:/Subject: header block. Older clients (and many forwards
 // today) still emit it. Match with flexible whitespace around "Original Message".
@@ -31,10 +39,15 @@ interface StripQuotedHistoryOptions {
 /**
  * Strip a terminal quoted-history block from an email body and replace it with a short marker.
  * Detects the earliest valid terminal block among:
+ *   - Outlook-2003 `-----Original Message-----` separator followed by an Outlook header cluster
  *   - Gmail/Apple "On <date>, <name> wrote:" preamble validated by a following quote line or
- *     Outlook header cluster
- *   - Outlook header cluster (From: + at least two of Sent/To/Subject within a small window)
+ *     Outlook header cluster, AND with no user prose between the cut and end-of-body
+ *   - Outlook header cluster (From: + at least two of Sent/Date/To/Subject within a small window)
  *   - A terminal run of `>`-prefix lines with only blank lines between it and end-of-body
+ *
+ * "Terminal" means: the first non-history line after the candidate cut is end-of-body. An inline
+ * `On … wrote:` quote followed by user prose is NOT stripped — only the genuine bottom-of-thread
+ * pattern is.
  *
  * Inline blockquotes appearing within the latest reply are preserved (i.e. a `>`-prefix line
  * that has non-quoted user content after it does not trigger stripping).
@@ -56,6 +69,14 @@ export function stripQuotedHistory(body: string, opts?: StripQuotedHistoryOption
     scanBody = body.slice(0, attachMatch.index);
   }
 
+  // Upstream HTML-to-markdown flattens block-level `<div>` content onto a single line
+  // (the content engine's hidden-element translator returns no block formatting for
+  // div/span/p outside of `<p>` paragraphs). That means real Outlook reply HTML often
+  // arrives as `Confirmed.From: Alice<a@x.com>Sent: …To: …Subject: …Body.` with no
+  // line breaks separating header fields. Restore line boundaries before scanning so
+  // the line-anchored detectors can fire.
+  scanBody = normalizeHeaderBoundaries(scanBody);
+
   const lines = scanBody.split('\n');
   const cutLine = findTerminalQuoteBlockStart(lines);
   if (cutLine === null) return body;
@@ -67,27 +88,63 @@ export function stripQuotedHistory(body: string, opts?: StripQuotedHistoryOption
   return stripped + attachmentsSummary;
 }
 
+// Pre-scan normalization: inject newlines before recognized header tokens and `On … wrote:`
+// preambles when they appear glued mid-line. The HTML normalizer flattens `<div>From:</div>`
+// blocks into inline runs, so without this step the line-anchored detectors miss any
+// Outlook header cluster that came from div-based source HTML.
+//
+// Safety: header-field insertions only fire when followed by `\s` after the colon (so a
+// stray "From:" without a header value is left alone), and the cluster detector still
+// requires ≥3 fields, so a single mid-prose `From:` cannot trigger stripping. The
+// `On … wrote:` insertion only fires when `wrote:` actually appears later on the same
+// physical line, and the terminal-tail validator still has to pass.
+function normalizeHeaderBoundaries(body: string): string {
+  let out = body;
+  // Insert before bolded or plain header field markers: From|Sent|Date|To|Subject|Cc|Bcc
+  // Forms supported: `From: `, `**From:** `, `**From**: `.
+  out = out.replace(
+    /([^\s\n])((?:\*\*)?(?:From|Sent|Date|To|Subject|Cc|Bcc)(?:\*\*)?\s*:(?:\*\*)?\s)/g,
+    '$1\n$2',
+  );
+  // Insert before `On … wrote:` only when `wrote:` is on the same physical line.
+  out = out.replace(/([^\s\n])(On\b[^\n]+\bwrote:)/g, '$1\n$2');
+  return out;
+}
+
 function findTerminalQuoteBlockStart(lines: string[]): number | null {
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i] ?? '';
 
-    // "-----Original Message-----" Outlook-2003 separator. Strong signal on its own;
-    // include the line in the cut so the marker replaces the whole block.
-    if (ORIGINAL_MESSAGE_RE.test(line)) return i;
+    // "-----Original Message-----" Outlook-2003 separator. Cut here only if a real
+    // Outlook header cluster follows — without that, the separator could be user
+    // prose (e.g. literary use). Followed cluster + plaintext body is treated as
+    // forwarded content and is allowed to extend to EOF without further validation.
+    if (ORIGINAL_MESSAGE_RE.test(line)) {
+      if (checkOutlookClusterAt(lines, nextNonBlankIndex(lines, i + 1))) return i;
+      continue;
+    }
 
     if (ON_WROTE_RE.test(line)) {
       const next = lookAheadNonBlank(lines, i, 3);
       const hasQuote = next.some(l => QUOTE_LINE_RE.test(l));
       const hasOutlookCluster = checkOutlookClusterAt(lines, i + 1);
-      if (hasQuote || hasOutlookCluster) return i;
-    } else if (ON_LINE_PREFIX_RE.test(line) && lineWrapsToWrote(lines, i)) {
-      // Wrapped "On <long sender info>\n<email>\nwrote:" preamble — only count when
-      // "wrote:" lands within the next 2 lines AND there's a quote line or header
-      // cluster after that, to keep false-positive risk low.
-      const next = lookAheadNonBlank(lines, i + 2, 3);
-      const hasQuote = next.some(l => QUOTE_LINE_RE.test(l));
-      const hasOutlookCluster = checkOutlookClusterAt(lines, i + 3);
-      if (hasQuote || hasOutlookCluster) return i;
+      if ((hasQuote || hasOutlookCluster) && isTailQuotedHistoryOnly(lines, i + 1)) {
+        return i;
+      }
+      continue;
+    }
+
+    if (ON_LINE_PREFIX_RE.test(line)) {
+      const wroteIdx = findWroteWithin(lines, i, 2);
+      if (wroteIdx !== -1) {
+        const next = lookAheadNonBlank(lines, wroteIdx, 3);
+        const hasQuote = next.some(l => QUOTE_LINE_RE.test(l));
+        const hasOutlookCluster = checkOutlookClusterAt(lines, wroteIdx + 1);
+        if ((hasQuote || hasOutlookCluster) && isTailQuotedHistoryOnly(lines, wroteIdx + 1)) {
+          return i;
+        }
+      }
+      continue;
     }
 
     if (OUTLOOK_FROM_RE.test(line) && checkOutlookClusterAt(lines, i)) {
@@ -101,12 +158,19 @@ function findTerminalQuoteBlockStart(lines: string[]): number | null {
   return null;
 }
 
-function lineWrapsToWrote(lines: string[], from: number): boolean {
-  for (let i = from + 1; i < lines.length && i <= from + 2; i++) {
+function findWroteWithin(lines: string[], from: number, withinLines: number): number {
+  for (let i = from + 1; i < lines.length && i <= from + withinLines; i++) {
     const l = lines[i] ?? '';
-    if (/\bwrote:\s*$/.test(l)) return true;
+    if (WROTE_TAIL_RE.test(l)) return i;
   }
-  return false;
+  return -1;
+}
+
+function nextNonBlankIndex(lines: string[], from: number): number {
+  for (let i = from; i < lines.length; i++) {
+    if ((lines[i] ?? '').trim() !== '') return i;
+  }
+  return lines.length;
 }
 
 function lookAheadNonBlank(lines: string[], from: number, n: number): string[] {
@@ -144,6 +208,59 @@ function isTerminalQuoteBlock(lines: string[], from: number): boolean {
     const l = lines[i] ?? '';
     if (l.trim() === '') continue;
     if (!QUOTE_LINE_RE.test(l)) return false;
+  }
+  return true;
+}
+
+// Verify the lines from `fromIdx` to EOF look like a continuation of quoted history rather
+// than a return to user-authored prose. Used for the `On … wrote:` preamble where Gmail/Apple
+// always `>`-prefix the quoted body — a non-quoted, non-header line below the preamble means
+// the user added text after pulling in an inline quote, so we must NOT cut.
+//
+// Allowed continuation shapes:
+//   - blank line
+//   - `>`-prefix quote
+//   - Outlook field (From/Sent/Date/To/Subject/Cc/Bcc, plain or bolded)
+//   - another `On … wrote:` preamble (nested)
+//   - a wrapped `On …` preamble (we jump past it)
+//   - `-----Original Message-----` separator
+//
+// Any other non-blank line aborts validation. Plaintext "original message body" is intentionally
+// rejected here because this validator is only used for the Gmail/Apple `On … wrote:` path,
+// which always uses `>` prefixing. The Outlook cluster path has its own (more permissive)
+// terminal model.
+function isTailQuotedHistoryOnly(lines: string[], fromIdx: number): boolean {
+  let i = fromIdx;
+  while (i < lines.length) {
+    const line = lines[i] ?? '';
+    if (line.trim() === '') {
+      i++;
+      continue;
+    }
+    if (QUOTE_LINE_RE.test(line)) {
+      i++;
+      continue;
+    }
+    if (OUTLOOK_FROM_RE.test(line) || OUTLOOK_FIELD_RE.test(line)) {
+      i++;
+      continue;
+    }
+    if (ORIGINAL_MESSAGE_RE.test(line)) {
+      i++;
+      continue;
+    }
+    if (ON_WROTE_RE.test(line)) {
+      i++;
+      continue;
+    }
+    if (ON_LINE_PREFIX_RE.test(line)) {
+      const wroteIdx = findWroteWithin(lines, i, 2);
+      if (wroteIdx !== -1) {
+        i = wroteIdx + 1;
+        continue;
+      }
+    }
+    return false;
   }
   return true;
 }

--- a/packages/email-core/src/content/quotes.ts
+++ b/packages/email-core/src/content/quotes.ts
@@ -1,0 +1,149 @@
+// Quoted-history stripping — heuristic detection of terminal reply chains in already-normalized
+// markdown text emitted by the content engine. Operates after htmlToMarkdown, so blockquotes have
+// already been flattened to `> ` lines, gmail_quote/Outlook header divs to plain text.
+
+const DEFAULT_MARKER = '[...prior thread truncated]';
+
+const ATTACHMENTS_SUMMARY_RE = /\n\nAttachments: [^\n]+\s*$/;
+// "On <date>, <name> wrote:" preamble (Gmail / Apple Mail). Single-line variant.
+const ON_WROTE_RE = /^On\b.+\bwrote:\s*$/;
+// Wrapped variant: "On" line begins the preamble but the "wrote:" tail wraps to a later
+// line because long sender/email/date strings push it. github/email_reply_parser exercises
+// this in `test/emails/email_1_3.txt`. Match an "On" line that does NOT contain "wrote:" yet,
+// confirmed only when "wrote:" appears within the next 2 lines.
+const ON_LINE_PREFIX_RE = /^On\b/;
+// Outlook reply headers come through node-html-markdown either as plain `From: …`
+// or as markdown-bolded `**From:** …` (when the source HTML uses <strong>/<b>,
+// which is the common case in Outlook-365 / Outlook-on-the-web). Match both shapes.
+// `Date:` covers Apple Mail's quoted-message header where Apple uses Date instead of Sent.
+const OUTLOOK_FROM_RE = /^(?:\*\*)?From:(?:\*\*)?\s/;
+const OUTLOOK_FIELD_RE = /^(?:\*\*)?(?:Sent|Date|To|Subject|Cc|Bcc):(?:\*\*)?\s/;
+// Outlook 2003-era plaintext separator. Outlook used "-----Original Message-----" before
+// switching to the From:/Sent:/To:/Subject: header block. Older clients (and many forwards
+// today) still emit it. Match with flexible whitespace around "Original Message".
+const ORIGINAL_MESSAGE_RE = /^-{2,}\s*Original\s+Message\s*-{2,}\s*$/i;
+const QUOTE_LINE_RE = /^>+/;
+
+interface StripQuotedHistoryOptions {
+  marker?: string;
+}
+
+/**
+ * Strip a terminal quoted-history block from an email body and replace it with a short marker.
+ * Detects the earliest valid terminal block among:
+ *   - Gmail/Apple "On <date>, <name> wrote:" preamble validated by a following quote line or
+ *     Outlook header cluster
+ *   - Outlook header cluster (From: + at least two of Sent/To/Subject within a small window)
+ *   - A terminal run of `>`-prefix lines with only blank lines between it and end-of-body
+ *
+ * Inline blockquotes appearing within the latest reply are preserved (i.e. a `>`-prefix line
+ * that has non-quoted user content after it does not trigger stripping).
+ *
+ * Idempotent: returns the body unchanged when no terminal block is detected, and avoids
+ * appending the marker twice when called repeatedly.
+ */
+export function stripQuotedHistory(body: string, opts?: StripQuotedHistoryOptions): string {
+  if (!body) return body;
+  const marker = opts?.marker ?? DEFAULT_MARKER;
+
+  // The content engine (sanitize.ts) appends `\n\nAttachments: ...` after the body. Detach it
+  // so detection scans only the message body, then re-attach after stripping.
+  let attachmentsSummary = '';
+  let scanBody = body;
+  const attachMatch = body.match(ATTACHMENTS_SUMMARY_RE);
+  if (attachMatch && attachMatch.index !== undefined) {
+    attachmentsSummary = attachMatch[0];
+    scanBody = body.slice(0, attachMatch.index);
+  }
+
+  const lines = scanBody.split('\n');
+  const cutLine = findTerminalQuoteBlockStart(lines);
+  if (cutLine === null) return body;
+
+  const before = lines.slice(0, cutLine).join('\n').replace(/\s+$/, '');
+  const stripped = before.endsWith(marker)
+    ? before
+    : before + (before ? '\n\n' : '') + marker;
+  return stripped + attachmentsSummary;
+}
+
+function findTerminalQuoteBlockStart(lines: string[]): number | null {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+
+    // "-----Original Message-----" Outlook-2003 separator. Strong signal on its own;
+    // include the line in the cut so the marker replaces the whole block.
+    if (ORIGINAL_MESSAGE_RE.test(line)) return i;
+
+    if (ON_WROTE_RE.test(line)) {
+      const next = lookAheadNonBlank(lines, i, 3);
+      const hasQuote = next.some(l => QUOTE_LINE_RE.test(l));
+      const hasOutlookCluster = checkOutlookClusterAt(lines, i + 1);
+      if (hasQuote || hasOutlookCluster) return i;
+    } else if (ON_LINE_PREFIX_RE.test(line) && lineWrapsToWrote(lines, i)) {
+      // Wrapped "On <long sender info>\n<email>\nwrote:" preamble — only count when
+      // "wrote:" lands within the next 2 lines AND there's a quote line or header
+      // cluster after that, to keep false-positive risk low.
+      const next = lookAheadNonBlank(lines, i + 2, 3);
+      const hasQuote = next.some(l => QUOTE_LINE_RE.test(l));
+      const hasOutlookCluster = checkOutlookClusterAt(lines, i + 3);
+      if (hasQuote || hasOutlookCluster) return i;
+    }
+
+    if (OUTLOOK_FROM_RE.test(line) && checkOutlookClusterAt(lines, i)) {
+      return i;
+    }
+
+    if (QUOTE_LINE_RE.test(line) && isTerminalQuoteBlock(lines, i)) {
+      return i;
+    }
+  }
+  return null;
+}
+
+function lineWrapsToWrote(lines: string[], from: number): boolean {
+  for (let i = from + 1; i < lines.length && i <= from + 2; i++) {
+    const l = lines[i] ?? '';
+    if (/\bwrote:\s*$/.test(l)) return true;
+  }
+  return false;
+}
+
+function lookAheadNonBlank(lines: string[], from: number, n: number): string[] {
+  const result: string[] = [];
+  for (let i = from + 1; i < lines.length && result.length < n; i++) {
+    const l = lines[i] ?? '';
+    if (l.trim() !== '') result.push(l);
+  }
+  return result;
+}
+
+// Outlook reply headers look like:
+//   From: Alice <alice@example.com>
+//   Sent: Wednesday, March 13, 2024 9:30 AM
+//   To: Bob <bob@example.com>
+//   Subject: RE: Contract review
+// We require a `From:` start and at least two more recognized fields among the next non-blank
+// lines (so 3+ fields total) — a single "From: Alice" line in user content does not match.
+function checkOutlookClusterAt(lines: string[], from: number): boolean {
+  const nonBlank: string[] = [];
+  for (let i = from; i < lines.length && nonBlank.length < 6; i++) {
+    const l = lines[i] ?? '';
+    if (l.trim() !== '') nonBlank.push(l);
+  }
+  if (nonBlank.length === 0 || !OUTLOOK_FROM_RE.test(nonBlank[0]!)) return false;
+  let fieldCount = 1; // From:
+  for (const l of nonBlank.slice(1, 5)) {
+    if (OUTLOOK_FIELD_RE.test(l)) fieldCount += 1;
+  }
+  return fieldCount >= 3;
+}
+
+function isTerminalQuoteBlock(lines: string[], from: number): boolean {
+  for (let i = from; i < lines.length; i++) {
+    const l = lines[i] ?? '';
+    if (l.trim() === '') continue;
+    if (!QUOTE_LINE_RE.test(l)) return false;
+  }
+  return true;
+}

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -37,6 +37,7 @@ export {
 } from './security/send-allowlist.js';
 export { WatchedAllowlist } from './security/watched-allowlist.js';
 export { htmlToMarkdown, transformEmailContent } from './content/sanitize.js';
+export { readEmailAction } from './actions/read.js';
 export { sendEmailAction } from './actions/send.js';
 export {
   SearchEmailThreadFieldsSchema,

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -737,6 +737,51 @@ describe('mcp-transport/Lazy Provider State', () => {
     ]);
   });
 
+  it('Scenario: read_email omits cc field even when provider returns it (wire-shape parity with pre-PR MCP tool)', async () => {
+    // The pre-PR hand-rolled MCP `read_email` did not surface `cc`. The refactor delegates
+    // to readEmailAction (which returns `cc`), but the MCP adapter must drop it so the wire
+    // shape stays unchanged. Adding cc to the MCP surface is a separate, additive change.
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-cc',
+      subject: 'Has cc',
+      from: { email: 'alice@corp.com', name: 'Alice' },
+      to: [{ email: 'bob@corp.com', name: 'Bob' }],
+      cc: [{ email: 'carol@corp.com', name: 'Carol' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      body: 'Hello.',
+    });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'alice@corp.com';
+    state.mailboxes = [
+      {
+        name: 'alice',
+        emailAddress: 'alice@corp.com',
+        displayName: 'alice@corp.com',
+        providerType: 'gmail',
+        provider: { getMessage } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, { id: 'msg-cc' }) as Record<string, unknown>;
+
+    expect(result).not.toHaveProperty('cc');
+    expect(result.id).toBe('msg-cc');
+    expect(result.to).toEqual(['Bob <bob@corp.com>']);
+    // The action's full schema includes cc; the MCP output schema does NOT.
+    const schema = readEmail.output as { shape?: Record<string, unknown> };
+    expect(schema.shape).toBeDefined();
+    expect(schema.shape!.cc).toBeUndefined();
+  });
+
   it('Scenario: read_email exposes strip_quoted_history with default false', async () => {
     const state = createLazyProviderState();
     state.status = 'connected';

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -737,6 +737,125 @@ describe('mcp-transport/Lazy Provider State', () => {
     ]);
   });
 
+  it('Scenario: read_email exposes strip_quoted_history with default false', async () => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage: vi.fn() } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.mailboxes = [];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+
+    const schema = readEmail.input as { shape?: Record<string, unknown> };
+    expect(schema.shape).toBeDefined();
+    expect(schema.shape!.strip_quoted_history).toBeDefined();
+
+    const parsed = (readEmail.input as { parse: (v: unknown) => Record<string, unknown> }).parse({ id: 'msg1' });
+    expect(parsed.strip_quoted_history).toBe(false);
+  });
+
+  it('Scenario: read_email with strip_quoted_history=true delegates to action and strips quoted reply', async () => {
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-quoted',
+      subject: 'Re: Standup',
+      from: { email: 'alice@corp.com', name: 'Alice' },
+      to: [{ email: 'bob@corp.com', name: 'Bob' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      body: [
+        'Sounds good.',
+        '',
+        'On Wed, Mar 13, 2024 at 9:30 AM Bob <bob@corp.com> wrote:',
+        '> Want to push standup to 10am?',
+      ].join('\n'),
+    });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'alice@corp.com';
+    state.mailboxes = [
+      {
+        name: 'alice',
+        emailAddress: 'alice@corp.com',
+        displayName: 'alice@corp.com',
+        providerType: 'gmail',
+        provider: { getMessage } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, { id: 'msg-quoted', strip_quoted_history: true }) as { body: string };
+
+    expect(result.body).toContain('Sounds good.');
+    expect(result.body).toContain('[...prior thread truncated]');
+    expect(result.body).not.toContain('Want to push standup to 10am?');
+  });
+
+  it('Scenario: read_email does NOT strip signatures even with sig delimiter present', async () => {
+    // Wiring strip_signatures through the MCP tool is out of scope for issue #76 and
+    // tracked separately. The MCP adapter must keep the previous behavior of returning
+    // signatures intact regardless of the action default.
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-sig',
+      subject: 'Signed reply',
+      from: { email: 'alice@corp.com', name: 'Alice' },
+      to: [{ email: 'bob@corp.com', name: 'Bob' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      body: [
+        'Sounds good.',
+        '',
+        '-- ',
+        'Alice Smith',
+        'Senior Partner',
+      ].join('\n'),
+    });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'alice@corp.com';
+    state.mailboxes = [
+      {
+        name: 'alice',
+        emailAddress: 'alice@corp.com',
+        displayName: 'alice@corp.com',
+        providerType: 'gmail',
+        provider: { getMessage } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, { id: 'msg-sig' }) as { body: string };
+
+    expect(result.body).toContain('Alice Smith');
+    expect(result.body).toContain('Senior Partner');
+  });
+
+  it('Scenario: read_email demo path is unchanged when no mailbox is configured', async () => {
+    const state = createLazyProviderState();
+    state.status = 'configuring';
+    state.initPromise = Promise.resolve();
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+
+    const result = await readEmail.run({}, { id: 'demo-1' }) as { id: string; body: string };
+    expect(result.id).toBe('demo-1');
+    expect(result.body).toContain('No mailbox configured');
+  });
+
   it('Scenario: get_mailbox_status resolves the requested mailbox instead of the default', async () => {
     const state = createLazyProviderState();
     state.status = 'connected';

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -780,7 +780,6 @@ export async function buildLazyActions(
         subject: z.string(),
         from: z.string(),
         to: z.array(z.string()),
-        cc: z.array(z.string()).optional(),
         body: z.string(),
         receivedAt: z.string(),
         attachments: z.array(z.object({
@@ -803,7 +802,7 @@ export async function buildLazyActions(
         // must not re-implement business logic). strip_signatures stays false for
         // backwards compatibility — wiring it through is tracked separately.
         const { readEmailAction } = await import('@usejunior/email-core');
-        return readEmailAction.run(
+        const actionResult = await readEmailAction.run(
           { provider: mailbox.provider },
           {
             id: inp.id,
@@ -812,6 +811,11 @@ export async function buildLazyActions(
             strip_quoted_history: inp.strip_quoted_history ?? false,
           },
         );
+        // Drop `cc` — the pre-PR hand-rolled MCP tool did not return cc, so omit it
+        // here to keep the MCP wire shape unchanged. Adding cc to the MCP surface is
+        // a separate, additive wire change and is tracked separately.
+        const { cc: _cc, ...rest } = actionResult;
+        return rest;
       },
     },
     {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -769,13 +769,18 @@ export async function buildLazyActions(
     },
     {
       name: 'read_email',
-      description: 'Read the full content of an email by ID, transformed to token-efficient markdown',
-      input: z.object({ id: z.string(), mailbox: z.string().optional() }),
+      description: 'Read the full content of an email by ID, transformed to token-efficient markdown. Set strip_quoted_history to true to drop the terminal "On … wrote:" / Outlook-header / `>`-prefix reply chain and replace it with a short marker.',
+      input: z.object({
+        id: z.string(),
+        mailbox: z.string().optional(),
+        strip_quoted_history: z.boolean().optional().default(false),
+      }),
       output: z.object({
         id: z.string(),
         subject: z.string(),
         from: z.string(),
         to: z.array(z.string()),
+        cc: z.array(z.string()).optional(),
         body: z.string(),
         receivedAt: z.string(),
         attachments: z.array(z.object({
@@ -790,51 +795,23 @@ export async function buildLazyActions(
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
-        const inp = input as { id: string; mailbox?: string };
+        const inp = input as { id: string; mailbox?: string; strip_quoted_history?: boolean };
         if (!getDefaultMailbox(state)) return demoReadEmail(inp.id);
         const { mailbox } = resolveMailboxContext(state, inp.mailbox);
-        const msg = await mailbox.provider.getMessage(inp.id) as {
-          id: string;
-          subject: string;
-          from: { email: string; name?: string };
-          to: Array<{ email: string; name?: string }>;
-          receivedAt: string;
-          body?: string;
-          bodyHtml?: string;
-          attachments?: Array<{
-            id: string;
-            filename: string;
-            mimeType: string;
-            size: number;
-            contentId?: string;
-            isInline: boolean;
-          }>;
-        };
-
-        let emailBody = '';
-        try {
-          const { transformEmailContent } = await import('@usejunior/email-core');
-          emailBody = transformEmailContent(msg.body, msg.bodyHtml, msg.attachments);
-        } catch {
-          emailBody = msg.bodyHtml ?? msg.body ?? '';
-        }
-
-        return {
-          id: msg.id,
-          subject: msg.subject,
-          from: msg.from.name ? `${msg.from.name} <${msg.from.email}>` : msg.from.email,
-          to: msg.to.map(a => a.name ? `${a.name} <${a.email}>` : a.email),
-          body: emailBody,
-          receivedAt: msg.receivedAt,
-          attachments: msg.attachments?.map(attachment => ({
-            id: attachment.id,
-            filename: attachment.filename,
-            mimeType: attachment.mimeType,
-            size: attachment.size,
-            contentId: attachment.contentId,
-            isInline: attachment.isInline,
-          })),
-        };
+        // Delegate to the canonical readEmailAction so MCP stays a thin adapter
+        // (per AGENTS.md: actions are the single source of truth, transport layers
+        // must not re-implement business logic). strip_signatures stays false for
+        // backwards compatibility — wiring it through is tracked separately.
+        const { readEmailAction } = await import('@usejunior/email-core');
+        return readEmailAction.run(
+          { provider: mailbox.provider },
+          {
+            id: inp.id,
+            mailbox: inp.mailbox,
+            strip_signatures: false,
+            strip_quoted_history: inp.strip_quoted_history ?? false,
+          },
+        );
       },
     },
     {


### PR DESCRIPTION
## Summary

- Add opt-in `strip_quoted_history: boolean` (default `false`) to `read_email`. When true, strips a terminal Gmail/Apple "On … wrote:" preamble, Outlook `From:/Sent:/To:/Subject:` header cluster, Outlook-2003 `-----Original Message-----` separator, or terminal `>`-prefix run, and replaces it with a `[...prior thread truncated]` marker.
- Refactor MCP `read_email` from a hand-rolled duplicate into a thin adapter that delegates to `readEmailAction.run(...)`, restoring the "actions are the single source of truth, MCP is a thin adapter" convention from `AGENTS.md`.
- Detector handles plain and markdown-bolded Outlook headers (Outlook-on-the-web), Apple Mail's `Date:` variant, ISO-8601 dates, wrapped multi-line "On … wrote:" preambles, CRLF line endings, and preserves the trailing `Attachments:` summary added by `transformEmailContent`.

Closes #76. Out of scope (tracked separately): wiring `strip_signatures` through to the MCP tool — see #87.

## Implementation notes

- New module: `packages/email-core/src/content/quotes.ts` (text-level, no new runtime dep).
- Quote stripping runs **before** signature stripping in `readEmailAction.run()` so the 30%-body-length signature heuristic in `signatures.ts` can fire on the latest reply once the long thread tail is removed.
- Detector semantics are conservative: only **terminal** quoted-history blocks are stripped. Inline markdown blockquotes the user wrote in their latest reply are preserved (`> note to self` followed by more user text is unchanged).
- False-positive guards covered by tests: "On vacation, I wrote:" without following quotes, single-line "From:" in narrative content, inline blockquotes mid-body.
- OpenSpec change `add-strip-quoted-history` documents the new requirement under `## ADDED Requirements` (not modified — additive flag preserves existing scenarios).

## Verification

- `npm run test:run --workspaces` — 685 tests passing across email-core (275), email-mcp (185), provider-gmail (79), provider-microsoft (133), oauth-broker (13)
- `npm run lint --workspaces` — clean across all packages
- `npm run build` — workspace build succeeds; MCP resolves the new `readEmailAction` export from `email-core`
- `openspec validate add-strip-quoted-history --strict` — passes

## Test fixtures

The 20 quote-stripper tests are derived from real-world inbox sampling (anonymized) plus open-source corpora research:

- Gmail "On … wrote:" + multi-line `>` quoted reply
- Outlook plaintext header cluster
- Outlook-365 / OWA bolded header cluster (`**From:** …`)
- Apple Mail comma+at preamble (`On Apr 29, 2026, at 1:14 AM, …`)
- ISO-8601 preamble (`On 2026-05-08 17:26, …`)
- Apple Mail `Date:` field variant
- Outlook-2003 `-----Original Message-----` separator
- Wrapped multi-line "On … wrote:" preamble
- 11-level deep `>` nesting
- CRLF line endings
- Mixed bold + plain Outlook fields
- Idempotency (double-strip yields same result)
- Custom marker
- False-positive guards: inline blockquote, "On vacation, I wrote:", bare `From:` line
- Attachments summary preserved across strip
- No-quote and empty-body identity

## Test plan
- [ ] CI: `npm run test:run --workspaces`
- [ ] CI: `npm run lint --workspaces`
- [ ] CI: `npm run build`
- [ ] CI: `openspec validate add-strip-quoted-history --strict`
- [ ] Manual smoke (optional): connect a real mailbox, call `read_email` on a long thread with and without `strip_quoted_history: true`, confirm the marker replaces the trailing chain only when the flag is true.