### PR TITLE
chore(release): bump workspace versions to 0.1.9

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -5923,10 +5923,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.1.8"
+        "@usejunior/email-mcp": "^0.1.9"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -5937,7 +5937,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "^18.0.0",
@@ -5956,14 +5956,14 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.1.8",
-        "@usejunior/provider-gmail": "^0.1.8",
-        "@usejunior/provider-microsoft": "^0.1.8"
+        "@usejunior/email-core": "^0.1.9",
+        "@usejunior/provider-gmail": "^0.1.9",
+        "@usejunior/provider-microsoft": "^0.1.9"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5977,11 +5977,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.1.8",
+        "@usejunior/email-core": "^0.1.9",
         "google-auth-library": "^8.9.0"
       },
       "devDependencies": {
@@ -5996,13 +5996,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.1.8"
+        "@usejunior/email-core": "^0.1.9"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 and manual-token Gmail setup",
   "type": "module",

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook and manual-token Gmail setup",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.1.8"
+    "@usejunior/email-mcp": "^0.1.9"
   },
   "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -21,9 +21,9 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.1.8",
-    "@usejunior/provider-gmail": "^0.1.8",
-    "@usejunior/provider-microsoft": "^0.1.8"
+    "@usejunior/email-core": "^0.1.9",
+    "@usejunior/provider-gmail": "^0.1.9",
+    "@usejunior/provider-microsoft": "^0.1.9"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.1.8",
+    "@usejunior/email-core": "^0.1.9",
     "google-auth-library": "^8.9.0"
   },
   "devDependencies": {

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.1.8"
+    "@usejunior/email-core": "^0.1.9"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Prepares the v0.1.9 patch release. Ships since v0.1.8:

- #99 — Office/ODF attachments (.docx/.xlsx/.pptx, macro-enabled and ODF variants) now get their real MIME types instead of `application/zip` (fixes #98). Verified end-to-end against a live Graph mailbox with a real .docx.
- #97 — README link tagging.

After merge: push the `v0.1.9` tag at the squash commit to fire `release.yml` (npm suite + MCP Registry + GitHub release notes).