### PR TITLE
feat: outbound attachments on create_draft/update_draft/send_email/reply_to_email

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ Agent Email exposes 15 MCP tools:
 | `move_to_folder` | Move between folders | write |
 | `delete_email` | Delete (requires operator env + caller flag) | destructive |
 
+### Outbound attachments
+
+`send_email`, `reply_to_email`, `create_draft`, and `update_draft` accept an
+optional `attachments` array. Each entry takes a sandboxed file `path` (read
+relative to `EMAIL_MCP_SAFE_DIR`, default the process working directory) or
+inline `base64`, plus optional `filename` / `mimeType` overrides:
+
+```json
+{
+  "to": "alice@example.com",
+  "subject": "Signed agreement",
+  "body": "Attached as requested.",
+  "attachments": [
+    { "path": "./out/agreement.pdf" },
+    { "base64": "iVBORw0KGgo...", "filename": "screenshot.png" }
+  ]
+}
+```
+
+Files are capped at 25MB each; Microsoft Graph additionally caps inline sends
+at ~3MB total (larger files need an upload session — not yet supported). For
+`update_draft`, omitting `attachments` preserves the draft's existing files;
+passing an array (even empty) replaces them.
+
 ## Provider Support
 
 | Provider | Status | Package |

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -91,6 +91,10 @@ Agent Email exposes 15 MCP tools:
 | `move_to_folder` | Move between folders | write |
 | `delete_email` | Delete (requires operator env + caller flag) | destructive |
 
+`send_email`, `reply_to_email`, `create_draft`, and `update_draft` accept an
+optional `attachments` array — each entry is a sandboxed file `path` or inline
+`base64`, with optional `filename` / `mimeType`. Files are capped at 25MB each.
+
 ## Provider Support
 
 | Provider | Status | Package |

--- a/packages/email-core/src/actions/attachments.ts
+++ b/packages/email-core/src/actions/attachments.ts
@@ -3,8 +3,7 @@ import { z } from 'zod';
 import { extname } from 'node:path';
 import type { EmailAction } from './registry.js';
 import { AttachmentNotSupportedError, AttachmentNotFoundError } from '../providers/provider.js';
-
-const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024; // 25MB
+import { MAX_ATTACHMENT_SIZE } from '../content/attachment-loader.js';
 
 // Binary file magic bytes
 const MAGIC_BYTES: [Buffer, string][] = [

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -1,12 +1,15 @@
 // Shared helpers for compose actions — internal module, NOT exported from package root
 import { z } from 'zod';
+import { basename } from 'node:path';
 import type { RateLimiter, MailboxEntry } from './registry.js';
 import { ProviderError } from '../providers/provider.js';
 import type { EmailReader } from '../providers/provider.js';
 import { resolveBodyFile } from '../content/body-loader.js';
+import { resolveAttachmentFile } from '../content/attachment-loader.js';
 import type { BodyFormat } from '../content/body-renderer.js';
 import { parseAddressList } from '../utils/address.js';
-import type { EmailAddress } from '../types.js';
+import { validateAttachment, sanitizeFilename } from './attachments.js';
+import type { EmailAddress, OutboundAttachment } from '../types.js';
 
 // --- Error shape used by all actions ---
 
@@ -105,6 +108,106 @@ export async function resolveComposeFields(
   }
 
   return { body: body ?? '', to, cc, subject, replyTo, draft, format, forceBlack };
+}
+
+// --- Outbound attachments ---
+
+// Strict standard-base64: zero or more full quartets, then an optional final
+// group of 2 chars + `==` or 3 chars + `=`. Rejects lengths that are not a
+// valid base64 size (e.g. a lone `A` or `abcde`), which Node's decoder would
+// otherwise silently truncate into corrupt bytes.
+const BASE64_PATTERN = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+const hasNonEmpty = (v: string | undefined): boolean => v !== undefined && v !== '';
+
+/** True when `value` (whitespace stripped) is non-empty, valid standard base64. */
+function isValidBase64(value: string): boolean {
+  const stripped = value.replace(/\s/g, '');
+  return stripped.length > 0 && BASE64_PATTERN.test(stripped);
+}
+
+/**
+ * Per-attachment input schema for the four outbound actions. Each entry takes
+ * a sandboxed file path OR inline base64 — exactly one — plus optional
+ * filename/mimeType overrides.
+ */
+export const AttachmentInputSchema = z
+  .object({
+    path: z.string().optional()
+      .describe('Path to a file within the working directory (sandboxed, like body_file).'),
+    base64: z.string().optional()
+      .describe('Inline standard-base64-encoded file content. Alternative to path.'),
+    filename: z.string().optional()
+      .describe('Attachment filename. Defaults to basename(path); REQUIRED when using base64.'),
+    mimeType: z.string().optional()
+      .describe('MIME type override. Defaults to magic-byte detection.'),
+  })
+  .refine(v => hasNonEmpty(v.path) !== hasNonEmpty(v.base64), {
+    message: 'Each attachment must set exactly one of `path` or `base64`.',
+  })
+  .refine(v => !(hasNonEmpty(v.base64) && !hasNonEmpty(v.path) && !hasNonEmpty(v.filename)), {
+    message: '`filename` is required when an attachment is provided as `base64`.',
+  })
+  .refine(
+    v => !(hasNonEmpty(v.base64) && !hasNonEmpty(v.path)) || isValidBase64(v.base64!),
+    { message: '`base64` is not valid standard base64.' },
+  );
+
+export type AttachmentInput = z.infer<typeof AttachmentInputSchema>;
+
+export interface ResolveAttachmentsResult {
+  files?: OutboundAttachment[];
+  error?: ActionError;
+}
+
+/**
+ * Resolve caller-supplied attachment inputs into validated OutboundAttachment
+ * buffers. Path entries are read sandboxed to `safeDir`; base64 entries are
+ * decoded inline. Each file is run through validateAttachment (25MB cap +
+ * magic-byte MIME). Returns a structured error on the first failure — never
+ * throws. An undefined/empty input yields `{ files: [] }`.
+ */
+export async function resolveAttachments(
+  attachments: AttachmentInput[] | undefined,
+  safeDir: string | undefined,
+): Promise<ResolveAttachmentsResult> {
+  if (!attachments || attachments.length === 0) {
+    return { files: [] };
+  }
+
+  const files: OutboundAttachment[] = [];
+  for (const [index, att] of attachments.entries()) {
+    let content: Buffer;
+    let defaultName: string;
+
+    if (hasNonEmpty(att.path)) {
+      const read = await resolveAttachmentFile(att.path!, safeDir);
+      if (read.error) {
+        return { error: { ...read.error, message: `attachments[${index}]: ${read.error.message}` } };
+      }
+      content = read.content!;
+      defaultName = basename(att.path!);
+    } else {
+      content = Buffer.from(att.base64!.replace(/\s/g, ''), 'base64');
+      defaultName = 'attachment';
+    }
+
+    const filename = sanitizeFilename(att.filename ?? defaultName);
+    const validation = validateAttachment(content, filename, att.mimeType);
+    if (!validation.valid) {
+      return {
+        error: {
+          code: 'ATTACHMENT_INVALID',
+          message: `attachments[${index}]: ${validation.error}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    files.push({ filename, content, mimeType: validation.detectedMimeType });
+  }
+
+  return { files };
 }
 
 // --- validateRequiredFields ---

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -14,6 +14,8 @@ import {
   handleProviderError,
   parseRecipients,
   buildDraftPreview,
+  resolveAttachments,
+  AttachmentInputSchema,
   DraftPreviewSchema,
   PreviewErrorSchema,
 } from './compose-helpers.js';
@@ -46,6 +48,8 @@ const CreateDraftInput = z.object({
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
     .describe('Wrap rendered HTML in a force-black div so Outlook dark mode does not hide the text. Default true.'),
+  attachments: z.array(AttachmentInputSchema).optional()
+    .describe('Files to attach. Each entry takes a sandboxed `path` or inline `base64`.'),
 });
 
 export const createDraftAction: EmailAction<
@@ -72,6 +76,13 @@ export const createDraftAction: EmailAction<
 
     const { to, cc, subject, replyTo, format, forceBlack } = fields;
     let { body } = fields;
+
+    // Resolve attachments (sandboxed path reads + validation)
+    const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+    if (attResult.error) {
+      return { success: false, error: attResult.error };
+    }
+    const attachments = attResult.files!;
 
     // Validate required fields
     const requiredError = validateRequiredFields(to, subject);
@@ -120,6 +131,7 @@ export const createDraftAction: EmailAction<
         const result = await ctx.provider.createReplyDraft(replyTo, body, {
           cc: parsed.cc,
           bodyHtml: outBodyHtml,
+          attachments: attachments.length > 0 ? attachments : undefined,
         });
         const previewResult = result.success && result.draftId
           ? await buildDraftPreview(ctx.provider, result.draftId)
@@ -143,6 +155,7 @@ export const createDraftAction: EmailAction<
         subject: subject!,
         body,
         bodyHtml: outBodyHtml,
+        attachments: attachments.length > 0 ? attachments : undefined,
       });
       const previewResult = result.success && result.draftId
         ? await buildDraftPreview(ctx.provider, result.draftId)
@@ -267,6 +280,8 @@ const UpdateDraftInput = z.object({
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
     .describe('Wrap rendered HTML in a force-black div so Outlook dark mode does not hide the text. Default true.'),
+  attachments: z.array(AttachmentInputSchema).optional()
+    .describe('Files to attach. Omit to preserve the draft\'s existing attachments; provide an array (possibly empty) to replace them entirely.'),
 });
 
 export const updateDraftAction: EmailAction<
@@ -326,6 +341,17 @@ export const updateDraftAction: EmailAction<
       if (cc !== undefined) partial.cc = parsed.cc;
     }
     if (subject) partial.subject = subject;
+
+    // Attachments: omitted → preserve existing (handled provider-side);
+    // provided → replace entirely (an empty array removes all).
+    if (input.attachments !== undefined) {
+      const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+      if (attResult.error) {
+        return { success: false, error: attResult.error };
+      }
+      partial.attachments = attResult.files!;
+    }
+
     if (body) {
       const rendered = renderEmailBody(body, { format, forceBlack });
       let outBody = rendered.body;

--- a/packages/email-core/src/actions/outbound-attachments.test.ts
+++ b/packages/email-core/src/actions/outbound-attachments.test.ts
@@ -1,0 +1,310 @@
+// Outbound attachment coverage for create_draft / update_draft / send_email /
+// reply_to_email — issue #89.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { MockEmailProvider } from '../testing/mock-provider.js';
+import { sendEmailAction } from './send.js';
+import { createDraftAction, updateDraftAction } from './draft.js';
+import { replyToEmailAction } from './reply.js';
+import type { ActionContext } from './registry.js';
+
+// Minimal valid PDF — the %PDF magic bytes drive MIME detection.
+const PDF_BYTES = Buffer.from('%PDF-1.4\n1 0 obj<<>>endobj\n', 'utf-8');
+const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02]);
+
+const VALID_MSG_ID = 'abc123def456ghi789jkl012';
+
+let provider: MockEmailProvider;
+let ctx: ActionContext;
+let testDir: string;
+
+beforeEach(async () => {
+  provider = new MockEmailProvider();
+  provider.addMessage({
+    id: VALID_MSG_ID,
+    subject: 'Original',
+    from: { email: 'partner@allowed.com', name: 'Partner' },
+    to: [{ email: 'me@company.com' }],
+    receivedAt: '2026-05-01T10:00:00Z',
+    isRead: true,
+    hasAttachments: false,
+  });
+  testDir = join(tmpdir(), `outbound-att-test-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  await mkdir(testDir, { recursive: true });
+  ctx = {
+    provider,
+    mailboxName: 'work',
+    allMailboxes: [
+      { name: 'work', emailAddress: 'me@company.com', provider, providerType: 'microsoft', isDefault: true, status: 'connected' },
+    ],
+    sendAllowlist: { entries: ['*@allowed.com'] },
+    safeDir: testDir,
+  };
+});
+
+describe('outbound-attachments/send_email', () => {
+  it('Scenario: single file by path', async () => {
+    await writeFile(join(testDir, 'doc.pdf'), PDF_BYTES);
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'With attachment',
+      body: 'See attached.',
+      attachments: [{ path: 'doc.pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    const sent = provider.getSentMessages();
+    expect(sent[0]!.attachments).toHaveLength(1);
+    expect(sent[0]!.attachments![0]!.filename).toBe('doc.pdf');
+    expect(sent[0]!.attachments![0]!.content.equals(PDF_BYTES)).toBe(true);
+    expect(sent[0]!.attachments![0]!.mimeType).toBe('application/pdf');
+  });
+
+  it('Scenario: multiple files by path preserve order', async () => {
+    await writeFile(join(testDir, 'a.pdf'), PDF_BYTES);
+    await writeFile(join(testDir, 'b.png'), PNG_BYTES);
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Two files',
+      body: 'body',
+      attachments: [{ path: 'a.pdf' }, { path: 'b.png' }],
+    });
+
+    expect(result.success).toBe(true);
+    const att = provider.getSentMessages()[0]!.attachments!;
+    expect(att.map(a => a.filename)).toEqual(['a.pdf', 'b.png']);
+  });
+
+  it('Scenario: base64 input with explicit filename', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Inline base64',
+      body: 'body',
+      attachments: [{ base64: PDF_BYTES.toString('base64'), filename: 'inline.pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    const att = provider.getSentMessages()[0]!.attachments![0]!;
+    expect(att.filename).toBe('inline.pdf');
+    expect(att.content.equals(PDF_BYTES)).toBe(true);
+  });
+
+  it('Scenario: MIME inference overrides a wrong declared type', async () => {
+    await writeFile(join(testDir, 'mystery.pdf'), PDF_BYTES);
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Mime',
+      body: 'body',
+      attachments: [{ path: 'mystery.pdf', mimeType: 'application/octet-stream' }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(provider.getSentMessages()[0]!.attachments![0]!.mimeType).toBe('application/pdf');
+  });
+
+  it('Scenario: missing file returns a structured error', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Missing',
+      body: 'body',
+      attachments: [{ path: 'nope.pdf' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('FILE_NOT_FOUND');
+    expect(result.error!.message).toContain('attachments[0]');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
+  it('Scenario: path traversal is rejected', async () => {
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Traversal',
+      body: 'body',
+      attachments: [{ path: '../../../etc/passwd' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('PATH_TRAVERSAL');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
+  it('Scenario: oversize file (>25MB) is rejected', async () => {
+    await writeFile(join(testDir, 'huge.bin'), Buffer.alloc(25 * 1024 * 1024 + 1));
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Huge',
+      body: 'body',
+      attachments: [{ path: 'huge.bin' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ATTACHMENT_TOO_LARGE');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
+  it('Scenario: malformed base64 is rejected by the input schema', () => {
+    const parsed = sendEmailAction.input.safeParse({
+      to: 'alice@allowed.com',
+      subject: 'Bad',
+      body: 'body',
+      attachments: [{ base64: 'not valid base64 !!!', filename: 'x.bin' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Scenario: base64 with a valid charset but invalid length is rejected', () => {
+    // "abcde" — all base64 chars but not a valid quartet length; Node's
+    // decoder would silently truncate it instead of erroring.
+    const parsed = sendEmailAction.input.safeParse({
+      to: 'alice@allowed.com',
+      subject: 'Bad',
+      body: 'body',
+      attachments: [{ base64: 'abcde', filename: 'x.bin' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Scenario: an attachment with neither path nor base64 is rejected', () => {
+    const parsed = sendEmailAction.input.safeParse({
+      to: 'alice@allowed.com',
+      subject: 'Bad',
+      body: 'body',
+      attachments: [{ filename: 'x.bin' }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('Scenario: base64 attachment without filename is rejected', () => {
+    const parsed = sendEmailAction.input.safeParse({
+      to: 'alice@allowed.com',
+      subject: 'Bad',
+      body: 'body',
+      attachments: [{ base64: PDF_BYTES.toString('base64') }],
+    });
+    expect(parsed.success).toBe(false);
+  });
+});
+
+describe('outbound-attachments/create_draft', () => {
+  it('Scenario: create_draft carries attachments to the provider', async () => {
+    await writeFile(join(testDir, 'doc.pdf'), PDF_BYTES);
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'anyone@example.com',
+      subject: 'Draft with file',
+      body: 'body',
+      attachments: [{ path: 'doc.pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = provider.getDrafts().get(result.draftId!);
+    expect(draft!.attachments).toHaveLength(1);
+    expect(draft!.attachments![0]!.filename).toBe('doc.pdf');
+  });
+});
+
+describe('outbound-attachments/update_draft', () => {
+  it('Scenario: omitting attachments preserves the existing set', async () => {
+    await writeFile(join(testDir, 'doc.pdf'), PDF_BYTES);
+    const created = await createDraftAction.run(ctx, {
+      to: 'anyone@example.com',
+      subject: 'Original subject',
+      body: 'body',
+      attachments: [{ path: 'doc.pdf' }],
+    });
+    const draftId = created.draftId!;
+
+    const updated = await updateDraftAction.run(ctx, {
+      draft_id: draftId,
+      subject: 'New subject',
+    });
+
+    expect(updated.success).toBe(true);
+    const draft = provider.getDrafts().get(draftId)!;
+    expect(draft.subject).toBe('New subject');
+    expect(draft.attachments).toHaveLength(1);
+    expect(draft.attachments![0]!.filename).toBe('doc.pdf');
+  });
+
+  it('Scenario: providing attachments replaces the existing set', async () => {
+    await writeFile(join(testDir, 'old.pdf'), PDF_BYTES);
+    await writeFile(join(testDir, 'new.png'), PNG_BYTES);
+    const created = await createDraftAction.run(ctx, {
+      to: 'anyone@example.com',
+      subject: 'Subject',
+      body: 'body',
+      attachments: [{ path: 'old.pdf' }],
+    });
+    const draftId = created.draftId!;
+
+    const updated = await updateDraftAction.run(ctx, {
+      draft_id: draftId,
+      attachments: [{ path: 'new.png' }],
+    });
+
+    expect(updated.success).toBe(true);
+    const draft = provider.getDrafts().get(draftId)!;
+    expect(draft.attachments).toHaveLength(1);
+    expect(draft.attachments![0]!.filename).toBe('new.png');
+  });
+
+  it('Scenario: an empty attachments array removes all attachments', async () => {
+    await writeFile(join(testDir, 'old.pdf'), PDF_BYTES);
+    const created = await createDraftAction.run(ctx, {
+      to: 'anyone@example.com',
+      subject: 'Subject',
+      body: 'body',
+      attachments: [{ path: 'old.pdf' }],
+    });
+    const draftId = created.draftId!;
+
+    const updated = await updateDraftAction.run(ctx, {
+      draft_id: draftId,
+      attachments: [],
+    });
+
+    expect(updated.success).toBe(true);
+    expect(provider.getDrafts().get(draftId)!.attachments).toEqual([]);
+  });
+});
+
+describe('outbound-attachments/reply_to_email', () => {
+  it('Scenario: reply send path carries attachments', async () => {
+    await writeFile(join(testDir, 'doc.pdf'), PDF_BYTES);
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Reply body',
+      reply_all: true,
+      attachments: [{ path: 'doc.pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    const sent = provider.getSentMessages();
+    expect(sent[0]!.attachments).toHaveLength(1);
+    expect(sent[0]!.attachments![0]!.filename).toBe('doc.pdf');
+  });
+
+  it('Scenario: reply draft path carries attachments', async () => {
+    await writeFile(join(testDir, 'doc.pdf'), PDF_BYTES);
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Reply body',
+      draft: true,
+      reply_all: true,
+      attachments: [{ path: 'doc.pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    const draft = provider.getDrafts().get(result.draftId!);
+    expect(draft!.attachments).toHaveLength(1);
+  });
+});

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -12,6 +12,8 @@ import {
   handleProviderError,
   parseRecipients,
   buildDraftPreview,
+  resolveAttachments,
+  AttachmentInputSchema,
   DraftPreviewSchema,
   PreviewErrorSchema,
 } from './compose-helpers.js';
@@ -28,6 +30,8 @@ const ReplyToEmailInput = z.object({
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
     .describe('Wrap rendered HTML in a force-black div so Outlook dark mode does not hide the text. Default true.'),
+  attachments: z.array(AttachmentInputSchema).optional()
+    .describe('Files to attach. Each entry takes a sandboxed `path` or inline `base64`.'),
 });
 
 const ReplyToEmailOutput = z.object({
@@ -138,6 +142,13 @@ export const replyToEmailAction: EmailAction<
       return { success: false, error: parsed.error };
     }
 
+    // Resolve attachments (sandboxed path reads + validation)
+    const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+    if (attResult.error) {
+      return { success: false, error: attResult.error };
+    }
+    const attachments = attResult.files!.length > 0 ? attResult.files : undefined;
+
     // Render body: markdown → HTML by default
     const rendered = renderEmailBody(input.body, { format: input.format, forceBlack: input.force_black });
     const bodyPlain = rendered.body;
@@ -160,6 +171,7 @@ export const replyToEmailAction: EmailAction<
           cc: parsed.cc,
           bodyHtml,
           replyAll: input.reply_all,
+          attachments,
         });
         const previewResult = draftResult.success && draftResult.draftId
           ? await buildDraftPreview(ctx.provider, draftResult.draftId)
@@ -210,6 +222,7 @@ export const replyToEmailAction: EmailAction<
           cc: parsed.cc,
           bodyHtml,
           replyAll: input.reply_all,
+          attachments,
         }),
         { maxRetries: 3, baseDelay: 1000 },
       );

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -14,6 +14,8 @@ import {
   handleProviderError,
   parseRecipients,
   buildDraftPreview,
+  resolveAttachments,
+  AttachmentInputSchema,
   DraftPreviewSchema,
   PreviewErrorSchema,
 } from './compose-helpers.js';
@@ -30,6 +32,8 @@ const SendEmailInput = z.object({
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
   force_black: z.boolean().optional()
     .describe('Wrap rendered HTML in a force-black div so Outlook dark mode does not hide the text. Default true. Ignored when format is "text".'),
+  attachments: z.array(AttachmentInputSchema).optional()
+    .describe('Files to attach. Each entry takes a sandboxed `path` or inline `base64`.'),
 });
 
 const SendEmailOutput = z.object({
@@ -69,6 +73,13 @@ export const sendEmailAction: EmailAction<
 
     const { to, cc, subject, draft, format, forceBlack } = fields;
     let { body } = fields;
+
+    // Resolve attachments (sandboxed path reads + validation)
+    const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+    if (attResult.error) {
+      return { success: false, error: attResult.error };
+    }
+    const attachments = attResult.files!.length > 0 ? attResult.files : undefined;
 
     // Validate required fields after merge
     const requiredError = validateRequiredFields(to, subject);
@@ -116,6 +127,7 @@ export const sendEmailAction: EmailAction<
         subject: subject!,
         body,
         bodyHtml: outBodyHtml,
+        attachments,
       });
       const previewResult = draftResult.success && draftResult.draftId
         ? await buildDraftPreview(ctx.provider, draftResult.draftId)
@@ -156,6 +168,7 @@ export const sendEmailAction: EmailAction<
           subject: subject!,
           body,
           bodyHtml: outBodyHtml,
+          attachments,
         }),
         { maxRetries: 3, baseDelay: 1000 },
       );

--- a/packages/email-core/src/content/attachment-loader.ts
+++ b/packages/email-core/src/content/attachment-loader.ts
@@ -1,0 +1,87 @@
+// Sandboxed binary file reader for outbound attachments.
+// Shares the path-traversal / symlink policy with body-loader via
+// assertPathInSafeDir, but reads raw bytes — no text-extension gate, no
+// null-byte rejection, no UTF-8 decode, no frontmatter parsing.
+import { open } from 'node:fs/promises';
+import { assertPathInSafeDir } from './safe-path.js';
+
+export const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024; // 25MB
+
+export interface AttachmentFileResult {
+  content?: Buffer;
+  error?: { code: string; message: string; recoverable: boolean };
+}
+
+/** Map a Node filesystem error to a structured AttachmentFileResult error. */
+function mapFsError(err: unknown, filePath: string): AttachmentFileResult {
+  const code = (err as { code?: string } | null)?.code;
+  if (code === 'ENOENT') {
+    return { error: { code: 'FILE_NOT_FOUND', message: `attachment path not found: ${filePath}`, recoverable: false } };
+  }
+  if (code === 'EACCES' || code === 'EPERM') {
+    return { error: { code: 'PERMISSION_DENIED', message: `attachment path is not readable: ${filePath}`, recoverable: false } };
+  }
+  if (code === 'EISDIR') {
+    return { error: { code: 'INVALID_FILE_TYPE', message: `attachment path is not a regular file: ${filePath}`, recoverable: false } };
+  }
+  return {
+    error: {
+      code: 'ATTACHMENT_READ_FAILED',
+      message: `could not read attachment ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      recoverable: false,
+    },
+  };
+}
+
+/**
+ * Resolve and read an attachment file from disk, sandboxed to `safeDir`.
+ * Rejects path traversal, symlink escape, missing files, non-files, and
+ * files larger than MAX_ATTACHMENT_SIZE. Size is checked via fstat on an
+ * open file descriptor and the bytes are read from that same descriptor, so
+ * the check and read cannot race against a file swap. Never throws — all
+ * filesystem errors are mapped to a structured error result.
+ */
+export async function resolveAttachmentFile(
+  filePath: string,
+  safeDir?: string,
+): Promise<AttachmentFileResult> {
+  const pathCheck = await assertPathInSafeDir(filePath, safeDir, 'attachment path');
+  if (pathCheck.error) {
+    return { error: pathCheck.error };
+  }
+  const resolved = pathCheck.resolved!;
+
+  let filehandle;
+  try {
+    filehandle = await open(resolved, 'r');
+    const fileStat = await filehandle.stat();
+
+    if (!fileStat.isFile()) {
+      return {
+        error: {
+          code: 'INVALID_FILE_TYPE',
+          message: `attachment path is not a regular file: ${filePath}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    // Reject oversize before reading the whole file into memory.
+    if (fileStat.size > MAX_ATTACHMENT_SIZE) {
+      return {
+        error: {
+          code: 'ATTACHMENT_TOO_LARGE',
+          message: `Attachment exceeds maximum size of 25MB: ${filePath}`,
+          recoverable: false,
+        },
+      };
+    }
+
+    const content = await filehandle.readFile();
+    return { content };
+  } catch (err) {
+    return mapFsError(err, filePath);
+  } finally {
+    await filehandle?.close();
+  }
+}

--- a/packages/email-core/src/content/body-loader.ts
+++ b/packages/email-core/src/content/body-loader.ts
@@ -1,7 +1,8 @@
 // Shared body-file resolution — safe file loading with frontmatter support
-import { readFile, realpath, lstat } from 'node:fs/promises';
-import { resolve, relative, isAbsolute, extname } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
 import { parseFrontmatter, type FrontmatterFields } from './frontmatter.js';
+import { assertPathInSafeDir } from './safe-path.js';
 
 export const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 export const TEXT_EXTENSIONS = new Set(['.md', '.html', '.htm', '.txt', '.text']);
@@ -16,56 +17,11 @@ export async function resolveBodyFile(
   bodyFile: string,
   safeDir?: string,
 ): Promise<BodyFileResult> {
-  const baseDir = safeDir ?? process.cwd();
-  const resolved = resolve(baseDir, bodyFile);
-
-  // Check path traversal
-  if (bodyFile.includes('..') || (isAbsolute(bodyFile) && !resolved.startsWith(baseDir))) {
-    return {
-      error: {
-        code: 'PATH_TRAVERSAL',
-        message: 'body_file must be within the working directory',
-        recoverable: false,
-      },
-    };
+  const pathCheck = await assertPathInSafeDir(bodyFile, safeDir, 'body_file');
+  if (pathCheck.error) {
+    return { error: pathCheck.error };
   }
-
-  // Verify it's within the safe directory
-  const rel = relative(baseDir, resolved);
-  if (rel.startsWith('..')) {
-    return {
-      error: {
-        code: 'PATH_TRAVERSAL',
-        message: 'body_file must be within the working directory',
-        recoverable: false,
-      },
-    };
-  }
-
-  // Check if file exists and is not a symlink escape
-  try {
-    const stat = await lstat(resolved);
-    if (stat.isSymbolicLink()) {
-      const realPath = await realpath(resolved);
-      if (!realPath.startsWith(baseDir)) {
-        return {
-          error: {
-            code: 'SYMLINK_ESCAPE',
-            message: 'body_file symlink targets outside working directory',
-            recoverable: false,
-          },
-        };
-      }
-    }
-  } catch {
-    return {
-      error: {
-        code: 'FILE_NOT_FOUND',
-        message: `body_file not found: ${bodyFile}`,
-        recoverable: false,
-      },
-    };
-  }
+  const resolved = pathCheck.resolved!;
 
   // Check file extension
   const ext = extname(resolved).toLowerCase();

--- a/packages/email-core/src/content/safe-path.ts
+++ b/packages/email-core/src/content/safe-path.ts
@@ -1,0 +1,92 @@
+// Shared sandbox policy for file reads (body_file, attachment paths).
+// Resolves a caller-supplied path against a safe base directory and rejects
+// path traversal and symlink escapes. Used by body-loader and
+// attachment-loader so both file-read surfaces share one policy.
+import { realpath } from 'node:fs/promises';
+import { resolve, relative, isAbsolute } from 'node:path';
+
+export interface SafePathError {
+  code: string;
+  message: string;
+  recoverable: boolean;
+}
+
+export interface SafePathResult {
+  resolved?: string;
+  error?: SafePathError;
+}
+
+/** True when `target` is `base` itself or a descendant of it. */
+function isWithin(base: string, target: string): boolean {
+  if (target === base) return true;
+  const rel = relative(base, target);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+/**
+ * Resolve `filePath` within `safeDir` and verify it does not escape that
+ * directory via `..` segments, an absolute path, or a symlink (leaf OR an
+ * ancestor directory). Both the base directory and the fully resolved target
+ * are canonicalized with `realpath` before the containment check, so a
+ * symlink anywhere in the chain that points outside the sandbox is caught —
+ * and the comparison is a true path-segment containment test, not a string
+ * prefix (so a sibling like `<safeDir>-evil` cannot pass).
+ *
+ * `fieldName` is interpolated into error messages (e.g. "body_file",
+ * "attachment path") so callers get a field-specific message.
+ */
+export async function assertPathInSafeDir(
+  filePath: string,
+  safeDir: string | undefined,
+  fieldName: string,
+): Promise<SafePathResult> {
+  const baseDir = resolve(safeDir ?? process.cwd());
+  const resolved = resolve(baseDir, filePath);
+
+  // Cheap literal pre-check before touching the filesystem.
+  if (filePath.includes('..') || !isWithin(baseDir, resolved)) {
+    return {
+      error: {
+        code: 'PATH_TRAVERSAL',
+        message: `${fieldName} must be within the working directory`,
+        recoverable: false,
+      },
+    };
+  }
+
+  // Canonicalize the target — realpath resolves every symlink in the path,
+  // so a leaf or intermediate-directory symlink escape surfaces here.
+  let realResolved: string;
+  try {
+    realResolved = await realpath(resolved);
+  } catch {
+    return {
+      error: {
+        code: 'FILE_NOT_FOUND',
+        message: `${fieldName} not found: ${filePath}`,
+        recoverable: false,
+      },
+    };
+  }
+
+  // Canonicalize the base too — the sandbox root itself may live under a
+  // symlink (e.g. macOS /var → /private/var), so both sides must be real.
+  let realBase: string;
+  try {
+    realBase = await realpath(baseDir);
+  } catch {
+    realBase = baseDir;
+  }
+
+  if (!isWithin(realBase, realResolved)) {
+    return {
+      error: {
+        code: 'SYMLINK_ESCAPE',
+        message: `${fieldName} symlink targets outside working directory`,
+        recoverable: false,
+      },
+    };
+  }
+
+  return { resolved: realResolved };
+}

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -7,8 +7,10 @@ export type {
   EmailThread,
   EmailAttachment,
   ComposeMessage,
+  OutboundAttachment,
   SendResult,
   DraftResult,
+  EmailError,
   ListOptions,
   ReplyOptions,
 } from './types.js';

--- a/packages/email-core/src/providers/provider.ts
+++ b/packages/email-core/src/providers/provider.ts
@@ -60,7 +60,12 @@ export type EmailProvider = EmailReader & EmailSender & Partial<EmailSubscriber>
 export interface ProviderInfo {
   name: string;
   displayName: string;
-  capabilities: ('read' | 'send' | 'subscribe' | 'categorize' | 'attachments')[];
+  // 'attachments' covers inbound (list/download); 'outbound-attachments'
+  // covers attaching files to sent mail / drafts. Both Graph and Gmail
+  // support both. Note: no provider currently exports a ProviderInfo value —
+  // this is a forward-compat type surface; wiring a real metadata surface
+  // that declares these is a follow-up.
+  capabilities: ('read' | 'send' | 'subscribe' | 'categorize' | 'attachments' | 'outbound-attachments')[];
 }
 
 // Error normalization

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -108,6 +108,13 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
     // Fall back to drafts — allows send_draft to look up draft recipients
     const draft = this.drafts.get(id);
     if (draft) {
+      const attachments = draft.attachments?.map((a, i) => ({
+        id: `${id}-att-${i}`,
+        filename: a.filename,
+        mimeType: a.mimeType,
+        size: a.content.length,
+        isInline: false,
+      }));
       return {
         id,
         subject: draft.subject,
@@ -116,8 +123,9 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
         cc: draft.cc,
         receivedAt: new Date().toISOString(),
         isRead: true,
-        hasAttachments: false,
+        hasAttachments: (attachments?.length ?? 0) > 0,
         body: draft.body,
+        attachments,
       };
     }
 
@@ -263,6 +271,7 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
       subject: `Re: ${original.subject}`,
       body,
       bodyHtml: opts?.bodyHtml,
+      attachments: opts?.attachments,
     });
     return { success: true, draftId };
   }
@@ -280,6 +289,9 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
       ...(msg.subject !== undefined && { subject: msg.subject }),
       ...(msg.body !== undefined && { body: msg.body }),
       ...(msg.bodyHtml !== undefined && { bodyHtml: msg.bodyHtml }),
+      // Omitted attachments → preserve via the `...existing` spread;
+      // provided (even []) → replace.
+      ...(msg.attachments !== undefined && { attachments: msg.attachments }),
     });
     return { success: true, draftId };
   }

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -661,6 +661,11 @@ export async function buildLazyActions(
   getSendAllowlist: () => { entries: string[] } | undefined,
   getDeletePolicy: () => DeletePolicy | undefined = () => undefined,
 ): Promise<EmailActionDef[]> {
+  // Sandbox boundary for body_file / attachment path reads. Resolved once so
+  // the boundary is intentional and operator-overridable rather than an
+  // implicit process.cwd() fallback inside the file loaders.
+  const safeDir = process.env.EMAIL_MCP_SAFE_DIR || process.cwd();
+
   const {
     sendEmailAction,
     replyToEmailAction,
@@ -709,6 +714,7 @@ export async function buildLazyActions(
           mailboxName: resolved.mailbox.name,
           allMailboxes: resolved.allMailboxes,
           sendAllowlist: getSendAllowlist(),
+          safeDir,
           deleteEnabled: deletePolicy?.enabled === true,
           hardDeleteAllowed: deletePolicy?.hardDeleteAllowed === true,
         };

--- a/packages/provider-gmail/README.md
+++ b/packages/provider-gmail/README.md
@@ -134,7 +134,14 @@ To search for an older driver's license email, start with Gmail's native query s
 
 Then widen or narrow with Gmail filters such as `older_than:5y`, `from:dmv`, `filename:pdf`, or `in:anywhere`.
 
+## Outbound attachments
+
+`create_draft`, `update_draft`, `send_email`, and `reply_to_email` accept an
+`attachments` array. Each entry is either a sandboxed file `path` or inline
+`base64`, with optional `filename` / `mimeType` overrides. Gmail builds a
+`multipart/mixed` MIME message; the 25MB per-file cap is enforced before send.
+
 ## Current caveats
 
 - Gmail watcher / PubSub wiring is not implemented yet.
-- Gmail attachments on outgoing mail are not implemented yet.
+- Inline (CID) image attachments on outgoing mail are not implemented yet.

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -430,9 +430,10 @@ describe('provider-gmail/buildRawMessage', () => {
 
     const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
     expect(raw).toContain('Content-Type: text/plain; charset=utf-8');
+    expect(raw).toContain('Content-Transfer-Encoding: quoted-printable');
     expect(raw).not.toContain('multipart/alternative');
-    // Body newlines are preserved verbatim — outer CRLF is from the mime header join.
-    expect(raw).toContain('line one\nline two');
+    // Body line breaks are normalized to canonical CRLF inside the part.
+    expect(raw).toContain('line one\r\nline two');
   });
 
   it('Scenario: Cc and Bcc headers emitted when recipients supplied', async () => {
@@ -859,5 +860,159 @@ describe('provider-gmail/Update Draft', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('UPDATE_DRAFT_FAILED');
     expect(result.error?.message).toMatch(/draft not found/);
+  });
+
+  it('Scenario: updateDraft preserves attachments using the backing message id', async () => {
+    const attachmentBytes = Buffer.from('PDF-ATTACHMENT-BYTES');
+    // Backing message id deliberately differs from the draft id passed in.
+    const draftWithAttachment = {
+      id: 'msg-backing-123',
+      threadId: 'thread-draft',
+      labelIds: ['DRAFT'],
+      payload: {
+        headers: [
+          { name: 'From', value: 'me@corp.com' },
+          { name: 'To', value: 'bob@corp.com' },
+          { name: 'Subject', value: 'Original subject' },
+        ],
+        mimeType: 'multipart/mixed',
+        parts: [
+          { mimeType: 'text/plain', body: { data: Buffer.from('Original body').toString('base64url') } },
+          { mimeType: 'application/pdf', filename: 'r.pdf', body: { attachmentId: 'att-1', size: attachmentBytes.length } },
+        ],
+      },
+      internalDate: String(Date.now()),
+    };
+    const getAttachment = vi.fn().mockResolvedValue({
+      data: attachmentBytes.toString('base64url'),
+      size: attachmentBytes.length,
+    });
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(draftWithAttachment),
+      getAttachment,
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const result = await provider.updateDraft('draft-existing', { subject: 'New subject' });
+
+    expect(result.success).toBe(true);
+    // Attachment bytes fetched with the backing message id, not the draft id.
+    expect(getAttachment).toHaveBeenCalledWith('msg-backing-123', 'att-1');
+    const raw = lastRaw(client.updateDraft as ReturnType<typeof vi.fn>, 1);
+    expect(raw).toContain('filename="r.pdf"');
+    expect(raw).toContain(attachmentBytes.toString('base64'));
+  });
+
+  it('Scenario: updateDraft fails closed when preserving a draft with inline attachments', async () => {
+    const draftWithInline = {
+      id: 'msg-backing-456',
+      threadId: 'thread-draft',
+      labelIds: ['DRAFT'],
+      payload: {
+        headers: [
+          { name: 'From', value: 'me@corp.com' },
+          { name: 'To', value: 'bob@corp.com' },
+          { name: 'Subject', value: 'Has inline image' },
+        ],
+        mimeType: 'multipart/related',
+        parts: [
+          { mimeType: 'text/html', body: { data: Buffer.from('<img src="cid:x">').toString('base64url') } },
+          {
+            mimeType: 'image/png',
+            filename: 'logo.png',
+            headers: [{ name: 'Content-ID', value: '<x>' }],
+            body: { attachmentId: 'inline-1', size: 4 },
+          },
+        ],
+      },
+      internalDate: String(Date.now()),
+    };
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(draftWithInline),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const result = await provider.updateDraft('draft-existing', { subject: 'New subject' });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INLINE_ATTACHMENTS_UNSUPPORTED');
+  });
+});
+
+describe('provider-gmail/buildRawMessage attachments', () => {
+  const PDF = Buffer.from('%PDF-1.4\nbinary\x00bytes', 'binary');
+
+  it('Scenario: attachments produce multipart/mixed with a base64 file part', async () => {
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'With file',
+      body: 'see attached',
+      attachments: [{ filename: 'report.pdf', content: PDF, mimeType: 'application/pdf' }],
+    });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toMatch(/Content-Type: multipart\/mixed; boundary="=_Part_[a-f0-9]{24}"/);
+    expect(raw).toContain('Content-Type: application/pdf; name="report.pdf"');
+    expect(raw).toContain('Content-Transfer-Encoding: base64');
+    expect(raw).toContain('Content-Disposition: attachment; filename="report.pdf"');
+    // The file bytes appear base64-encoded, not raw.
+    expect(raw).toContain(PDF.toString('base64'));
+  });
+
+  it('Scenario: text body uses quoted-printable, not 7bit', async () => {
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'Unicode',
+      body: 'Café — déjà vu',
+    });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('Content-Transfer-Encoding: quoted-printable');
+    expect(raw).not.toContain('Content-Transfer-Encoding: 7bit');
+    // Non-ASCII bytes are =XX-encoded (é = UTF-8 0xC3 0xA9).
+    expect(raw).toContain('=C3=A9');
+  });
+
+  it('Scenario: attachments + bodyHtml nest multipart/alternative inside multipart/mixed', async () => {
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'Rich',
+      body: 'plain',
+      bodyHtml: '<p>rich</p>',
+      attachments: [{ filename: 'a.pdf', content: PDF, mimeType: 'application/pdf' }],
+    });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('multipart/mixed');
+    expect(raw).toContain('multipart/alternative');
+    const mixedIdx = raw.indexOf('multipart/mixed');
+    const altIdx = raw.indexOf('multipart/alternative');
+    expect(mixedIdx).toBeLessThan(altIdx);
+  });
+
+  it('Scenario: long base64 payload is wrapped at 76 chars', async () => {
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'Big-ish',
+      body: 'body',
+      attachments: [{ filename: 'big.bin', content: Buffer.alloc(1000, 0x41), mimeType: 'application/octet-stream' }],
+    });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    for (const line of raw.split('\r\n')) {
+      expect(line.length).toBeLessThanOrEqual(76);
+    }
   });
 });

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -11,6 +11,7 @@ import type {
   ListOptions,
   ReplyOptions,
   DownloadedAttachment,
+  OutboundAttachment,
 } from '@usejunior/email-core';
 import { AttachmentNotFoundError } from '@usejunior/email-core';
 
@@ -213,6 +214,7 @@ export class GmailEmailProvider {
         subject,
         body,
         bodyHtml: opts?.bodyHtml,
+        attachments: opts?.attachments,
       },
       {
         inReplyTo: original.messageId,
@@ -252,6 +254,7 @@ export class GmailEmailProvider {
           subject,
           body,
           bodyHtml: opts?.bodyHtml,
+          attachments: opts?.attachments,
         },
         {
           inReplyTo: original.messageId,
@@ -291,6 +294,37 @@ export class GmailEmailProvider {
       // lose thread association.
       const current = await this.getMessage(draftId);
 
+      // Attachments: drafts.update is a full replacement, so an omitted
+      // `attachments` field must be rehydrated from the existing draft or it
+      // would be silently dropped. When the caller supplies `attachments`
+      // (possibly an empty array), that set replaces the existing one.
+      let attachments: OutboundAttachment[] | undefined;
+      if (msg.attachments !== undefined) {
+        attachments = msg.attachments;
+      } else if (current.attachments && current.attachments.length > 0) {
+        // Inline (CID) parts cannot be safely round-tripped: this builder
+        // re-emits attachments with `Content-Disposition: attachment`, which
+        // would orphan the `cid:` references in the preserved HTML body.
+        // Fail closed and tell the caller to pass `attachments` explicitly.
+        if (current.attachments.some(att => att.isInline)) {
+          return {
+            success: false,
+            error: {
+              code: 'INLINE_ATTACHMENTS_UNSUPPORTED',
+              message: 'This draft has inline (CID) attachments that cannot be preserved automatically. Pass an explicit `attachments` array to update it.',
+              recoverable: false,
+            },
+          };
+        }
+        attachments = [];
+        for (const att of current.attachments) {
+          // Gmail attachment bytes are keyed by the backing message id, not
+          // the draft id — use current.id (the resolved message).
+          const dl = await this.downloadAttachment(current.id, att.id);
+          attachments.push({ filename: dl.filename, content: dl.content, mimeType: dl.mimeType });
+        }
+      }
+
       const merged: ComposeMessage = {
         to: msg.to ?? current.to,
         cc: msg.cc ?? current.cc,
@@ -298,6 +332,7 @@ export class GmailEmailProvider {
         subject: msg.subject ?? current.subject,
         body: msg.body ?? current.body ?? '',
         bodyHtml: msg.bodyHtml ?? current.bodyHtml,
+        attachments,
       };
 
       const raw = buildRawMessage(merged, {
@@ -565,19 +600,121 @@ interface BuildRawOptions {
   references?: string[];
 }
 
+const CRLF = '\r\n';
+
+/**
+ * Encode text as quoted-printable (RFC 2045) with CRLF line endings and
+ * 76-char soft line wrapping. Replaces the previous `7bit` labelling, which
+ * was incorrect for UTF-8 bodies, and normalizes embedded `\n` to canonical
+ * CRLF inside the part.
+ */
+function encodeQuotedPrintable(text: string): string {
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const outLines: string[] = [];
+
+  for (const line of normalized.split('\n')) {
+    const bytes = Buffer.from(line, 'utf-8');
+    const tokens: string[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+      const b = bytes[i]!;
+      const isLast = i === bytes.length - 1;
+      if (b === 0x20 || b === 0x09) {
+        // Space/tab: literal, except a trailing one must be encoded so it
+        // survives transport whitespace stripping.
+        tokens.push(isLast ? `=${b.toString(16).toUpperCase().padStart(2, '0')}` : String.fromCharCode(b));
+      } else if (b >= 0x21 && b <= 0x7e && b !== 0x3d) {
+        tokens.push(String.fromCharCode(b));
+      } else {
+        tokens.push(`=${b.toString(16).toUpperCase().padStart(2, '0')}`);
+      }
+    }
+    // Soft-wrap so no line (including the trailing '=') exceeds 76 chars.
+    // Tokens are atomic (1 char or a 3-char '=XX') and never split.
+    let current = '';
+    for (const tok of tokens) {
+      if (current.length + tok.length > 75) {
+        outLines.push(current + '=');
+        current = '';
+      }
+      current += tok;
+    }
+    outLines.push(current);
+  }
+
+  return outLines.join(CRLF);
+}
+
+/** Wrap a base64 string at 76 chars per line with CRLF endings (RFC 2045). */
+function wrapBase64(b64: string): string {
+  const out: string[] = [];
+  for (let i = 0; i < b64.length; i += 76) {
+    out.push(b64.slice(i, i + 76));
+  }
+  return out.join(CRLF);
+}
+
+/** A fully serialized MIME part: headers, blank line, encoded body. */
+type MimePart = string;
+
+function serializeTextPart(content: string, contentType: 'text/plain' | 'text/html'): MimePart {
+  return [
+    `Content-Type: ${contentType}; charset=utf-8`,
+    'Content-Transfer-Encoding: quoted-printable',
+    '',
+    encodeQuotedPrintable(content),
+  ].join(CRLF);
+}
+
+function serializeAttachmentPart(att: OutboundAttachment): MimePart {
+  const name = att.filename.replace(/[\r\n"\\]+/g, '_') || 'attachment';
+  const mimeType = att.mimeType.replace(/[\r\n";]+/g, '') || 'application/octet-stream';
+  return [
+    `Content-Type: ${mimeType}; name="${name}"`,
+    'Content-Transfer-Encoding: base64',
+    `Content-Disposition: attachment; filename="${name}"`,
+    '',
+    wrapBase64(att.content.toString('base64')),
+  ].join(CRLF);
+}
+
+/** Join MIME parts under a fresh boundary, returning the Content-Type value and body. */
+function serializeMultipart(
+  subtype: 'alternative' | 'mixed',
+  parts: MimePart[],
+): { contentType: string; body: string } {
+  const boundary = generateBoundary(parts.join(CRLF));
+  const sections: string[] = [];
+  for (const part of parts) {
+    sections.push(`--${boundary}`);
+    sections.push(part);
+  }
+  sections.push(`--${boundary}--`);
+  return {
+    contentType: `multipart/${subtype}; boundary="${boundary}"`,
+    body: sections.join(CRLF),
+  };
+}
+
+/** A nested multipart rendered as a single MIME part (carries its own Content-Type header). */
+function multipartAsPart(subtype: 'alternative' | 'mixed', parts: MimePart[]): MimePart {
+  const { contentType, body } = serializeMultipart(subtype, parts);
+  return [`Content-Type: ${contentType}`, '', body].join(CRLF);
+}
+
 /**
  * Assemble a raw RFC 2822 message with CRLF line endings, base64url-encoded
  * for Gmail's `drafts.create` / `messages.send` APIs.
  *
- * - When `msg.bodyHtml` is set, emits `multipart/alternative` with a
- *   plain-text part first (for text-only clients) and the HTML part second.
- * - When only `msg.body` is set, emits a single `text/plain` part.
- * - Populates `Cc`, `Bcc`, `In-Reply-To`, `References` headers when present.
- * - Sanitizes all header values to prevent CR/LF injection.
- * - `attachments` are intentionally not emitted — documented follow-up.
+ * - With attachments: `multipart/mixed` whose first part is the body (a
+ *   nested `multipart/alternative` when bodyHtml is set, else a single
+ *   text part), followed by one `fileAttachment`-style part per attachment.
+ * - Without attachments: `multipart/alternative` when bodyHtml is set, else
+ *   a single quoted-printable `text/plain` message.
+ * - Text parts use quoted-printable so UTF-8 survives transport.
+ * - Populates `Cc`, `Bcc`, `In-Reply-To`, `References` when present and
+ *   sanitizes all header values to prevent CR/LF injection.
  */
 function buildRawMessage(msg: ComposeMessage, opts: BuildRawOptions = {}): string {
-  const CRLF = '\r\n';
   const headers: string[] = [];
   headers.push('MIME-Version: 1.0');
   headers.push(`To: ${formatAddressList(msg.to)}`);
@@ -590,42 +727,35 @@ function buildRawMessage(msg: ComposeMessage, opts: BuildRawOptions = {}): strin
   }
 
   const hasHtml = msg.bodyHtml !== undefined;
+  const attachments = msg.attachments ?? [];
 
-  if (hasHtml) {
-    // Boundary must not appear in either part; check against both the plain
-    // body and the html body.
-    const boundary = generateBoundary(msg.body + (msg.bodyHtml ?? ''));
-    headers.push(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+  let body: string;
 
-    const sections: string[] = [];
-    sections.push(headers.join(CRLF));
-    sections.push(''); // blank line terminates headers
-
-    // Plain-text part
-    sections.push(`--${boundary}`);
-    sections.push('Content-Type: text/plain; charset=utf-8');
-    sections.push('Content-Transfer-Encoding: 7bit');
-    sections.push('');
-    sections.push(msg.body);
-
-    // HTML part
-    sections.push(`--${boundary}`);
-    sections.push('Content-Type: text/html; charset=utf-8');
-    sections.push('Content-Transfer-Encoding: 7bit');
-    sections.push('');
-    sections.push(msg.bodyHtml!);
-
-    // Close boundary
-    sections.push(`--${boundary}--`);
-    sections.push('');
-
-    return Buffer.from(sections.join(CRLF)).toString('base64url');
+  if (attachments.length > 0) {
+    const bodyPart: MimePart = hasHtml
+      ? multipartAsPart('alternative', [
+        serializeTextPart(msg.body, 'text/plain'),
+        serializeTextPart(msg.bodyHtml!, 'text/html'),
+      ])
+      : serializeTextPart(msg.body, 'text/plain');
+    const mixed = serializeMultipart('mixed', [bodyPart, ...attachments.map(serializeAttachmentPart)]);
+    headers.push(`Content-Type: ${mixed.contentType}`);
+    body = mixed.body;
+  } else if (hasHtml) {
+    const alt = serializeMultipart('alternative', [
+      serializeTextPart(msg.body, 'text/plain'),
+      serializeTextPart(msg.bodyHtml!, 'text/html'),
+    ]);
+    headers.push(`Content-Type: ${alt.contentType}`);
+    body = alt.body;
+  } else {
+    headers.push('Content-Type: text/plain; charset=utf-8');
+    headers.push('Content-Transfer-Encoding: quoted-printable');
+    body = encodeQuotedPrintable(msg.body);
   }
 
-  // Single-part text/plain fallback
-  headers.push('Content-Type: text/plain; charset=utf-8');
-  const lines = [...headers, '', msg.body];
-  return Buffer.from(lines.join(CRLF)).toString('base64url');
+  const message = [...headers, '', body].join(CRLF);
+  return Buffer.from(message, 'utf-8').toString('base64url');
 }
 
 /**

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1700,3 +1700,96 @@ describe('provider-microsoft/Watcher Timestamp Boundary', () => {
     expect(decoded).not.toContain('receivedDateTime gt ');
   });
 });
+
+describe('provider-microsoft/Outbound Attachments', () => {
+  const PDF = Buffer.from('%PDF-1.4\nbytes', 'utf-8');
+  type MockFn = ReturnType<typeof vi.fn>;
+
+  it('Scenario: sendMessage includes inline fileAttachment', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'With file',
+      body: 'body',
+      attachments: [{ filename: 'r.pdf', content: PDF, mimeType: 'application/pdf' }],
+    });
+
+    const call = (client.post as MockFn).mock.calls.find(c => String(c[0]).endsWith('/sendMail'))!;
+    const message = (call[1] as { message: { attachments?: Array<Record<string, unknown>> } }).message;
+    expect(message.attachments).toHaveLength(1);
+    expect(message.attachments![0]!['@odata.type']).toBe('#microsoft.graph.fileAttachment');
+    expect(message.attachments![0]!.name).toBe('r.pdf');
+    expect(message.attachments![0]!.contentBytes).toBe(PDF.toString('base64'));
+  });
+
+  it('Scenario: createDraft includes inline fileAttachment', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createDraft({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'Draft',
+      body: 'body',
+      attachments: [{ filename: 'r.pdf', content: PDF, mimeType: 'application/pdf' }],
+    });
+
+    const call = (client.post as MockFn).mock.calls.find(c => String(c[0]).endsWith('/messages'))!;
+    const graphMsg = call[1] as { attachments?: Array<Record<string, unknown>> };
+    expect(graphMsg.attachments).toHaveLength(1);
+    expect(graphMsg.attachments![0]!['@odata.type']).toBe('#microsoft.graph.fileAttachment');
+  });
+
+  it('Scenario: reply draft attachments use the two-step POST /attachments flow', async () => {
+    const client = createMockClient({
+      post: vi.fn()
+        .mockResolvedValueOnce(quotedReplyResponse()) // createReplyAll
+        .mockResolvedValue({ id: 'att-1' }),          // attachment POST
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.createReplyDraft('msg-1', 'reply', {
+      attachments: [{ filename: 'r.pdf', content: PDF, mimeType: 'application/pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    const attCalls = (client.post as MockFn).mock.calls.filter(c => String(c[0]).endsWith('/attachments'));
+    expect(attCalls).toHaveLength(1);
+    const body = attCalls[0]![1] as Record<string, unknown>;
+    expect(body['@odata.type']).toBe('#microsoft.graph.fileAttachment');
+    expect(body.contentBytes).toBe(PDF.toString('base64'));
+  });
+
+  it('Scenario: an attachment over 3MB is rejected before any request', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.sendMessage({
+      to: [{ email: 'bob@corp.com' }],
+      subject: 'Too big',
+      body: 'body',
+      attachments: [{ filename: 'big.bin', content: Buffer.alloc(3 * 1024 * 1024 + 1), mimeType: 'application/octet-stream' }],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ATTACHMENT_TOO_LARGE_FOR_PROVIDER');
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: update_draft replaces attachments by deleting then re-posting', async () => {
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValue({ value: [{ id: 'old-att' }] }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.updateDraft('draft-1', {
+      attachments: [{ filename: 'new.pdf', content: PDF, mimeType: 'application/pdf' }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(client.delete).toHaveBeenCalledWith(expect.stringContaining('/attachments/old-att'));
+    const attCalls = (client.post as MockFn).mock.calls.filter(c => String(c[0]).endsWith('/attachments'));
+    expect(attCalls).toHaveLength(1);
+  });
+});

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -4,8 +4,10 @@ import type {
   EmailMessage,
   EmailThread,
   ComposeMessage,
+  OutboundAttachment,
   SendResult,
   DraftResult,
+  EmailError,
   ListOptions,
   ReplyOptions,
   EmailReader,
@@ -18,6 +20,74 @@ import { AttachmentNotSupportedError, AttachmentNotFoundError } from '@usejunior
 
 const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 const SUBJECT_MAX_LENGTH = 255;
+
+// Microsoft Graph's hard cap is on the *encoded write request* size, not the
+// raw file: a fileAttachment carries the bytes as base64 (≈4/3 expansion)
+// inside JSON. Graph rejects requests past ~4MB, so the preflight measures
+// base64-encoded size and caps it at 3MB — conservative headroom for the
+// JSON envelope and (for inline sends) the message body. Files past this
+// need the upload-session flow, which is intentionally out of scope here.
+const GRAPH_ENCODED_LIMIT = 3 * 1024 * 1024;
+
+/** base64-encoded byte length of a buffer of `rawBytes` bytes. */
+function base64Size(rawBytes: number): number {
+  return 4 * Math.ceil(rawBytes / 3);
+}
+
+/**
+ * Reject attachments Microsoft Graph's inline / simple-upload paths cannot
+ * carry, so callers fail fast with a clear message instead of a late 413.
+ * `checkTotal` additionally caps the combined encoded size (for inline
+ * /sendMail and POST /messages, where every attachment rides in one request).
+ */
+function checkGraphAttachmentLimits(
+  attachments: OutboundAttachment[] | undefined,
+  opts: { checkTotal: boolean },
+): EmailError | null {
+  if (!attachments || attachments.length === 0) return null;
+  let totalEncoded = 0;
+  for (const att of attachments) {
+    const encoded = base64Size(att.content.length);
+    totalEncoded += encoded;
+    if (encoded > GRAPH_ENCODED_LIMIT) {
+      return {
+        code: 'ATTACHMENT_TOO_LARGE_FOR_PROVIDER',
+        message: `Attachment "${att.filename}" is ${att.content.length} bytes (${encoded} base64-encoded); Microsoft Graph supports roughly 3MB encoded per file without an upload session. Larger files require the Graph upload-session flow (out of scope — tracked as a follow-up).`,
+        recoverable: false,
+      };
+    }
+  }
+  if (opts.checkTotal && totalEncoded > GRAPH_ENCODED_LIMIT) {
+    return {
+      code: 'ATTACHMENT_TOO_LARGE_FOR_PROVIDER',
+      message: `Combined attachments are ${totalEncoded} bytes base64-encoded; Microsoft Graph's inline send payload supports roughly 3MB. Use fewer or smaller files.`,
+      recoverable: false,
+    };
+  }
+  return null;
+}
+
+/** Build a Graph `fileAttachment` resource from an OutboundAttachment. */
+function toGraphFileAttachment(att: OutboundAttachment): Record<string, unknown> {
+  return {
+    '@odata.type': '#microsoft.graph.fileAttachment',
+    name: att.filename,
+    contentType: att.mimeType,
+    contentBytes: att.content.toString('base64'),
+  };
+}
+
+/**
+ * Carries a structured attachment error out of prepareReplyDraft, optionally
+ * with the id of a draft that was created but could not be completed — so the
+ * caller can surface it for inspection/retry instead of orphaning it silently.
+ */
+class GraphAttachmentError extends Error {
+  constructor(public readonly emailError: EmailError, public readonly draftId?: string) {
+    super(emailError.message);
+    this.name = 'GraphAttachmentError';
+  }
+}
 
 // Sent message tracking via custom extended property
 const TRACKING_PROPERTY = 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailTrackingId';
@@ -383,8 +453,14 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async sendMessage(msg: ComposeMessage): Promise<SendResult> {
+    // Inline /sendMail carries every attachment in one request — cap total size.
+    const sizeError = checkGraphAttachmentLimits(msg.attachments, { checkTotal: true });
+    if (sizeError) {
+      return { success: false, error: sizeError };
+    }
+
     const trackingId = msg.trackingId ?? `ae-${Date.now()}`;
-    const graphMsg = {
+    const graphMsg: Record<string, unknown> = {
       subject: msg.subject.slice(0, SUBJECT_MAX_LENGTH),
       body: buildGraphBody(msg.bodyHtml, msg.body),
       toRecipients: msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } })),
@@ -393,6 +469,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
         { id: TRACKING_PROPERTY, value: trackingId },
       ],
     };
+    if (msg.attachments && msg.attachments.length > 0) {
+      graphMsg.attachments = msg.attachments.map(toGraphFileAttachment);
+    }
 
     await this.client.post(`${this.basePath}/sendMail`, { message: graphMsg });
     // sendMail returns 202 with no body — use tracking ID for sent message lookup
@@ -407,17 +486,35 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(draftId)}/send`, {});
       return { success: true, messageId: draftId };
     } catch (err) {
+      if (err instanceof GraphAttachmentError) {
+        const detail = err.draftId
+          ? ` A reply draft (${err.draftId}) was created but not sent.`
+          : '';
+        return {
+          success: false,
+          error: { ...err.emailError, message: err.emailError.message + detail },
+        };
+      }
       const message = err instanceof Error ? err.message : 'Failed to send reply';
       return { success: false, error: { code: 'REPLY_FAILED', message, recoverable: false } };
     }
   }
 
   async createDraft(msg: ComposeMessage): Promise<DraftResult> {
-    const graphMsg = {
+    // Attachments ride inline in the POST /messages payload — cap total size.
+    const sizeError = checkGraphAttachmentLimits(msg.attachments, { checkTotal: true });
+    if (sizeError) {
+      return { success: false, error: sizeError };
+    }
+
+    const graphMsg: Record<string, unknown> = {
       subject: msg.subject,
       body: buildGraphBody(msg.bodyHtml, msg.body),
       toRecipients: msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } })),
     };
+    if (msg.attachments && msg.attachments.length > 0) {
+      graphMsg.attachments = msg.attachments.map(toGraphFileAttachment);
+    }
 
     const response = await this.client.post(`${this.basePath}/messages`, graphMsg);
     return { success: true, draftId: response.id };
@@ -435,6 +532,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       const draftId = await this.prepareReplyDraft(messageId, body, opts);
       return { success: true, draftId };
     } catch (err) {
+      if (err instanceof GraphAttachmentError) {
+        return { success: false, draftId: err.draftId, error: err.emailError };
+      }
       const message = err instanceof Error ? err.message : 'Failed to create reply draft';
       return { success: false, error: { code: 'DRAFT_FAILED', message, recoverable: false } };
     }
@@ -449,11 +549,32 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
    *
    * Returns the draft id. Throws if the Graph endpoint fails or returns no id.
    */
+  /**
+   * POST each attachment to a draft's `/attachments` collection. Used for the
+   * two-step draft attachment flow (reply drafts, draft updates), since Graph's
+   * createReply/createReplyAll and PATCH paths cannot carry attachments inline.
+   */
+  private async postDraftAttachments(draftId: string, attachments: OutboundAttachment[]): Promise<void> {
+    for (const att of attachments) {
+      await this.client.post(
+        `${this.basePath}/messages/${encodeGraphPathId(draftId)}/attachments`,
+        toGraphFileAttachment(att),
+      );
+    }
+  }
+
   private async prepareReplyDraft(
     messageId: string,
     body: string,
     opts?: ReplyOptions,
   ): Promise<string> {
+    // Size preflight before creating the draft, so an oversize attachment
+    // never leaves an orphan draft behind.
+    const sizeError = checkGraphAttachmentLimits(opts?.attachments, { checkTotal: false });
+    if (sizeError) {
+      throw new GraphAttachmentError(sizeError);
+    }
+
     const endpoint = opts?.replyAll === false ? 'createReply' : 'createReplyAll';
     const draft = await this.client.post(
       `${this.basePath}/messages/${encodeGraphPathId(messageId)}/${endpoint}`,
@@ -491,6 +612,25 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (bccMerged.length > 0) patch.bccRecipients = bccMerged;
 
     await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(draft.id)}`, patch);
+
+    // Two-step attachment upload: the draft now exists, so POST each file to
+    // its /attachments collection. A failure here leaves a created-but-
+    // incomplete draft — surface its id so the caller can inspect or retry.
+    if (opts?.attachments && opts.attachments.length > 0) {
+      try {
+        await this.postDraftAttachments(draft.id, opts.attachments);
+      } catch (err) {
+        throw new GraphAttachmentError(
+          {
+            code: 'ATTACHMENT_UPLOAD_FAILED',
+            message: `Reply draft was created but attaching files failed: ${err instanceof Error ? err.message : String(err)}`,
+            recoverable: false,
+          },
+          draft.id,
+        );
+      }
+    }
+
     return draft.id;
   }
 
@@ -527,7 +667,45 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     if (msg.to) patch.toRecipients = msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
     if (msg.cc) patch.ccRecipients = msg.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
 
+    // Attachments: an omitted field preserves the draft's existing attachments
+    // (Graph attachments are child resources untouched by this PATCH). A
+    // provided array replaces them — delete the existing set, then add the new
+    // one. Size preflight runs first so nothing is deleted if it would fail.
+    if (msg.attachments !== undefined) {
+      const sizeError = checkGraphAttachmentLimits(msg.attachments, { checkTotal: false });
+      if (sizeError) {
+        return { success: false, draftId, error: sizeError };
+      }
+    }
+
     await this.client.patch(`${this.basePath}/messages/${encodeGraphPathId(draftId)}`, patch);
+
+    if (msg.attachments !== undefined) {
+      try {
+        const existing = await this.client.get(
+          `${this.basePath}/messages/${encodeGraphPathId(draftId)}/attachments?$select=id`,
+        );
+        for (const att of ((existing.value ?? []) as Array<{ id?: string }>)) {
+          if (att.id) {
+            await this.client.delete(
+              `${this.basePath}/messages/${encodeGraphPathId(draftId)}/attachments/${encodeGraphPathId(att.id)}`,
+            );
+          }
+        }
+        await this.postDraftAttachments(draftId, msg.attachments);
+      } catch (err) {
+        return {
+          success: false,
+          draftId,
+          error: {
+            code: 'ATTACHMENT_UPDATE_FAILED',
+            message: `Draft ${draftId} field updates were applied, but replacing attachments failed: ${err instanceof Error ? err.message : String(err)}`,
+            recoverable: false,
+          },
+        };
+      }
+    }
+
     return { success: true, draftId };
   }
 


### PR DESCRIPTION
## Summary

Closes #89. Adds an `attachments` field to the four outbound MCP actions —
`create_draft`, `update_draft`, `send_email`, `reply_to_email` — so agents can
send PDFs, DOCXs, and images without bypassing the MCP (and its send
allowlist / rate limit / threading guardrails). Each attachment is a sandboxed
file `path` or inline `base64`, with optional `filename` / `mimeType`.

## What changed

- **email-core**: `AttachmentInputSchema` (path XOR base64, strict-quartet
  base64 validation) + `resolveAttachments` helper. New sandboxed binary
  reader (`attachment-loader`) sharing a hardened path policy (`safe-path`)
  with `body-loader`: realpath-canonicalized containment check (fixes a
  sibling-prefix bypass, catches ancestor-symlink escapes), fd-based read
  (no TOCTOU), structured fs-error mapping.
- **Gmail**: rewrote `buildRawMessage` with a factored MIME serializer —
  quoted-printable text parts (replaces incorrect `7bit` labelling,
  normalizes CRLF) and `multipart/mixed` for attachments. Reply paths now
  thread `opts.attachments`. `updateDraft` rehydrates omitted attachments
  from the backing message id; fails closed on inline-CID drafts.
- **Graph**: inline `fileAttachment` on `sendMail` / `POST /messages`;
  two-step `POST /messages/{id}/attachments` for reply/update drafts;
  base64-encoded size preflight rejects payloads Graph would 413; partial
  failures surface the draft id.
- **update_draft**: omitting `attachments` preserves the existing set;
  providing an array (even empty) replaces it.
- **email-mcp**: wires `ctx.safeDir` from a new `EMAIL_MCP_SAFE_DIR` env var.

## Process

Plan reviewed by Gemini + Codex CLI before implementation; the diff was
reviewed again after — 2 blockers (Gmail draft-id vs message-id; symlink
sandbox bypass), 3 important (Graph encoding overhead, base64 validation,
inline-CID corruption), 1 nit all addressed.

## Test plan

- [x] `npm run build` — clean across all packages
- [x] `npm run lint` (tsc --noEmit) — clean
- [x] `npm run test:run` — 789 tests pass
- [x] New coverage: single/multiple/base64 attachments, MIME inference,
      oversize / missing-file / traversal rejection, malformed + wrong-length
      base64, update_draft preserve vs replace vs empty, reply send + draft
      paths, Gmail multipart/mixed + QP + 76-char wrapping + draft-id/message-id
      preservation + inline fail-closed, Graph inline + two-step + 3MB preflight
- [ ] Manual smoke against real Gmail + Outlook mailboxes (attach a PDF, reply
      with attachment, update-draft preserving attachments)

## Follow-ups (out of scope)

- Graph upload sessions for attachments >3MB
- Inline (CID) image attachments on outbound
- A real provider-metadata surface that declares the `outbound-attachments` capability