### PR TITLE
chore(gitignore): ignore Office lock files (~$*)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ allure-report/
 # OS artifacts
 .DS_Store
 Thumbs.db
+# Office lock files (Word/Excel/PowerPoint create these while a file is open)
+~$*
 
 # IDE and editor
 .idea/


### PR DESCRIPTION
## Summary
- Add `~$*` to `.gitignore` (defensive — Office lock files from inspecting attachments shouldn't show up in `git status`).

## Test plan
- [ ] CI green.