### PR TITLE
chore(readme): UTM-tag the usejunior.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 [English](./README.md) | [Español](./README.es.md) | [简体中文](./README.zh.md) | [Português (Brasil)](./README.pt-br.md) | [Deutsch](./README.de.md)
 
-**email-agent-mcp** by [UseJunior](https://usejunior.com) -- local email connectivity for AI agents.
+**email-agent-mcp** by [UseJunior](https://usejunior.com?utm_source=github&utm_medium=readme&utm_campaign=email-agent-mcp) -- local email connectivity for AI agents.
 
 Agent Email is an open-source TypeScript MCP server that lets Claude Code, Cursor, Gemini CLI, OpenClaw, and other MCP-compatible runtimes read email, search threads, draft replies, label messages, change read state, move messages, and send mail through your own mailbox. Microsoft 365 / Outlook and Gmail are supported today. Security-first defaults mean agents cannot send email until you explicitly configure an allowlist.
 


### PR DESCRIPTION
## Summary

Appends \`?utm_source=github&utm_medium=readme&utm_campaign=email-agent-mcp\` to the markdown link on line 16 so README-driven traffic to UseJunior surfaces in GA4 as \`session_source=github\` instead of collapsing into the Direct bucket. Skipped the \`beta@usejunior.com\` mailto-style email on line 137.

## Why

GA4 on usejunior.com shows 68% of homepage sessions as "Direct" with poor engagement; the site owner doesn't currently know what's actually in that bucket. Some of it is README clicks from this repo — those strip the referrer header when navigating cross-origin, so without UTM they collapse into Direct. Tagging makes them visible.

Same campaign treatment landing in parallel on \`open-agreements/open-agreements\` and \`UseJunior/safe-docx\`.