### PR TITLE
fix(graph): stop rejecting valid downloads when Graph reports framed size

### DIFF
--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -397,21 +397,49 @@ describe('provider-microsoft/Attachment Download', () => {
     await expect(provider.downloadAttachment('msg-1', 'att-bad')).rejects.toThrow(/invalid base64/);
   });
 
-  it('Scenario: downloadAttachment rejects size mismatch between Graph-reported size and decoded length', async () => {
-    const PAYLOAD = Buffer.from('actual bytes');
+  it('Scenario: downloadAttachment accepts inline fileAttachment where Graph-reported size > decoded length', async () => {
+    // For attachments uploaded via the inline fileAttachment path (POST
+    // /sendMail or POST /messages with attachments inline), Graph's `size`
+    // reflects the stored base64+MIME-framed length, not the decoded raw
+    // payload. Round-tripping our own outbound attachments through Graph
+    // download must NOT trip the truncation guard on this benign mismatch.
+    const PAYLOAD = Buffer.from('hello world from an inline fileAttachment round-trip');
+    const client = createSchemaValidatingClient([
+      {
+        id: 'att-inline',
+        '@odata.type': '#microsoft.graph.fileAttachment',
+        name: 'roundtrip.bin',
+        contentType: 'application/octet-stream',
+        size: PAYLOAD.length * 4, // simulate Graph's inflated stored size
+        contentBytes: PAYLOAD.toString('base64'),
+      },
+    ]);
+    const provider = new GraphEmailProvider(client);
+
+    const result = await provider.downloadAttachment('msg-1', 'att-inline');
+
+    expect(result.content.equals(PAYLOAD)).toBe(true);
+  });
+
+  it('Scenario: downloadAttachment rejects contentBytes truncated mid-base64', async () => {
+    // A base64 string whose length is not a multiple of 4 means the payload
+    // was cut on the wire — Node would silently decode the valid prefix.
+    // The base64-round-trip check catches it without depending on
+    // Graph's `size` field.
+    const truncated = Buffer.from('hello world').toString('base64').slice(0, -2); // drop trailing chars
     const client = createMockClient({
       get: vi.fn().mockResolvedValue({
-        id: 'att-mismatch',
+        id: 'att-trunc',
         '@odata.type': '#microsoft.graph.fileAttachment',
-        name: 'mismatch.bin',
+        name: 'trunc.bin',
         contentType: 'application/octet-stream',
-        size: 9999, // lies — actual decoded length is PAYLOAD.length
-        contentBytes: PAYLOAD.toString('base64'),
+        size: 11,
+        contentBytes: truncated,
       }),
     });
     const provider = new GraphEmailProvider(client);
 
-    await expect(provider.downloadAttachment('msg-1', 'att-mismatch')).rejects.toThrow(/does not match/);
+    await expect(provider.downloadAttachment('msg-1', 'att-trunc')).rejects.toThrow(/truncated/);
   });
 });
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -395,13 +395,18 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       );
     }
     const content = Buffer.from(cleanedBytes, 'base64');
-    // Compare decoded length to the size Graph reported on the same response.
-    // A mismatch signals truncation in transit or a malformed contentBytes
-    // payload — return a hard error rather than corrupt bytes.
-    if (typeof response.size === 'number' && content.length !== response.size) {
+    // Validate that contentBytes round-trips cleanly: re-encoding the decoded
+    // buffer should produce the same canonical base64 length as what Graph
+    // sent. This catches truncation in transit and stray invalid chars
+    // (Node's decoder silently drops them) without depending on Graph's
+    // `size` field — which, for attachments uploaded via the inline
+    // fileAttachment path, reflects the stored base64+MIME-framed length
+    // and intentionally does NOT match the decoded raw byte count.
+    const expectedEncodedLen = Math.ceil(content.length / 3) * 4;
+    if (cleanedBytes.length !== expectedEncodedLen) {
       throw new GraphApiError(
         500,
-        `Attachment ${attachmentId} decoded length ${content.length} does not match Graph-reported size ${response.size}`,
+        `Attachment ${attachmentId} contentBytes appears truncated (${cleanedBytes.length} base64 chars, expected ${expectedEncodedLen} for the ${content.length}-byte payload)`,
       );
     }
     return {


### PR DESCRIPTION
## Summary

`downloadAttachment` was throwing a synthetic 500 whenever the decoded `contentBytes` length didn't match `response.size`. For attachments uploaded via the inline `fileAttachment` path (`POST /sendMail` or `POST /messages` with attachments inline — i.e. exactly what #90 enables), Graph reports `size` as the **stored base64 + MIME-framed length**, not the raw decoded byte count. So the defensive check tripped on every attachment we sent through our own outbound flow, breaking download for the round-trip the feature is supposed to enable.

Surfaced by the live smoke for #90: a self-sent PDF (518 bytes raw, 704 bytes stored by Graph) couldn't be re-downloaded:

```
Graph API error 500: Attachment <id> decoded length 518 does not match Graph-reported size 704
```

## Fix

Replace the `size`-equality check with a **base64 round-trip integrity** check: the decoded buffer, re-encoded, must equal the cleaned `contentBytes` length. This catches truncation in transit (Node's decoder silently drops trailing invalid chars) and stray invalid bytes — without depending on Graph's `size` field at all.

```ts
const expectedEncodedLen = Math.ceil(content.length / 3) * 4;
if (cleanedBytes.length !== expectedEncodedLen) throw …
```

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:run` — 790 pass (+1 net; the "rejects size mismatch" test is repurposed into two)
  - **New**: `downloadAttachment accepts inline fileAttachment where Graph-reported size > decoded length` — pins the regression we just fixed.
  - **New**: `downloadAttachment rejects contentBytes truncated mid-base64` — preserves the real defensive intent of the original check.
- [x] Manually verified the Outlook self-send PDF from the #90 smoke would now download cleanly (against the new code).