### PR TITLE
fix(email-core): map Office/ODF attachments to their real MIME types

### DIFF
--- a/packages/email-core/src/actions/attachments.test.ts
+++ b/packages/email-core/src/actions/attachments.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockEmailProvider } from '../testing/mock-provider.js';
-import { listAttachmentsAction, downloadAttachmentAction, detectMimeType, validateAttachment, sanitizeFilename } from './attachments.js';
+import { listAttachmentsAction, downloadAttachmentAction, detectMimeType, validateAttachment, sanitizeFilename, ZIP_CONTAINER_TYPES } from './attachments.js';
 import { AttachmentNotSupportedError, AttachmentNotFoundError } from '../providers/provider.js';
 import type { ActionContext } from './registry.js';
 
@@ -305,17 +305,18 @@ describe('email-attachments/Binary File Detection', () => {
   });
 
   it('Scenario: OOXML/ODF extensions disambiguate the generic ZIP magic (#98)', () => {
-    const cases: [string, string][] = [
-      ['report.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
-      ['sheet.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
-      ['deck.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
-      ['macro.docm', 'application/vnd.ms-word.document.macroEnabled.12'],
-      ['notes.odt', 'application/vnd.oasis.opendocument.text'],
-      ['data.ods', 'application/vnd.oasis.opendocument.spreadsheet'],
-      ['slides.odp', 'application/vnd.oasis.opendocument.presentation'],
-    ];
-    for (const [filename, expected] of cases) {
-      expect(detectMimeType(ZIP_BYTES, undefined, filename)).toBe(expected);
+    // Spot-check the flagship types map to the exact expected strings...
+    expect(detectMimeType(ZIP_BYTES, undefined, 'report.docx'))
+      .toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+    expect(detectMimeType(ZIP_BYTES, undefined, 'sheet.xlsx'))
+      .toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    expect(detectMimeType(ZIP_BYTES, undefined, 'deck.pptx'))
+      .toBe('application/vnd.openxmlformats-officedocument.presentationml.presentation');
+
+    // ...then cover EVERY mapped extension so the map and test cannot drift.
+    for (const [ext, expected] of Object.entries(ZIP_CONTAINER_TYPES)) {
+      expect(detectMimeType(ZIP_BYTES, undefined, `file${ext}`)).toBe(expected);
+      expect(expected).not.toBe('application/zip');
     }
   });
 

--- a/packages/email-core/src/actions/attachments.test.ts
+++ b/packages/email-core/src/actions/attachments.test.ts
@@ -291,6 +291,10 @@ describe('email-attachments/Size and Type Validation', () => {
 });
 
 describe('email-attachments/Binary File Detection', () => {
+  // ZIP local file header (PK\x03\x04) — shared by plain archives and all
+  // OOXML/ODF documents.
+  const ZIP_BYTES = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x06, 0x00]);
+
   it('Scenario: MIME type detected from bytes', () => {
     // JPEG magic bytes (FF D8 FF)
     const jpegContent = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
@@ -298,6 +302,49 @@ describe('email-attachments/Binary File Detection', () => {
 
     // Should detect as image/jpeg despite declared text/plain
     expect(detected).toBe('image/jpeg');
+  });
+
+  it('Scenario: OOXML/ODF extensions disambiguate the generic ZIP magic (#98)', () => {
+    const cases: [string, string][] = [
+      ['report.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+      ['sheet.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+      ['deck.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+      ['macro.docm', 'application/vnd.ms-word.document.macroEnabled.12'],
+      ['notes.odt', 'application/vnd.oasis.opendocument.text'],
+      ['data.ods', 'application/vnd.oasis.opendocument.spreadsheet'],
+      ['slides.odp', 'application/vnd.oasis.opendocument.presentation'],
+    ];
+    for (const [filename, expected] of cases) {
+      expect(detectMimeType(ZIP_BYTES, undefined, filename)).toBe(expected);
+    }
+  });
+
+  it('Scenario: extension match is case-insensitive', () => {
+    expect(detectMimeType(ZIP_BYTES, undefined, 'REPORT.DOCX'))
+      .toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+  });
+
+  it('Scenario: a plain .zip archive still detects as application/zip', () => {
+    expect(detectMimeType(ZIP_BYTES, undefined, 'archive.zip')).toBe('application/zip');
+    expect(detectMimeType(ZIP_BYTES, undefined, 'no-extension')).toBe('application/zip');
+    expect(detectMimeType(ZIP_BYTES)).toBe('application/zip');
+  });
+
+  it('Scenario: declared type wins over the generic ZIP magic', () => {
+    expect(detectMimeType(ZIP_BYTES, 'application/epub+zip', 'book.epub')).toBe('application/epub+zip');
+    // Declared beats the extension map too — an explicit override is authoritative.
+    expect(detectMimeType(ZIP_BYTES, 'application/zip', 'report.docx')).toBe('application/zip');
+  });
+
+  it('Scenario: specific magic matches still win over declared type', () => {
+    const pdfContent = Buffer.from('%PDF-1.4 body');
+    expect(detectMimeType(pdfContent, 'application/octet-stream', 'file.docx')).toBe('application/pdf');
+  });
+
+  it('Scenario: validateAttachment threads the filename into detection (#98)', () => {
+    const result = validateAttachment(ZIP_BYTES, 'contract.docx');
+    expect(result.valid).toBe(true);
+    expect(result.detectedMimeType).toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
   });
 });
 

--- a/packages/email-core/src/actions/attachments.ts
+++ b/packages/email-core/src/actions/attachments.ts
@@ -14,13 +14,39 @@ const MAGIC_BYTES: [Buffer, string][] = [
   [Buffer.from([0x50, 0x4b, 0x03, 0x04]), 'application/zip'],
 ];
 
+// OOXML and ODF documents are ZIP containers, so the PK magic alone cannot
+// distinguish them from a plain archive. Disambiguate by extension (#98).
+const ZIP_CONTAINER_TYPES: Record<string, string> = {
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.docm': 'application/vnd.ms-word.document.macroEnabled.12',
+  '.xlsm': 'application/vnd.ms-excel.sheet.macroEnabled.12',
+  '.pptm': 'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+  '.odt': 'application/vnd.oasis.opendocument.text',
+  '.ods': 'application/vnd.oasis.opendocument.spreadsheet',
+  '.odp': 'application/vnd.oasis.opendocument.presentation',
+};
+
 /**
  * Detect MIME type from file content magic bytes.
+ *
+ * Specific magic matches (jpeg/png/gif/pdf) win over `declaredType` — content
+ * is authoritative when it identifies one concrete format. A ZIP match is only
+ * a container signature, so it defers to `declaredType`, then to the filename
+ * extension for known ZIP-based document formats (docx/xlsx/pptx/ODF).
  */
-export function detectMimeType(content: Buffer, declaredType?: string): string {
+export function detectMimeType(content: Buffer, declaredType?: string, filename?: string): string {
   for (const [magic, mimeType] of MAGIC_BYTES) {
     if (content.length >= magic.length && content.subarray(0, magic.length).equals(magic)) {
-      return mimeType;
+      if (mimeType !== 'application/zip') {
+        return mimeType;
+      }
+      if (declaredType) {
+        return declaredType;
+      }
+      const ext = filename ? extname(filename).toLowerCase() : '';
+      return ZIP_CONTAINER_TYPES[ext] ?? mimeType;
     }
   }
   return declaredType ?? 'application/octet-stream';
@@ -176,7 +202,7 @@ export const downloadAttachmentAction: EmailAction<
 // Validate attachment for outbound
 export function validateAttachment(
   content: Buffer,
-  _filename: string,
+  filename: string,
   declaredMimeType?: string,
 ): { valid: boolean; detectedMimeType: string; error?: string } {
   if (content.length > MAX_ATTACHMENT_SIZE) {
@@ -187,7 +213,7 @@ export function validateAttachment(
     };
   }
 
-  const detectedMimeType = detectMimeType(content, declaredMimeType);
+  const detectedMimeType = detectMimeType(content, declaredMimeType, filename);
 
   return { valid: true, detectedMimeType };
 }

--- a/packages/email-core/src/actions/attachments.ts
+++ b/packages/email-core/src/actions/attachments.ts
@@ -16,16 +16,29 @@ const MAGIC_BYTES: [Buffer, string][] = [
 
 // OOXML and ODF documents are ZIP containers, so the PK magic alone cannot
 // distinguish them from a plain archive. Disambiguate by extension (#98).
-const ZIP_CONTAINER_TYPES: Record<string, string> = {
+export const ZIP_CONTAINER_TYPES: Record<string, string> = {
   '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.dotx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
+  '.xltx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.template',
+  '.potx': 'application/vnd.openxmlformats-officedocument.presentationml.template',
+  '.ppsx': 'application/vnd.openxmlformats-officedocument.presentationml.slideshow',
   '.docm': 'application/vnd.ms-word.document.macroEnabled.12',
   '.xlsm': 'application/vnd.ms-excel.sheet.macroEnabled.12',
   '.pptm': 'application/vnd.ms-powerpoint.presentation.macroEnabled.12',
+  '.dotm': 'application/vnd.ms-word.template.macroEnabled.12',
+  '.xltm': 'application/vnd.ms-excel.template.macroEnabled.12',
+  '.potm': 'application/vnd.ms-powerpoint.template.macroEnabled.12',
+  '.ppsm': 'application/vnd.ms-powerpoint.slideshow.macroEnabled.12',
+  '.xlsb': 'application/vnd.ms-excel.sheet.binary.macroEnabled.12',
   '.odt': 'application/vnd.oasis.opendocument.text',
   '.ods': 'application/vnd.oasis.opendocument.spreadsheet',
   '.odp': 'application/vnd.oasis.opendocument.presentation',
+  '.odg': 'application/vnd.oasis.opendocument.graphics',
+  '.ott': 'application/vnd.oasis.opendocument.text-template',
+  '.ots': 'application/vnd.oasis.opendocument.spreadsheet-template',
+  '.otp': 'application/vnd.oasis.opendocument.presentation-template',
 };
 
 /**

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -140,7 +140,7 @@ export const AttachmentInputSchema = z
     filename: z.string().optional()
       .describe('Attachment filename. Defaults to basename(path); REQUIRED when using base64.'),
     mimeType: z.string().optional()
-      .describe('MIME type override. Defaults to magic-byte detection.'),
+      .describe('MIME type override. Defaults to detection from content magic bytes plus filename extension (Office/ODF documents are recognized without an override).'),
   })
   .refine(v => hasNonEmpty(v.path) !== hasNonEmpty(v.base64), {
     message: 'Each attachment must set exactly one of `path` or `base64`.',

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -140,7 +140,7 @@ export const AttachmentInputSchema = z
     filename: z.string().optional()
       .describe('Attachment filename. Defaults to basename(path); REQUIRED when using base64.'),
     mimeType: z.string().optional()
-      .describe('MIME type override. Defaults to detection from content magic bytes plus filename extension (Office/ODF documents are recognized without an override).'),
+      .describe('Optional MIME type hint. Overrides ZIP-container extension inference (Office/ODF documents are recognized without it); recognized JPEG/PNG/GIF/PDF magic bytes remain authoritative.'),
   })
   .refine(v => hasNonEmpty(v.path) !== hasNonEmpty(v.base64), {
     message: 'Each attachment must set exactly one of `path` or `base64`.',

--- a/packages/email-core/src/actions/outbound-attachments.test.ts
+++ b/packages/email-core/src/actions/outbound-attachments.test.ts
@@ -93,6 +93,23 @@ describe('outbound-attachments/send_email', () => {
     expect(att.content.equals(PDF_BYTES)).toBe(true);
   });
 
+  it('Scenario: .docx attachment gets the Word MIME type, not application/zip (#98)', async () => {
+    // OOXML files are ZIP containers — start with the PK magic.
+    const docxBytes = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x06, 0x00, 0x08, 0x00]);
+    await writeFile(join(testDir, 'term-sheet.docx'), docxBytes);
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Word doc',
+      body: 'body',
+      attachments: [{ path: 'term-sheet.docx' }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(provider.getSentMessages()[0]!.attachments![0]!.mimeType)
+      .toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
+  });
+
   it('Scenario: MIME inference overrides a wrong declared type', async () => {
     await writeFile(join(testDir, 'mystery.pdf'), PDF_BYTES);
 


### PR DESCRIPTION
Closes #98.

## Problem

`detectMimeType()` checked content magic bytes first and returned on the first match. Every OOXML (`.docx`/`.xlsx`/`.pptx`) and ODF file is a ZIP container starting with `PK\x03\x04`, so all Office attachments were uploaded as `application/zip` — rendering with a zip icon in Outlook and triggering warnings in some clients. The filename and any declared `mimeType` were never consulted.

## Fix

The ZIP magic is now treated as a *generic container* signature rather than a definitive answer:

1. Specific magic matches (jpeg/png/gif/pdf) still win over a wrong declared type — unchanged.
2. On a ZIP match, the caller's declared `mimeType` takes precedence (explicit override is authoritative).
3. Otherwise the filename extension disambiguates: `.docx`/`.xlsx`/`.pptx`, macro-enabled variants, and ODF `.odt`/`.ods`/`.odp` map to their proper types.
4. Plain `.zip` (or unknown extension) still falls back to `application/zip`.

`validateAttachment` now threads the (extension-preserving, sanitized) filename into detection — it previously accepted and ignored it — so all four outbound actions (`send_email`, `create_draft`, `update_draft`, `reply_to_email`) get the fix through `resolveAttachments` with no call-site changes.

## Tests

- Unit: extension disambiguation for all nine mapped types, case-insensitivity, plain-zip fallback, declared-type precedence over generic match, specific-magic precedence over declared, filename threading through `validateAttachment`.
- End-to-end: `send_email` with a `.docx` path yields `application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
- Full suite green across all workspaces; lint clean.