### PR TITLE
chore(cli): drop dev-only `serve` instructions from configure output

### DIFF
--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -1194,10 +1194,6 @@ async function finalizeGmailMailbox(
   console.error('');
   console.error(`✅ Connected as: ${emailAddress}`);
   console.error(`   Mailbox saved to ~/.email-agent-mcp/tokens/${safeKey}.json`);
-  console.error('');
-  console.error('To start the MCP server, run:');
-  console.error('   npx tsx packages/email-mcp/src/cli.ts serve   # from source');
-  console.error('   npx email-agent-mcp serve             # after npm publish');
 }
 
 export function inferProviderFromMailbox(
@@ -1335,10 +1331,6 @@ export async function runConfigure(opts: CliOptions): Promise<number> {
         console.error(`✅ Connected as: ${profile.displayName ?? 'Unknown'} (no email found)`);
         console.error(`   Mailbox "${mailboxName}" saved to ~/.email-agent-mcp/tokens/${mailboxName}.json`);
       }
-      console.error('');
-      console.error('To start the MCP server, run:');
-      console.error('   npx tsx packages/email-mcp/src/cli.ts serve   # from source');
-      console.error('   npx email-agent-mcp serve             # after npm publish');
     } else {
       console.error('');
       console.error(`⚠️  Authentication succeeded but profile fetch failed (${resp.status})`);


### PR DESCRIPTION
## Summary

The `configure` success path printed dev-only guidance after saving a mailbox:

```
To start the MCP server, run:
   npx tsx packages/email-mcp/src/cli.ts serve   # from source
   npx email-agent-mcp serve             # after npm publish
```

End users running `configure` do so because their MCP host (Claude Code, OpenClaw, Cursor, …) has already wired the server entry point and will auto-start it. The "# from source" / "# after npm publish" hints leak repo-internal terminology into user-facing output — and neither path matches how a typical user actually runs the server.

Removes the trailer in both the Gmail (`finalizeGmailMailbox`) and Microsoft branches.

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:run` — 789 pass (no test asserted the removed lines)
- [x] Manually verified the `configure` output ends at `Mailbox saved to ~/.email-agent-mcp/tokens/<key>.json`