### PR TITLE
fix: surface cc/bcc recipient topology in read_email and get_thread (#102)

### DIFF
--- a/openspec/specs/email-read/spec.md
+++ b/openspec/specs/email-read/spec.md
@@ -28,9 +28,16 @@ The system SHALL provide a `list_emails` action that returns recent emails filte
 
 The system SHALL provide a `read_email` action that returns the full content of a single email by ID, with the body transformed to token-efficient markdown via the content engine.
 
+The response SHALL surface recipient topology — `to`, `cc`, and `bcc` — as explicit arrays of `Name <email>` strings, returning an empty array `[]` (never a missing key) when a field has no recipients, so a caller can distinguish "no Cc recipients" from "Cc not reported." `bcc` is only populated on the sender's own copy of a message and is otherwise `[]`.
+
 #### Scenario: Read email with body and metadata
 - **WHEN** `read_email` is called with `{id: "msg123"}`
 - **THEN** the system returns the full email body as token-efficient markdown, sender, recipients, subject, timestamp, and attachment list
+
+#### Scenario: Cc and Bcc recipients are always reported
+- **WHEN** `read_email` is called for a message with Cc (and, on the sender's copy, Bcc) recipients
+- **THEN** the response includes `cc` (and `bcc`) as arrays of `Name <email>` entries
+- **AND** when a message has no Cc or Bcc recipients, `cc` and `bcc` are returned as empty arrays `[]` rather than omitted
 
 ### Requirement: Search Emails
 

--- a/openspec/specs/email-threading/spec.md
+++ b/openspec/specs/email-threading/spec.md
@@ -9,11 +9,12 @@ Defines conversation thread retrieval and assembly. Uses provider-native thread 
 
 ### Requirement: Get Thread
 
-The system SHALL provide a `get_thread` action that returns all messages in a conversation, ordered chronologically, with content engine transformations applied per message.
+The system SHALL provide a `get_thread` action that returns all messages in a conversation, ordered chronologically, with content engine transformations applied per message. Each returned message SHALL surface recipient topology — `to`, `cc`, and `bcc` — as explicit arrays of `Name <email>` strings, returning an empty array `[]` (never a missing key) when a field has no recipients, so a caller reasoning about reply-all scope can see who was on each message.
 
 #### Scenario: Retrieve thread by message ID
 - **WHEN** `get_thread` is called with `{message_id: "msg123"}`
 - **THEN** the system identifies the conversation and returns all messages in chronological order
+- **AND** each message reports `to`, `cc`, and `bcc` as arrays of `Name <email>` entries, using `[]` when a field has no recipients
 
 #### Scenario: Graph subject-change breakage
 - **WHEN** the conversation subject was changed mid-thread (Graph breaks `conversationId`)

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -305,11 +305,10 @@ const EmailAddressSchema = z.object({
 export const DraftPreviewSchema = z.object({
   to: z.array(EmailAddressSchema).optional(),
   cc: z.array(EmailAddressSchema).optional(),
-  // bcc intentionally omitted in v1: Gmail's mapGmailMessage at
-  // packages/provider-gmail/src/email-gmail-provider.ts (mapGmailMessage) does
-  // not parse the Bcc header, and Graph's mapGraphMessage similarly does not
-  // surface bcc on EmailMessage. Action-layer read-back cannot make
-  // preview.bcc meaningful without provider work; tracked as a follow-up.
+  // bcc is surfaced from the provider read-back: both Gmail's mapGmailMessage and
+  // Graph's mapGraphMessage now parse bcc on the sender's own copy (issue #102),
+  // so a draft preview can report the full recipient topology it will send with.
+  bcc: z.array(EmailAddressSchema).optional(),
   subject: z.string().optional(),
   body: z.string().optional(),
   bodyHtml: z.string().optional(),
@@ -407,6 +406,7 @@ export async function buildDraftPreview(
   const preview: DraftPreview = {
     to: persisted.to,
     cc: persisted.cc,
+    bcc: persisted.bcc,
     subject: persisted.subject,
   };
   if (persisted.body !== undefined) {

--- a/packages/email-core/src/actions/conversation.test.ts
+++ b/packages/email-core/src/actions/conversation.test.ts
@@ -39,6 +39,31 @@ describe('email-threading/Get Thread', () => {
     expect(result.messages[2]!.id).toBe('msg3');
   });
 
+  it('Scenario: Thread messages surface recipient topology as explicit arrays (issue #102)', async () => {
+    provider.addMessage({
+      id: 'm1', subject: 'Re: follow-up from coffee', conversationId: 'conv-x',
+      from: { email: 'alice@corp.com', name: 'Alice Smith' },
+      to: [{ email: 'bob@corp.com', name: 'Bob Jones' }],
+      cc: [{ email: 'nadim@corp.com', name: 'Nadim Cheaib' }],
+      receivedAt: '2024-03-15T10:00:00Z', isRead: true, hasAttachments: false,
+    });
+    // Second message has no cc/bcc — must come back as [] arrays, not missing keys.
+    provider.addMessage({
+      id: 'm2', subject: 'Re: follow-up from coffee', conversationId: 'conv-x',
+      from: { email: 'bob@corp.com', name: 'Bob Jones' },
+      to: [{ email: 'alice@corp.com', name: 'Alice Smith' }],
+      receivedAt: '2024-03-15T11:00:00Z', isRead: false, hasAttachments: false,
+    });
+
+    const result = await getThreadAction.run(ctx, { message_id: 'm1' });
+
+    expect(result.messages[0]!.to).toEqual(['Bob Jones <bob@corp.com>']);
+    expect(result.messages[0]!.cc).toEqual(['Nadim Cheaib <nadim@corp.com>']);
+    expect(result.messages[0]!.bcc).toEqual([]);
+    expect(result.messages[1]!.cc).toEqual([]);
+    expect(result.messages[1]!.bcc).toEqual([]);
+  });
+
   it('Scenario: Graph subject-change breakage', async () => {
     // Messages in same thread but Graph broke conversationId due to subject change
     // Use RFC headers to reconstruct

--- a/packages/email-core/src/actions/conversation.ts
+++ b/packages/email-core/src/actions/conversation.ts
@@ -14,6 +14,12 @@ const GetThreadOutput = z.object({
     id: z.string(),
     subject: z.string(),
     from: z.string(),
+    // Recipient topology per message as explicit arrays (`[]` when none), so a
+    // caller reasoning about reply-all scope on a multi-party thread can see who
+    // was on To/Cc rather than inferring absence from a missing field — issue #102.
+    to: z.array(z.string()),
+    cc: z.array(z.string()),
+    bcc: z.array(z.string()),
     receivedAt: z.string(),
     body: z.string().optional(),
     isRead: z.boolean(),
@@ -48,6 +54,9 @@ export const getThreadAction: EmailAction<
         id: m.id,
         subject: m.subject,
         from: m.from.name ? `${m.from.name} <${m.from.email}>` : m.from.email,
+        to: m.to.map(a => a.name ? `${a.name} <${a.email}>` : a.email),
+        cc: (m.cc ?? []).map(a => a.name ? `${a.name} <${a.email}>` : a.email),
+        bcc: (m.bcc ?? []).map(a => a.name ? `${a.name} <${a.email}>` : a.email),
         receivedAt: m.receivedAt,
         body: m.body,
         isRead: m.isRead,

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -213,6 +213,25 @@ describe('email-write/Send Draft', () => {
     expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
   });
 
+  it('Scenario: send_draft with allowed To but blocked Bcc is blocked by allowlist (issue #102)', async () => {
+    // Providers now surface bcc on the sender's own copy of a draft, so bcc must
+    // be gated too — otherwise a blocked bcc recipient slips past the allowlist.
+    provider.addMessage({
+      id: 'draft-with-bcc',
+      subject: 'Bcc bypass attempt',
+      from: { email: 'me@company.com' },
+      to: [{ email: 'alice@allowed.com' }],
+      bcc: [{ email: 'hacker@evil.com' }],
+      body: 'Body',
+    });
+
+    const result = await sendDraftAction.run(ctx, { draft_id: 'draft-with-bcc' });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
   it('Scenario: send_draft when draft lookup fails is blocked (fail closed)', async () => {
     // Use a draft_id that doesn't exist in drafts or messages
     const result = await sendDraftAction.run(ctx, {

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -220,9 +220,13 @@ export const sendDraftAction: EmailAction<
       };
     }
 
+    // All effective recipients — to, cc, AND bcc — must be gated. Providers now
+    // surface bcc on the sender's own copy (issue #102), so a bcc recipient that
+    // wasn't checked would be a silent allowlist bypass. Fail closed on every one.
     const recipients = [
       ...(draftMessage.to?.map(a => a.email) ?? []),
       ...(draftMessage.cc?.map(a => a.email) ?? []),
+      ...(draftMessage.bcc?.map(a => a.email) ?? []),
     ];
     if (recipients.length === 0) {
       return {

--- a/packages/email-core/src/actions/read.test.ts
+++ b/packages/email-core/src/actions/read.test.ts
@@ -42,7 +42,7 @@ describe('email-read/Read Email', () => {
     expect(result.attachments![0]!.filename).toBe('contract.pdf');
   });
 
-  it('Scenario: Read email surfaces cc and bcc recipients (issue #102)', async () => {
+  it('Scenario: Cc and Bcc recipients are always reported', async () => {
     provider.addMessage({
       id: 'msg-cc',
       subject: 'Re: follow-up from coffee',

--- a/packages/email-core/src/actions/read.test.ts
+++ b/packages/email-core/src/actions/read.test.ts
@@ -42,6 +42,48 @@ describe('email-read/Read Email', () => {
     expect(result.attachments![0]!.filename).toBe('contract.pdf');
   });
 
+  it('Scenario: Read email surfaces cc and bcc recipients (issue #102)', async () => {
+    provider.addMessage({
+      id: 'msg-cc',
+      subject: 'Re: follow-up from coffee',
+      from: { email: 'alice@corp.com', name: 'Alice Smith' },
+      to: [
+        { email: 'bob@corp.com', name: 'Bob Jones' },
+        { email: 'nandita@corp.com', name: 'Nandita Sethi' },
+      ],
+      cc: [
+        { email: 'nadim@corp.com', name: 'Nadim Cheaib' },
+        { email: 'tiffany@corp.com', name: 'Tiffany Loer' },
+      ],
+      bcc: [{ email: 'audit@corp.com' }],
+      body: 'See you then.',
+    });
+
+    const result = await readEmailAction.run(ctx, { id: 'msg-cc' });
+
+    expect(result.to).toEqual(['Bob Jones <bob@corp.com>', 'Nandita Sethi <nandita@corp.com>']);
+    expect(result.cc).toEqual(['Nadim Cheaib <nadim@corp.com>', 'Tiffany Loer <tiffany@corp.com>']);
+    expect(result.bcc).toEqual(['audit@corp.com']);
+  });
+
+  it('Scenario: cc and bcc are explicit empty arrays when absent, never dropped (issue #102)', async () => {
+    // Absence of Cc must be unambiguous: an empty array, not a missing key. A
+    // missing key silently reads as "no Cc" and can drop stakeholders on a reply.
+    provider.addMessage({
+      id: 'msg-nocc',
+      from: { email: 'alice@corp.com', name: 'Alice Smith' },
+      to: [{ email: 'bob@corp.com', name: 'Bob Jones' }],
+      body: 'One-to-one note.',
+    });
+
+    const result = await readEmailAction.run(ctx, { id: 'msg-nocc' });
+
+    expect(result.cc).toEqual([]);
+    expect(result.bcc).toEqual([]);
+    expect('cc' in result).toBe(true);
+    expect('bcc' in result).toBe(true);
+  });
+
   it('Scenario: strip_quoted_history omitted preserves full thread', async () => {
     provider.addMessage({
       id: 'msg-thread',

--- a/packages/email-core/src/actions/read.ts
+++ b/packages/email-core/src/actions/read.ts
@@ -16,8 +16,13 @@ const ReadEmailOutput = z.object({
   id: z.string(),
   subject: z.string(),
   from: z.string(),
+  // Recipient topology is always surfaced as explicit arrays so a caller can
+  // distinguish "no Cc recipients" (`[]`) from "not reported" — see issue #102.
+  // bcc is only ever populated on the sender's own copy of a message (the field
+  // is stripped from recipients' copies by design), so it is `[]` for most reads.
   to: z.array(z.string()),
-  cc: z.array(z.string()).optional(),
+  cc: z.array(z.string()),
+  bcc: z.array(z.string()),
   receivedAt: z.string(),
   body: z.string(),
   attachments: z.array(z.object({
@@ -58,7 +63,8 @@ export const readEmailAction: EmailAction<
       subject: msg.subject,
       from: msg.from.name ? `${msg.from.name} <${msg.from.email}>` : msg.from.email,
       to: msg.to.map(a => a.name ? `${a.name} <${a.email}>` : a.email),
-      cc: msg.cc?.map(a => a.name ? `${a.name} <${a.email}>` : a.email),
+      cc: (msg.cc ?? []).map(a => a.name ? `${a.name} <${a.email}>` : a.email),
+      bcc: (msg.bcc ?? []).map(a => a.name ? `${a.name} <${a.email}>` : a.email),
       receivedAt: msg.receivedAt,
       body,
       attachments: msg.attachments?.map(a => ({

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -121,6 +121,7 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSubscri
         from: { email: 'me@company.com' },
         to: draft.to,
         cc: draft.cc,
+        bcc: draft.bcc,
         receivedAt: new Date().toISOString(),
         isRead: true,
         hasAttachments: (attachments?.length ?? 0) > 0,

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -737,16 +737,17 @@ describe('mcp-transport/Lazy Provider State', () => {
     ]);
   });
 
-  it('Scenario: read_email omits cc field even when provider returns it (wire-shape parity with pre-PR MCP tool)', async () => {
-    // The pre-PR hand-rolled MCP `read_email` did not surface `cc`. The refactor delegates
-    // to readEmailAction (which returns `cc`), but the MCP adapter must drop it so the wire
-    // shape stays unchanged. Adding cc to the MCP surface is a separate, additive change.
+  it('Scenario: read_email surfaces cc and bcc on the MCP wire (issue #102)', async () => {
+    // Regression for issue #102: the MCP adapter used to strip `cc` and never
+    // surfaced `bcc`, so a caller could not tell "no Cc" from "Cc not reported"
+    // and could silently drop stakeholders when reasoning about reply-all scope.
     const getMessage = vi.fn().mockResolvedValue({
       id: 'msg-cc',
       subject: 'Has cc',
       from: { email: 'alice@corp.com', name: 'Alice' },
       to: [{ email: 'bob@corp.com', name: 'Bob' }],
       cc: [{ email: 'carol@corp.com', name: 'Carol' }],
+      bcc: [{ email: 'audit@corp.com' }],
       receivedAt: '2026-04-09T12:00:00.000Z',
       body: 'Hello.',
     });
@@ -773,13 +774,51 @@ describe('mcp-transport/Lazy Provider State', () => {
     const readEmail = actions.find(a => a.name === 'read_email')!;
     const result = await readEmail.run({}, { id: 'msg-cc' }) as Record<string, unknown>;
 
-    expect(result).not.toHaveProperty('cc');
     expect(result.id).toBe('msg-cc');
     expect(result.to).toEqual(['Bob <bob@corp.com>']);
-    // The action's full schema includes cc; the MCP output schema does NOT.
+    expect(result.cc).toEqual(['Carol <carol@corp.com>']);
+    expect(result.bcc).toEqual(['audit@corp.com']);
+    // The MCP output schema advertises cc and bcc as arrays.
     const schema = readEmail.output as { shape?: Record<string, unknown> };
     expect(schema.shape).toBeDefined();
-    expect(schema.shape!.cc).toBeUndefined();
+    expect(schema.shape!.cc).toBeDefined();
+    expect(schema.shape!.bcc).toBeDefined();
+  });
+
+  it('Scenario: read_email normalizes absent cc/bcc to empty arrays on the MCP wire (issue #102)', async () => {
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-nocc',
+      subject: 'No cc',
+      from: { email: 'alice@corp.com', name: 'Alice' },
+      to: [{ email: 'bob@corp.com', name: 'Bob' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      body: 'Hello.',
+    });
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'alice@corp.com';
+    state.mailboxes = [
+      {
+        name: 'alice',
+        emailAddress: 'alice@corp.com',
+        displayName: 'alice@corp.com',
+        providerType: 'gmail',
+        provider: { getMessage } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, { id: 'msg-nocc' }) as Record<string, unknown>;
+
+    expect(result.cc).toEqual([]);
+    expect(result.bcc).toEqual([]);
   });
 
   it('Scenario: read_email exposes strip_quoted_history with default false', async () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -743,6 +743,8 @@ export async function buildLazyActions(
     subject: 'Demo mode',
     from: 'system@email-agent-mcp.dev',
     to: ['user@example.com'],
+    cc: [],
+    bcc: [],
     body: NO_MAILBOX_CONFIGURED_MESSAGE,
     receivedAt: new Date().toISOString(),
   });
@@ -789,7 +791,11 @@ export async function buildLazyActions(
         id: z.string(),
         subject: z.string(),
         from: z.string(),
+        // Recipient topology surfaced as explicit arrays (`[]` when none) so a
+        // caller can distinguish "no Cc" from "Cc not reported" — issue #102.
         to: z.array(z.string()),
+        cc: z.array(z.string()),
+        bcc: z.array(z.string()),
         body: z.string(),
         receivedAt: z.string(),
         attachments: z.array(z.object({
@@ -821,11 +827,11 @@ export async function buildLazyActions(
             strip_quoted_history: inp.strip_quoted_history ?? false,
           },
         );
-        // Drop `cc` — the pre-PR hand-rolled MCP tool did not return cc, so omit it
-        // here to keep the MCP wire shape unchanged. Adding cc to the MCP surface is
-        // a separate, additive wire change and is tracked separately.
-        const { cc: _cc, ...rest } = actionResult;
-        return rest;
+        // Return the canonical action result verbatim, including `cc`/`bcc`.
+        // Surfacing recipient topology is the fix for issue #102 — a caller
+        // deciding reply-all scope must see who was on Cc, and an omitted key
+        // reads as "no Cc" and silently drops recipients.
+        return actionResult;
       },
     },
     {

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -50,6 +50,48 @@ describe('provider-gmail/Message Mapping', () => {
     expect(msg.isRead).toBe(false); // Has UNREAD label
   });
 
+  it('Scenario: Cc and Bcc headers map to cc/bcc arrays (issue #102)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-cc',
+        threadId: 'thread-cc',
+        labelIds: ['INBOX'],
+        payload: {
+          headers: [
+            { name: 'From', value: '"Alice Smith" <alice@corp.com>' },
+            { name: 'To', value: '"Bob Jones" <bob@corp.com>' },
+            { name: 'Cc', value: '"Nadim Cheaib" <nadim@corp.com>, "Tiffany Loer" <tiffany@corp.com>' },
+            { name: 'Bcc', value: 'audit@corp.com' },
+            { name: 'Subject', value: 'Re: follow-up from coffee' },
+            { name: 'Date', value: '2024-03-15T10:00:00Z' },
+          ],
+          body: { data: Buffer.from('See you then.').toString('base64url') },
+        },
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-cc');
+
+    expect(msg.cc).toEqual([
+      { email: 'nadim@corp.com', name: 'Nadim Cheaib' },
+      { email: 'tiffany@corp.com', name: 'Tiffany Loer' },
+    ]);
+    expect(msg.bcc).toEqual([{ email: 'audit@corp.com', name: undefined }]);
+  });
+
+  it('Scenario: cc/bcc are undefined when the message carries no such headers (issue #102)', async () => {
+    // The provider leaves cc/bcc undefined; the read_email action normalizes the
+    // absence to an explicit [] so callers never see a dropped key.
+    const client = createMockGmailClient();
+    const provider = new GmailEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-1');
+
+    expect(msg.cc).toBeUndefined();
+    expect(msg.bcc).toBeUndefined();
+  });
+
   it('Scenario: multipart Gmail messages expose attachment metadata and inline content ids', async () => {
     const client = createMockGmailClient({
       getMessage: vi.fn().mockResolvedValue({

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -80,6 +80,45 @@ describe('provider-gmail/Message Mapping', () => {
     expect(msg.bcc).toEqual([{ email: 'audit@corp.com', name: undefined }]);
   });
 
+  it('Scenario: To/Cc/Bcc with quoted-comma display names parse without corruption (issue #102)', async () => {
+    // Last-name-first display names like "Doe, Jane" contain a comma inside the
+    // quoted name. A naive split(',') would shatter them into bogus addresses.
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue({
+        id: 'msg-quoted',
+        threadId: 'thread-quoted',
+        labelIds: ['INBOX'],
+        payload: {
+          headers: [
+            { name: 'From', value: 'alice@corp.com' },
+            { name: 'To', value: '"Doe, Jane" <jane@example.com>, audit@example.com' },
+            { name: 'Cc', value: '"Loer, Tiffany" <tiffany@corp.com>, "Cheaib, Nadim" <nadim@corp.com>' },
+            { name: 'Bcc', value: '"Smith, Bob" <bob@corp.com>, ops@corp.com' },
+            { name: 'Subject', value: 'Quoted commas' },
+            { name: 'Date', value: '2024-03-15T10:00:00Z' },
+          ],
+          body: { data: Buffer.from('Body').toString('base64url') },
+        },
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-quoted');
+
+    expect(msg.to).toEqual([
+      { email: 'jane@example.com', name: 'Doe, Jane' },
+      { email: 'audit@example.com', name: undefined },
+    ]);
+    expect(msg.cc).toEqual([
+      { email: 'tiffany@corp.com', name: 'Loer, Tiffany' },
+      { email: 'nadim@corp.com', name: 'Cheaib, Nadim' },
+    ]);
+    expect(msg.bcc).toEqual([
+      { email: 'bob@corp.com', name: 'Smith, Bob' },
+      { email: 'ops@corp.com', name: undefined },
+    ]);
+  });
+
   it('Scenario: cc/bcc are undefined when the message carries no such headers (issue #102)', async () => {
     // The provider leaves cc/bcc undefined; the read_email action normalizes the
     // absence to an explicit [] so callers never see a dropped key.

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -328,7 +328,10 @@ export class GmailEmailProvider {
       const merged: ComposeMessage = {
         to: msg.to ?? current.to,
         cc: msg.cc ?? current.cc,
-        bcc: msg.bcc, // bcc is never exposed on EmailMessage, so only caller can set it
+        // Preserve the draft's existing bcc on a partial update: providers now
+        // read bcc back on the sender's own copy (issue #102), so falling back to
+        // current.bcc (like cc) keeps a bcc from being silently dropped.
+        bcc: msg.bcc ?? current.bcc,
         subject: msg.subject ?? current.subject,
         body: msg.body ?? current.body ?? '',
         bodyHtml: msg.bodyHtml ?? current.bodyHtml,
@@ -431,18 +434,12 @@ function collectPayloadContent(msg: GmailMessage): {
 
 function mapGmailMessage(msg: GmailMessage): EmailMessage {
   const from = parseEmailAddress(getHeader(msg, 'From') ?? '');
-  const to = (getHeader(msg, 'To') ?? '').split(',').map(a => parseEmailAddress(a.trim())).filter(a => a.email);
-  const ccHeader = getHeader(msg, 'Cc');
-  const cc = ccHeader
-    ? ccHeader.split(',').map(a => parseEmailAddress(a.trim())).filter(a => a.email)
-    : undefined;
+  const to = parseAddressList(getHeader(msg, 'To')) ?? [];
+  const cc = parseAddressList(getHeader(msg, 'Cc'));
   // A Bcc header only survives on the sender's own copy of a message; recipients'
   // copies have it stripped. Surface it when present for full recipient topology
   // on read_email (issue #102).
-  const bccHeader = getHeader(msg, 'Bcc');
-  const bcc = bccHeader
-    ? bccHeader.split(',').map(a => parseEmailAddress(a.trim())).filter(a => a.email)
-    : undefined;
+  const bcc = parseAddressList(getHeader(msg, 'Bcc'));
   const subject = getHeader(msg, 'Subject') ?? '';
   const date = getHeader(msg, 'Date') ?? new Date(parseInt(msg.internalDate ?? '0', 10)).toISOString();
 
@@ -551,6 +548,39 @@ function isNotFoundError(err: unknown): boolean {
   if (record.code === 404) return true;
   if (record.response && typeof record.response === 'object' && record.response.status === 404) return true;
   return false;
+}
+
+/**
+ * Split an RFC 5322 address-list header into individual mailbox tokens on the
+ * commas that separate addresses, ignoring commas inside a quoted display name.
+ * A plain `.split(',')` corrupts last-name-first display names such as
+ * `"Doe, Jane" <jane@x>` into bogus entries (`"Doe` / `Jane" <jane@x>`).
+ * Returns `undefined` when the header is absent/empty so callers can leave the
+ * field unset; otherwise an array of parsed addresses (empty if none valid).
+ */
+function parseAddressList(header: string | undefined): { email: string; name?: string }[] | undefined {
+  if (!header) return undefined;
+  const tokens: string[] = [];
+  let current = '';
+  let inQuotes = false;
+  for (let i = 0; i < header.length; i++) {
+    const ch = header[i]!;
+    if (ch === '\\' && inQuotes) {
+      // Preserve an escaped character (e.g. `\"`) verbatim inside a quoted name.
+      current += ch + (header[i + 1] ?? '');
+      i++;
+    } else if (ch === '"') {
+      inQuotes = !inQuotes;
+      current += ch;
+    } else if (ch === ',' && !inQuotes) {
+      tokens.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  tokens.push(current);
+  return tokens.map(t => parseEmailAddress(t.trim())).filter(a => a.email);
 }
 
 function parseEmailAddress(raw: string): { email: string; name?: string } {

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -436,6 +436,13 @@ function mapGmailMessage(msg: GmailMessage): EmailMessage {
   const cc = ccHeader
     ? ccHeader.split(',').map(a => parseEmailAddress(a.trim())).filter(a => a.email)
     : undefined;
+  // A Bcc header only survives on the sender's own copy of a message; recipients'
+  // copies have it stripped. Surface it when present for full recipient topology
+  // on read_email (issue #102).
+  const bccHeader = getHeader(msg, 'Bcc');
+  const bcc = bccHeader
+    ? bccHeader.split(',').map(a => parseEmailAddress(a.trim())).filter(a => a.email)
+    : undefined;
   const subject = getHeader(msg, 'Subject') ?? '';
   const date = getHeader(msg, 'Date') ?? new Date(parseInt(msg.internalDate ?? '0', 10)).toISOString();
 
@@ -457,6 +464,7 @@ function mapGmailMessage(msg: GmailMessage): EmailMessage {
     from,
     to,
     cc,
+    bcc,
     receivedAt: date,
     isRead: !labels.includes('UNREAD'),
     hasAttachments: attachments.length > 0,

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -232,6 +232,52 @@ describe('provider-microsoft/Message Mapping', () => {
       '/me/messages/msg-attachments/attachments?$select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId',
     );
   });
+
+  it('Scenario: getMessage maps ccRecipients and bccRecipients (issue #102)', async () => {
+    const client = createSchemaValidatingClient([
+      {
+        id: 'msg-cc',
+        subject: 'Re: follow-up from coffee',
+        from: { emailAddress: { address: 'alice@corp.com', name: 'Alice Smith' } },
+        toRecipients: [{ emailAddress: { address: 'bob@corp.com', name: 'Bob Jones' } }],
+        ccRecipients: [
+          { emailAddress: { address: 'nadim@corp.com', name: 'Nadim Cheaib' } },
+          { emailAddress: { address: 'tiffany@corp.com', name: 'Tiffany Loer' } },
+        ],
+        bccRecipients: [{ emailAddress: { address: 'audit@corp.com' } }],
+        receivedDateTime: '2026-04-09T12:00:00Z',
+        hasAttachments: false,
+      },
+    ]);
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-cc');
+
+    expect(msg.cc).toEqual([
+      { email: 'nadim@corp.com', name: 'Nadim Cheaib' },
+      { email: 'tiffany@corp.com', name: 'Tiffany Loer' },
+    ]);
+    expect(msg.bcc).toEqual([{ email: 'audit@corp.com', name: undefined }]);
+  });
+
+  it('Scenario: getMessage yields empty cc/bcc arrays when Graph omits them (issue #102)', async () => {
+    const client = createSchemaValidatingClient([
+      {
+        id: 'msg-nocc',
+        subject: 'One-to-one',
+        from: { emailAddress: { address: 'alice@corp.com' } },
+        toRecipients: [{ emailAddress: { address: 'bob@corp.com' } }],
+        receivedDateTime: '2026-04-09T12:00:00Z',
+        hasAttachments: false,
+      },
+    ]);
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('msg-nocc');
+
+    expect(msg.cc).toEqual([]);
+    expect(msg.bcc).toEqual([]);
+  });
 });
 
 describe('provider-microsoft/Attachment Download', () => {

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -791,6 +791,7 @@ interface GraphMessage {
   from?: { emailAddress: { address: string; name?: string } };
   toRecipients?: Array<{ emailAddress: { address: string; name?: string } }>;
   ccRecipients?: Array<{ emailAddress: { address: string; name?: string } }>;
+  bccRecipients?: Array<{ emailAddress: { address: string; name?: string } }>;
   receivedDateTime?: string;
   isRead?: boolean;
   hasAttachments?: boolean;
@@ -848,6 +849,13 @@ function mapGraphMessage(msg: GraphMessage): EmailMessage {
       name: r.emailAddress.name,
     })),
     cc: (msg.ccRecipients ?? []).map(r => ({
+      email: r.emailAddress.address,
+      name: r.emailAddress.name,
+    })),
+    // bccRecipients is only populated by Graph on the sender's own copy of a
+    // message; recipients' copies omit it. Surface it when present so read_email
+    // can report full recipient topology (issue #102).
+    bcc: (msg.bccRecipients ?? []).map(r => ({
       email: r.emailAddress.address,
       name: r.emailAddress.name,
     })),


### PR DESCRIPTION
## Summary

`read_email` silently dropped the **Cc** recipients: the MCP transport layer re-declared the tool with a trimmed output schema and explicitly stripped `cc` (`const { cc: _cc, ...rest }`), and never surfaced `bcc`. A caller couldn't distinguish "no Cc recipients" from "Cc not reported", so reasoning about reply-all topology could silently drop stakeholders the sender deliberately kept on Cc. Fixes #102.

## What changed

**Recipient topology is now surfaced as explicit arrays (`[]` when none, never a missing key):**
- `read_email` (email-core action **and** the MCP `server.ts` wire adapter): `cc` + `bcc` are required arrays. Removed the transport-layer `cc` strip and the test that locked it in.
- `get_thread`: each message now reports `to`/`cc`/`bcc` (was `from`-only) — the endpoint used to reason about reply-all scope on multi-party threads.
- Graph + Gmail providers now map `bcc` (populated only on the sender's own copy).

**Adjacent fixes surfaced by peer review:**
- **Security:** `send_draft` now includes draft `bcc` in the allowlist-gated recipient set. Surfacing provider bcc otherwise let a blocked bcc recipient bypass the send allowlist. Regression test added.
- **Correctness:** Gmail now parses `To`/`Cc`/`Bcc` with a quote-aware address-list splitter, so last-name-first display names like `"Doe, Jane" <j@x>` no longer shatter on the embedded comma (pre-existing `to`/`cc` bug the new `bcc` path inherited).
- Draft preview + Gmail partial draft update now surface/preserve `bcc`; removed now-false "bcc never exposed" comments.

## Scope note
`list_emails`/`search_emails` intentionally stay lean (summary/scanning views) — callers get full topology via `read_email`/`get_thread` after selecting a result.

## Verification
- `npm run build`, `npm test` (all packages green), `npm run lint`
- `npm run check:spec-coverage` → **201/201** scenarios covered
- `npm run check:server-json`, `check:gemini-extension-manifest` → pass
- Peer-reviewed with Codex (dynamic review: opened every file, ran build + full suite). All findings addressed.

## Spec
Updated `openspec/specs/email-read/spec.md` and `email-threading/spec.md` to require the explicit recipient-topology contract (bug fix — restores intended behavior, no change proposal per OpenSpec conventions).

Closes #102