### PR TITLE
feat(tools): add folder management and inbox rules MCP tools (closes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If your mailbox status name is not an email address, pass `--reply-sender <email
 
 ## Tool Reference
 
-Agent Email exposes 15 MCP tools:
+Agent Email exposes 23 MCP tools:
 
 | Tool | Description | Type |
 |------|-------------|------|
@@ -151,6 +151,8 @@ Agent Email exposes 15 MCP tools:
 | `search_emails` | Full-text search across mailboxes | read |
 | `get_mailbox_status` | Connection status and warnings | read |
 | `get_thread` | Full conversation context | read |
+| `list_attachments` | List attachment metadata for an email | read |
+| `download_attachment` | Download a file attachment as base64 | read |
 | `send_email` | Send new email (allowlist-gated) | write |
 | `reply_to_email` | Reply within thread (allowlist-gated on send) | write |
 | `create_draft` | Create email draft | write |
@@ -161,6 +163,14 @@ Agent Email exposes 15 MCP tools:
 | `mark_read` | Mark as read/unread | write |
 | `move_to_folder` | Move between folders | write |
 | `delete_email` | Delete (requires operator env + caller flag) | destructive |
+| `list_folders` | Recursively list folders and computed paths (Microsoft 365) | read |
+| `create_folder` | Create a custom child folder (Microsoft 365) | write |
+| `delete_folder` | Delete a custom folder; system folders are protected (Microsoft 365) | destructive |
+| `list_inbox_rules` | List server-side inbox rules (Microsoft 365) | read |
+| `create_inbox_rule` | Create a human-approved safe inbox rule; forwarding/redirection/deletion are blocked (Microsoft 365) | write |
+| `delete_inbox_rule` | Delete a server-side inbox rule (Microsoft 365) | destructive |
+
+Folder and inbox-rule management requires Microsoft Graph `MailboxSettings.ReadWrite` consent. Existing Microsoft mailbox connections must re-consent after upgrading. Gmail uses labels rather than hierarchical folders/server-side Exchange rules, so these six tools return `NOT_SUPPORTED` for Gmail mailboxes.
 
 ### Outbound attachments
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ Agent Email exposes 23 MCP tools:
 | `delete_email` | Delete (requires operator env + caller flag) | destructive |
 | `list_folders` | Recursively list folders and computed paths (Microsoft 365) | read |
 | `create_folder` | Create a custom child folder (Microsoft 365) | write |
-| `delete_folder` | Delete a custom folder; system folders are protected (Microsoft 365) | destructive |
+| `delete_folder` | Delete a custom folder (requires operator env + caller flag); system folders are protected (Microsoft 365) | destructive |
 | `list_inbox_rules` | List server-side inbox rules (Microsoft 365) | read |
-| `create_inbox_rule` | Create a human-approved safe inbox rule; forwarding/redirection/deletion are blocked (Microsoft 365) | write |
-| `delete_inbox_rule` | Delete a server-side inbox rule (Microsoft 365) | destructive |
+| `create_inbox_rule` | Create a persistent safe inbox rule; forwarding, redirection, deletion, and discarding to Deleted Items are blocked (Microsoft 365) | write |
+| `delete_inbox_rule` | Delete a server-side inbox rule (requires operator env + caller flag) (Microsoft 365) | destructive |
 
 Folder and inbox-rule management requires Microsoft Graph `MailboxSettings.ReadWrite` consent. Existing Microsoft mailbox connections must re-consent after upgrading. Gmail uses labels rather than hierarchical folders/server-side Exchange rules, so these six tools return `NOT_SUPPORTED` for Gmail mailboxes.
 

--- a/openspec/changes/add-folder-and-rule-management/design.md
+++ b/openspec/changes/add-folder-and-rule-management/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Folder and rule behavior differs sharply between Microsoft Graph and Gmail. Graph exposes hierarchical mail folders and Exchange inbox rules, while Gmail's closest primitives are labels and filters. The action registry must remain the single source of truth and transport adapters must remain generic.
+
+## Goals / Non-Goals
+
+- Goals: hierarchical folder CRUD, faithful rule listing, safe minimal rule creation, server-side rule deletion, and custom-folder moves for Microsoft Graph.
+- Goals: typed graceful degradation for providers that omit either capability.
+- Non-goals: Gmail label/filter emulation, client-side rule execution, unsafe forwarding/redirection/deletion actions, and transport-specific business logic.
+
+## Decisions
+
+### Optional provider capabilities
+
+`EmailFolderManager` and `EmailRuleManager` are composed into `EmailProvider` with `Partial<...>`, matching existing optional categorization and attachment capabilities. Core actions test for method presence and return `NOT_SUPPORTED` when absent.
+
+### Folder shape and traversal
+
+`listFolders` returns a flat recursive list. Each folder retains Graph folder fields used by callers and gains a computed slash-delimited `path`. Traversal follows `@odata.nextLink` for roots and every `childFolders` collection. A visited-id guard prevents pathological cycles.
+
+### Folder resolution and caching
+
+Resolution checks well-known aliases first to preserve existing behavior and avoid unnecessary calls. Custom input then matches ids, case-insensitive paths, or a unique case-insensitive display name. Ambiguous display names return a typed provider error asking for a path. The recursive folder list is cached for 60 seconds per provider instance and invalidated after successful create/delete.
+
+### System-folder deletion protection
+
+Deletion rejects known system aliases before resolution. It also loads the well-known folders and rejects a custom request if its resolved id equals a system-folder id. This closes the alias/id bypass while still permitting custom descendants.
+
+### Faithful list, minimal create
+
+`listInboxRules` returns Graph rule objects without discarding fields, including externally created rules containing unsafe actions. `createInboxRule` accepts Graph conditions/exceptions plus a deliberately small set of safe actions. Blocked action keys (`forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete`) remain representable at the action boundary so the core action can return a typed `UNSAFE_RULE_ACTION` response instead of throwing a schema-validation exception. A `user_explicitly_approved` flag is required and must be true.
+
+### Gmail behavior
+
+The Gmail provider does not implement either optional capability. Gmail has labels rather than hierarchical folders and its filter model is not treated as equivalent to Exchange inbox rules. Core actions therefore return `NOT_SUPPORTED` consistently.
+
+### Authentication
+
+Both short and full-URL delegated scope lists add `MailboxSettings.ReadWrite`. Existing cached consent may not include the new permission, so users must re-consent.
+
+## Risks / Trade-offs
+
+- Recursive traversal can make several Graph calls; pagination guards and the 60-second cache bound repeated resolver cost.
+- Display names need not be unique; ambiguous names are rejected in favor of explicit paths.
+- Faithful rule output is intentionally looser than create input so future Graph fields are not silently lost.

--- a/openspec/changes/add-folder-and-rule-management/proposal.md
+++ b/openspec/changes/add-folder-and-rule-management/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Agents can only organize messages reactively today. Microsoft 365 users cannot create custom folders or server-side inbox rules, so recurring mail must be rediscovered and moved during every agent session instead of being handled continuously by Exchange.
+
+## What Changes
+
+- Add `list_folders`, `create_folder`, and `delete_folder` actions backed by a new `EmailFolderManager` provider capability.
+- Recursively enumerate Microsoft Graph mail folders across every page, expose computed paths, and resolve custom folder names or paths for `move_to_folder`.
+- Add a 60-second folder resolver cache that is invalidated after folder creation or deletion.
+- Protect well-known/system folders from `delete_folder`, whether they are requested by well-known name or resolved Graph id.
+- Add `list_inbox_rules`, `create_inbox_rule`, and `delete_inbox_rule` actions backed by a new `EmailRuleManager` provider capability.
+- Return faithful Graph inbox-rule data when listing rules, while limiting rule creation to safe actions and rejecting `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete` with a typed error.
+- Require callers to affirm that a human approved every `create_inbox_rule` request.
+- Add the delegated Microsoft Graph `MailboxSettings.ReadWrite` scope. Existing Microsoft accounts must re-consent before using folder and inbox-rule management.
+- Leave Gmail unchanged: Gmail uses labels and does not provide the same folder/server-rule capabilities, so these actions return the standard typed `NOT_SUPPORTED` result.
+- Update the English tool reference.
+
+## Impact
+
+- Affected specs: `email-folders`, `email-inbox-rules`, `provider-interface`
+- Affected code: `packages/email-core/src/providers/provider.ts`, `packages/email-core/src/actions/`, `packages/email-core/src/index.ts`, `packages/provider-microsoft/src/email-graph-provider.ts`, `packages/provider-microsoft/src/auth.ts`, `README.md`
+- Authentication: Microsoft delegated users must re-consent to `MailboxSettings.ReadWrite`.
+- Compatibility: existing well-known `move_to_folder` destinations remain unchanged; providers without the new optional capabilities degrade with `NOT_SUPPORTED`.

--- a/openspec/changes/add-folder-and-rule-management/specs/email-folders/spec.md
+++ b/openspec/changes/add-folder-and-rule-management/specs/email-folders/spec.md
@@ -46,3 +46,43 @@ Folder actions SHALL return a typed `NOT_SUPPORTED` result when the selected pro
 #### Scenario: Gmail folder request
 - **WHEN** `list_folders` is called for a Gmail provider
 - **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`
+
+### Requirement: Bounded Folder Traversal
+
+Recursive folder traversal MUST be bounded by a request budget shared across the entire traversal, not per collection. Exceeding the budget SHALL truncate the listing rather than fail it, and a truncated snapshot MUST NOT be cached.
+
+#### Scenario: Truncate rather than fail on a very large mailbox
+- **WHEN** enumerating folders would exceed the traversal request budget
+- **THEN** `list_folders` returns the folders discovered so far instead of erroring
+
+#### Scenario: Never cache a partial tree
+- **WHEN** a traversal was truncated
+- **THEN** the result is not written to the folder cache, so the next call retries from scratch
+
+#### Scenario: Refuse to infer absence from a truncated tree
+- **WHEN** a folder name cannot be found in a truncated snapshot
+- **THEN** the system returns `FOLDER_TRAVERSAL_LIMIT`, not `FOLDER_NOT_FOUND`
+
+### Requirement: Fresh Resolution For Write Operations
+
+Folder name/path resolution for mutating operations (message moves, folder create/delete, rule destinations) MUST NOT be answered from the cached folder snapshot. A cached path-to-id mapping can point at a folder that was renamed or relocated out from under it, silently writing to the wrong destination.
+
+#### Scenario: Re-resolve before a move
+- **WHEN** `move_to_folder` resolves a custom folder name
+- **THEN** the provider refreshes the folder tree before selecting the destination id
+
+#### Scenario: Reads still use the cache
+- **WHEN** `list_folders` is called twice within the cache TTL
+- **THEN** the second call is served from the cached snapshot
+
+### Requirement: Gated Folder Deletion
+
+`delete_folder` MUST be disabled by default and gated behind the same operator deletion policy as `delete_email`, because deleting a folder discards every message it contains. It MUST require an explicit `user_explicitly_requested_deletion` affirmation and MUST return a typed `DELETE_DISABLED` error when the policy is off or the affirmation is absent.
+
+#### Scenario: Folder deletion is disabled by default
+- **WHEN** `delete_folder` is called and the operator has not enabled deletion
+- **THEN** it returns `{success: false, error: {code: "DELETE_DISABLED", ...}}` without calling the provider
+
+#### Scenario: Folder deletion requires explicit affirmation
+- **WHEN** `delete_folder` is called with `user_explicitly_requested_deletion: false`
+- **THEN** it returns `DELETE_DISABLED` without calling the provider

--- a/openspec/changes/add-folder-and-rule-management/specs/email-folders/spec.md
+++ b/openspec/changes/add-folder-and-rule-management/specs/email-folders/spec.md
@@ -60,16 +60,29 @@ Recursive folder traversal MUST be bounded by a request budget shared across the
 - **THEN** the result is not written to the folder cache, so the next call retries from scratch
 
 #### Scenario: Refuse to infer absence from a truncated tree
-- **WHEN** a folder name cannot be found in a truncated snapshot
-- **THEN** the system returns `FOLDER_TRAVERSAL_LIMIT`, not `FOLDER_NOT_FOUND`
+- **WHEN** a folder NAME or PATH match is the only candidate in a truncated snapshot
+- **THEN** the system returns `FOLDER_TRAVERSAL_LIMIT` rather than assuming the visible match is unique
+- **AND** an exact folder-id match still resolves, because ids are globally unique
 
-### Requirement: Fresh Resolution For Write Operations
+### Requirement: Fresh Resolution For Structural And Rule Writes
 
-Folder name/path resolution for mutating operations (message moves, folder create/delete, rule destinations) MUST NOT be answered from the cached folder snapshot. A cached path-to-id mapping can point at a folder that was renamed or relocated out from under it, silently writing to the wrong destination.
+Folder name/path resolution for operations that MUTATE the folder tree (`create_folder` parent, `delete_folder` target) and for inbox-rule destinations MUST NOT be answered from the cached folder snapshot. These are low-frequency and either unrecoverable (deleting the wrong folder) or persistent (a rule that acts 24/7), so a stale path-to-id mapping is worth one fresh traversal to avoid.
 
-#### Scenario: Re-resolve before a move
-- **WHEN** `move_to_folder` resolves a custom folder name
-- **THEN** the provider refreshes the folder tree before selecting the destination id
+#### Scenario: Re-resolve before a structural mutation
+- **WHEN** `create_folder` or `delete_folder` resolves its target folder
+- **THEN** the provider refreshes the folder tree before selecting the id
+
+#### Scenario: Re-resolve a rule destination
+- **WHEN** `create_inbox_rule` resolves a custom folder destination
+- **THEN** the provider refreshes the folder tree and resolves to an opaque folder id
+
+### Requirement: Cached Resolution For Message Moves
+
+`move_to_folder` name resolution SHALL be permitted to use the cached folder snapshot rather than forcing a fresh traversal. A move does not alter the folder tree, runs in high-volume triage loops, and its worst-case staleness (a message filed into a renamed-but-valid folder within the 60s TTL) is recoverable — so forcing a fresh traversal per move, which would trip Graph throttling on the exact workload this feature targets, is the wrong trade. An exact folder id MUST still resolve without depending on a fresh traversal.
+
+#### Scenario: Repeated moves reuse the cache
+- **WHEN** several `move_to_folder` calls target custom folders within the cache TTL
+- **THEN** only the first performs a folder traversal; the rest are served from cache
 
 #### Scenario: Reads still use the cache
 - **WHEN** `list_folders` is called twice within the cache TTL

--- a/openspec/changes/add-folder-and-rule-management/specs/email-folders/spec.md
+++ b/openspec/changes/add-folder-and-rule-management/specs/email-folders/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Recursive Folder Listing
+
+The system SHALL provide a `list_folders` action that recursively lists every provider mail folder across all pages and includes a computed slash-delimited path for each folder.
+
+#### Scenario: Nested paginated folders
+- **WHEN** a Microsoft mailbox has paginated root folders and nested child folders
+- **THEN** `list_folders` returns folders from every page and hierarchy level
+- **AND** a child named `Newsletters` under `Inbox` has path `Inbox/Newsletters`
+
+### Requirement: Folder Creation
+
+The system SHALL provide a `create_folder` action that creates a custom child folder beneath a caller-selected parent folder and invalidates cached folder resolution data.
+
+#### Scenario: Create an inbox child folder
+- **WHEN** `create_folder` is called with `{display_name: "Newsletters", parent_folder: "inbox"}`
+- **THEN** the provider creates `Newsletters` beneath Inbox
+- **AND** a subsequent folder lookup observes the new folder without waiting for cache expiry
+
+### Requirement: Protected Folder Deletion
+
+The system SHALL provide a destructive `delete_folder` action for custom folders and SHALL refuse to delete well-known/system folders by alias, path, or resolved id.
+
+#### Scenario: Refuse system folder id
+- **WHEN** `delete_folder` resolves its input to the Graph id of Inbox
+- **THEN** it returns a typed `SYSTEM_FOLDER_PROTECTED` error
+- **AND** it does not call the Graph delete endpoint
+
+### Requirement: Custom Folder Moves
+
+The system SHALL resolve `move_to_folder` destinations by well-known alias, custom folder id, case-insensitive path, or unambiguous case-insensitive display name, with a 60-second cache for recursive folder data.
+
+#### Scenario: Move to custom folder path
+- **WHEN** `move_to_folder` is called with `{id: "msg123", folder: "Inbox/Newsletters"}`
+- **THEN** the Microsoft provider posts the move using the resolved Graph folder id
+
+#### Scenario: Preserve well-known move behavior
+- **WHEN** `move_to_folder` is called with `inbox`, `archive`, or `trash`
+- **THEN** the provider uses the corresponding well-known Graph destination without requiring folder traversal
+
+### Requirement: Unsupported Folder Provider
+
+Folder actions SHALL return a typed `NOT_SUPPORTED` result when the selected provider does not implement `EmailFolderManager`.
+
+#### Scenario: Gmail folder request
+- **WHEN** `list_folders` is called for a Gmail provider
+- **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`

--- a/openspec/changes/add-folder-and-rule-management/specs/email-inbox-rules/spec.md
+++ b/openspec/changes/add-folder-and-rule-management/specs/email-inbox-rules/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Faithful Inbox Rule Listing
+
+The system SHALL provide a read-only `list_inbox_rules` action that returns all fields supplied by the provider, including unsafe actions on rules created outside this system.
+
+#### Scenario: List externally created forwarding rule
+- **WHEN** Graph returns a rule containing `forwardTo`
+- **THEN** `list_inbox_rules` returns the rule and its `forwardTo` action unchanged
+
+### Requirement: Safe Approved Inbox Rule Creation
+
+The system SHALL provide `create_inbox_rule` with minimal safe actions and SHALL require the caller to affirm that a human explicitly approved the proposed rule before it is created.
+
+#### Scenario: Create approved move rule
+- **WHEN** `create_inbox_rule` receives an approved rule that moves matching mail to a custom folder
+- **THEN** the system resolves the folder and creates the rule through the provider
+
+#### Scenario: Missing human approval
+- **WHEN** `create_inbox_rule` is called without `user_explicitly_approved: true`
+- **THEN** it returns a typed `APPROVAL_REQUIRED` error without calling the provider
+
+### Requirement: Unsafe Rule Action Rejection
+
+The system MUST reject creation of any inbox rule whose actions contain `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, or `delete`, returning a typed error instead of throwing.
+
+#### Scenario: Reject forwarding action
+- **WHEN** `create_inbox_rule` receives an action containing `forwardTo`
+- **THEN** it returns `{success: false, error: {code: "UNSAFE_RULE_ACTION", ...}}`
+- **AND** it does not call the provider
+
+### Requirement: Inbox Rule Deletion
+
+The system SHALL provide a destructive `delete_inbox_rule` action that deletes a rule by id.
+
+#### Scenario: Delete a rule
+- **WHEN** `delete_inbox_rule` is called with `{id: "rule123"}`
+- **THEN** the provider deletes `rule123` from the inbox rules collection
+
+### Requirement: Unsupported Rule Provider
+
+Inbox-rule actions SHALL return a typed `NOT_SUPPORTED` result when the selected provider does not implement `EmailRuleManager`.
+
+#### Scenario: Gmail rule request
+- **WHEN** `list_inbox_rules` is called for a Gmail provider
+- **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`

--- a/openspec/changes/add-folder-and-rule-management/specs/email-inbox-rules/spec.md
+++ b/openspec/changes/add-folder-and-rule-management/specs/email-inbox-rules/spec.md
@@ -10,13 +10,15 @@ The system SHALL provide a read-only `list_inbox_rules` action that returns all 
 
 ### Requirement: Safe Approved Inbox Rule Creation
 
-The system SHALL provide `create_inbox_rule` with minimal safe actions and SHALL require the caller to affirm that a human explicitly approved the proposed rule before it is created.
+The system SHALL provide `create_inbox_rule` with minimal safe actions and SHALL require the caller to affirm intent via `user_explicitly_approved` before a rule is created.
 
-#### Scenario: Create approved move rule
-- **WHEN** `create_inbox_rule` receives an approved rule that moves matching mail to a custom folder
+This affirmation is caller attestation and audit metadata — NOT a security boundary. The flag is supplied by the calling model, which can set it without consulting a human, so it cannot enforce human approval on its own. Genuine human-in-the-loop MUST come from the MCP client's tool-approval UI. The system SHALL NOT describe this flag as human approval in user-facing text.
+
+#### Scenario: Create attested move rule
+- **WHEN** `create_inbox_rule` receives an attested rule that moves matching mail to a custom folder
 - **THEN** the system resolves the folder and creates the rule through the provider
 
-#### Scenario: Missing human approval
+#### Scenario: Missing intent affirmation
 - **WHEN** `create_inbox_rule` is called without `user_explicitly_approved: true`
 - **THEN** it returns a typed `APPROVAL_REQUIRED` error without calling the provider
 
@@ -44,3 +46,40 @@ Inbox-rule actions SHALL return a typed `NOT_SUPPORTED` result when the selected
 #### Scenario: Gmail rule request
 - **WHEN** `list_inbox_rules` is called for a Gmail provider
 - **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`
+
+### Requirement: Destructive Rule Destination Rejection
+
+The system MUST reject creation of any inbox rule whose `moveToFolder` or `copyToFolder` destination resolves to a mail-discarding folder (Deleted Items, recoverable-items dumpster, or their aliases such as `trash`/`deleted`). Filing mail into these is functionally equivalent to the blocked `delete` action and, combined with empty conditions, would discard the entire mailbox.
+
+#### Scenario: Reject a rule that files mail into Deleted Items
+- **WHEN** `create_inbox_rule` receives `{"actions": {"moveToFolder": "trash"}}`
+- **THEN** it returns `{success: false, error: {code: "UNSAFE_RULE_DESTINATION", ...}}`
+- **AND** it does not call the provider
+
+#### Scenario: Reject aliases and case variants after resolution
+- **WHEN** a destination such as `deleted`, `DeletedItems`, or ` Trash ` normalizes to the deleted-items folder
+- **THEN** the provider rejects it with `UNSAFE_RULE_DESTINATION` before issuing any write
+
+### Requirement: Provider-Layer Rule Action Enforcement
+
+Provider implementations of `EmailRuleManager.createInboxRule` MUST independently enforce the safe-action allowlist using case-normalized keys, because Microsoft Graph accepts JSON keys case-insensitively and the interface is callable without passing through the MCP action layer.
+
+#### Scenario: Reject case-variant forwarding at the provider
+- **WHEN** `createInboxRule` is called directly with an action key of `ForwardTo` or `REDIRECTTO`
+- **THEN** the provider throws `UNSAFE_RULE_ACTION` without issuing a write
+
+#### Scenario: Fail closed on unknown actions
+- **WHEN** an action key outside the safe allowlist is supplied
+- **THEN** the provider throws `UNSUPPORTED_RULE_ACTION` rather than forwarding it to Graph
+
+### Requirement: Gated Rule Deletion
+
+`delete_inbox_rule` MUST be disabled by default and gated behind the same operator deletion policy as `delete_email`, because removing a rule can silently re-expose the mailbox to filtered mail or remove an organization/anti-abuse rule. It MUST require an explicit `user_explicitly_requested_deletion` affirmation and MUST return a typed `DELETE_DISABLED` error when the policy is off or the affirmation is absent.
+
+#### Scenario: Rule deletion is disabled by default
+- **WHEN** `delete_inbox_rule` is called and the operator has not enabled deletion
+- **THEN** it returns `{success: false, error: {code: "DELETE_DISABLED", ...}}` without calling the provider
+
+#### Scenario: Rule deletion requires explicit affirmation
+- **WHEN** `delete_inbox_rule` is called with `user_explicitly_requested_deletion: false`
+- **THEN** it returns `DELETE_DISABLED` without calling the provider

--- a/openspec/changes/add-folder-and-rule-management/specs/provider-interface/spec.md
+++ b/openspec/changes/add-folder-and-rule-management/specs/provider-interface/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Optional Folder and Rule Capabilities
+
+The provider abstraction SHALL define `EmailFolderManager` and `EmailRuleManager` as optional capabilities on the combined `EmailProvider` type and SHALL advertise `folders` and `rules` in provider capability metadata.
+
+#### Scenario: Provider omits optional capabilities
+- **WHEN** a provider implements email reading and sending but not folder or rule management
+- **THEN** it remains a valid `EmailProvider`
+- **AND** folder and rule actions can detect the missing capability
+
+### Requirement: Microsoft Mailbox Settings Consent
+
+The Microsoft delegated authentication configuration SHALL request `MailboxSettings.ReadWrite` in both the short and full-URL Graph scope lists.
+
+#### Scenario: Existing user reconnects
+- **WHEN** an existing Microsoft user reconnects after this capability is introduced
+- **THEN** the consent request includes `MailboxSettings.ReadWrite`
+- **AND** user-facing documentation states that re-consent is required

--- a/openspec/changes/add-folder-and-rule-management/tasks.md
+++ b/openspec/changes/add-folder-and-rule-management/tasks.md
@@ -1,0 +1,9 @@
+- [x] Add and export `EmailFolderManager` and `EmailRuleManager` provider contracts and capability metadata.
+- [x] Add folder actions and unit tests for listing, creation, deletion, annotations, unsupported providers, and system-folder errors.
+- [x] Add inbox-rule actions and unit tests for faithful listing, safe creation, explicit approval, blocked actions, deletion, annotations, and unsupported providers.
+- [x] Implement recursive paginated Microsoft Graph folder traversal, computed paths, creation, deletion, and 60-second cached resolution.
+- [x] Resolve custom folder names and paths in `moveToFolder` while preserving well-known aliases.
+- [x] Implement Microsoft Graph inbox-rule list/create/delete endpoints.
+- [x] Add `MailboxSettings.ReadWrite` to both delegated scope lists and document re-consent.
+- [x] Export/register all six actions and update the English README tool reference.
+- [x] Run strict OpenSpec validation, focused action tests, move regression tests, build, full test suite, type-check, and lint.

--- a/packages/email-core/src/actions/folders.test.ts
+++ b/packages/email-core/src/actions/folders.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EmailProvider } from '../providers/provider.js';
+import { ProviderError } from '../providers/provider.js';
+import { MockEmailProvider } from '../testing/mock-provider.js';
+import { createFolderAction, deleteFolderAction, listFoldersAction } from './folders.js';
+import type { ActionContext } from './registry.js';
+
+function contextWith(methods: Partial<EmailProvider> = {}): ActionContext {
+  return { provider: Object.assign(new MockEmailProvider(), methods) };
+}
+
+describe('email-folders/List Folders', () => {
+  it('Scenario: List folders recursively through the provider capability', async () => {
+    const folders = [
+      { id: 'inbox-id', displayName: 'Inbox', path: 'Inbox' },
+      { id: 'news-id', displayName: 'Newsletters', path: 'Inbox/Newsletters', parentFolderId: 'inbox-id' },
+    ];
+    const listFolders = vi.fn().mockResolvedValue(folders);
+
+    const result = await listFoldersAction.run(contextWith({ listFolders }), {});
+
+    expect(result).toEqual({ success: true, folders });
+    expect(listFolders).toHaveBeenCalledOnce();
+    expect(listFoldersAction.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
+  });
+
+  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+    const result = await listFoldersAction.run(contextWith(), {});
+    expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});
+
+describe('email-folders/Create Folder', () => {
+  it('Scenario: Create an inbox child folder', async () => {
+    const folder = { id: 'news-id', displayName: 'Newsletters', path: 'Inbox/Newsletters' };
+    const createFolder = vi.fn().mockResolvedValue(folder);
+
+    const result = await createFolderAction.run(contextWith({ createFolder }), {
+      display_name: 'Newsletters',
+      parent_folder: 'inbox',
+    });
+
+    expect(result).toEqual({ success: true, folder });
+    expect(createFolder).toHaveBeenCalledWith('Newsletters', 'inbox');
+  });
+
+  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+    const result = await createFolderAction.run(contextWith(), {
+      display_name: 'Newsletters',
+      parent_folder: 'inbox',
+    });
+    expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});
+
+describe('email-folders/Delete Folder', () => {
+  it('Scenario: Delete a custom folder', async () => {
+    const deleteFolder = vi.fn().mockResolvedValue(undefined);
+    const result = await deleteFolderAction.run(contextWith({ deleteFolder }), { folder: 'Inbox/Newsletters' });
+
+    expect(result).toEqual({ success: true });
+    expect(deleteFolder).toHaveBeenCalledWith('Inbox/Newsletters');
+    expect(deleteFolderAction.annotations.destructiveHint).toBe(true);
+  });
+
+  it('Scenario: System folder protection is returned as a typed error', async () => {
+    const deleteFolder = vi.fn().mockRejectedValue(
+      new ProviderError('SYSTEM_FOLDER_PROTECTED', 'System folders cannot be deleted', 'microsoft', false),
+    );
+    const result = await deleteFolderAction.run(contextWith({ deleteFolder }), { folder: 'inbox-id' });
+
+    expect(result).toMatchObject({ success: false, error: { code: 'SYSTEM_FOLDER_PROTECTED' } });
+  });
+
+  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+    const result = await deleteFolderAction.run(contextWith(), { folder: 'Newsletters' });
+    expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});

--- a/packages/email-core/src/actions/folders.test.ts
+++ b/packages/email-core/src/actions/folders.test.ts
@@ -5,8 +5,10 @@ import { MockEmailProvider } from '../testing/mock-provider.js';
 import { createFolderAction, deleteFolderAction, listFoldersAction } from './folders.js';
 import type { ActionContext } from './registry.js';
 
-function contextWith(methods: Partial<EmailProvider> = {}): ActionContext {
-  return { provider: Object.assign(new MockEmailProvider(), methods) };
+function contextWith(methods: Partial<EmailProvider> = {}, overrides: Partial<ActionContext> = {}): ActionContext {
+  // Folder deletion is gated by the same operator policy as delete_email;
+  // default to enabled here so non-deletion scenarios stay focused.
+  return { provider: Object.assign(new MockEmailProvider(), methods), deleteEnabled: true, ...overrides };
 }
 
 describe('email-folders/List Folders', () => {
@@ -56,24 +58,46 @@ describe('email-folders/Create Folder', () => {
 describe('email-folders/Delete Folder', () => {
   it('Scenario: Delete a custom folder', async () => {
     const deleteFolder = vi.fn().mockResolvedValue(undefined);
-    const result = await deleteFolderAction.run(contextWith({ deleteFolder }), { folder: 'Inbox/Newsletters' });
+    const result = await deleteFolderAction.run(contextWith({ deleteFolder }), { folder: 'Inbox/Newsletters', user_explicitly_requested_deletion: true });
 
     expect(result).toEqual({ success: true });
     expect(deleteFolder).toHaveBeenCalledWith('Inbox/Newsletters');
     expect(deleteFolderAction.annotations.destructiveHint).toBe(true);
   });
 
+  it('Scenario: Deletion is disabled by default without operator opt-in', async () => {
+    const deleteFolder = vi.fn().mockResolvedValue(undefined);
+    const result = await deleteFolderAction.run(
+      contextWith({ deleteFolder }, { deleteEnabled: false }),
+      { folder: 'Inbox/Newsletters', user_explicitly_requested_deletion: true },
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: 'DELETE_DISABLED' } });
+    expect(deleteFolder).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Deletion requires an explicit caller affirmation', async () => {
+    const deleteFolder = vi.fn().mockResolvedValue(undefined);
+    const result = await deleteFolderAction.run(
+      contextWith({ deleteFolder }),
+      { folder: 'Inbox/Newsletters', user_explicitly_requested_deletion: false },
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: 'DELETE_DISABLED' } });
+    expect(deleteFolder).not.toHaveBeenCalled();
+  });
+
   it('Scenario: System folder protection is returned as a typed error', async () => {
     const deleteFolder = vi.fn().mockRejectedValue(
       new ProviderError('SYSTEM_FOLDER_PROTECTED', 'System folders cannot be deleted', 'microsoft', false),
     );
-    const result = await deleteFolderAction.run(contextWith({ deleteFolder }), { folder: 'inbox-id' });
+    const result = await deleteFolderAction.run(contextWith({ deleteFolder }), { folder: 'inbox-id', user_explicitly_requested_deletion: true });
 
     expect(result).toMatchObject({ success: false, error: { code: 'SYSTEM_FOLDER_PROTECTED' } });
   });
 
   it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
-    const result = await deleteFolderAction.run(contextWith(), { folder: 'Newsletters' });
+    const result = await deleteFolderAction.run(contextWith(), { folder: 'Newsletters', user_explicitly_requested_deletion: true });
     expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
   });
 });

--- a/packages/email-core/src/actions/folders.ts
+++ b/packages/email-core/src/actions/folders.ts
@@ -1,0 +1,132 @@
+// Folder management actions
+import { z } from 'zod';
+import type { EmailAction } from './registry.js';
+import { ProviderError } from '../providers/provider.js';
+
+const ActionError = z.object({
+  code: z.string(),
+  message: z.string(),
+  recoverable: z.boolean(),
+});
+
+const EmailFolderSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  path: z.string(),
+  parentFolderId: z.string().optional(),
+  childFolderCount: z.number().optional(),
+  unreadItemCount: z.number().optional(),
+  totalItemCount: z.number().optional(),
+  isHidden: z.boolean().optional(),
+}).catchall(z.unknown());
+
+const ListFoldersInput = z.object({
+  mailbox: z.string().optional(),
+});
+
+const ListFoldersOutput = z.object({
+  success: z.boolean(),
+  folders: z.array(EmailFolderSchema).optional(),
+  error: ActionError.optional(),
+});
+
+export const listFoldersAction: EmailAction<
+  z.infer<typeof ListFoldersInput>,
+  z.infer<typeof ListFoldersOutput>
+> = {
+  name: 'list_folders',
+  description: 'Recursively list mail folders, including computed paths for nested folders',
+  input: ListFoldersInput,
+  output: ListFoldersOutput,
+  annotations: { readOnlyHint: true, destructiveHint: false },
+  run: async (ctx) => {
+    if (!ctx.provider.listFolders) {
+      return notSupported('Provider does not support folder management');
+    }
+    const folders = await ctx.provider.listFolders();
+    return { success: true, folders };
+  },
+};
+
+const CreateFolderInput = z.object({
+  display_name: z.string().min(1),
+  parent_folder: z.string().min(1).optional().default('inbox'),
+  mailbox: z.string().optional(),
+});
+
+const CreateFolderOutput = z.object({
+  success: z.boolean(),
+  folder: EmailFolderSchema.optional(),
+  error: ActionError.optional(),
+});
+
+export const createFolderAction: EmailAction<
+  z.infer<typeof CreateFolderInput>,
+  z.infer<typeof CreateFolderOutput>
+> = {
+  name: 'create_folder',
+  description: 'Create a custom child mail folder (defaults to a child of Inbox)',
+  input: CreateFolderInput,
+  output: CreateFolderOutput,
+  annotations: { readOnlyHint: false, destructiveHint: false },
+  run: async (ctx, input) => {
+    if (!ctx.provider.createFolder) {
+      return notSupported('Provider does not support folder management');
+    }
+    try {
+      const folder = await ctx.provider.createFolder(input.display_name, input.parent_folder);
+      return { success: true, folder };
+    } catch (err) {
+      return providerErrorResult(err);
+    }
+  },
+};
+
+const DeleteFolderInput = z.object({
+  folder: z.string().min(1),
+  mailbox: z.string().optional(),
+});
+
+const DeleteFolderOutput = z.object({
+  success: z.boolean(),
+  error: ActionError.optional(),
+});
+
+export const deleteFolderAction: EmailAction<
+  z.infer<typeof DeleteFolderInput>,
+  z.infer<typeof DeleteFolderOutput>
+> = {
+  name: 'delete_folder',
+  description: 'Delete a custom mail folder. Well-known/system folders are protected.',
+  input: DeleteFolderInput,
+  output: DeleteFolderOutput,
+  annotations: { readOnlyHint: false, destructiveHint: true },
+  run: async (ctx, input) => {
+    if (!ctx.provider.deleteFolder) {
+      return notSupported('Provider does not support folder management');
+    }
+    try {
+      await ctx.provider.deleteFolder(input.folder);
+      return { success: true };
+    } catch (err) {
+      return providerErrorResult(err);
+    }
+  },
+};
+
+function notSupported(message: string): { success: false; error: { code: string; message: string; recoverable: boolean } } {
+  return {
+    success: false,
+    error: { code: 'NOT_SUPPORTED', message, recoverable: false },
+  };
+}
+
+function providerErrorResult(err: unknown): { success: false; error: { code: string; message: string; recoverable: boolean } } {
+  if (err instanceof ProviderError) {
+    return {
+      success: false,
+      error: { code: err.code, message: err.message, recoverable: err.recoverable },
+    };
+  }
+  throw err;
+}

--- a/packages/email-core/src/actions/folders.ts
+++ b/packages/email-core/src/actions/folders.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { ProviderError } from '../providers/provider.js';
+import { checkDeletePolicy } from '../security/receive-allowlist.js';
 
 const ActionError = z.object({
   code: z.string(),
@@ -84,6 +85,7 @@ export const createFolderAction: EmailAction<
 
 const DeleteFolderInput = z.object({
   folder: z.string().min(1),
+  user_explicitly_requested_deletion: z.boolean(),
   mailbox: z.string().optional(),
 });
 
@@ -97,11 +99,21 @@ export const deleteFolderAction: EmailAction<
   z.infer<typeof DeleteFolderOutput>
 > = {
   name: 'delete_folder',
-  description: 'Delete a custom mail folder. Well-known/system folders are protected.',
+  description: 'Delete a custom mail folder, including any mail it contains (disabled by default, requires explicit configuration). Well-known/system folders are protected.',
   input: DeleteFolderInput,
   output: DeleteFolderOutput,
   annotations: { readOnlyHint: false, destructiveHint: true },
   run: async (ctx, input) => {
+    // Gated by the same operator policy as delete_email: deleting a folder can
+    // discard every message inside it, so it must not be an ungated capability.
+    const policyError = checkDeletePolicy(
+      ctx.deleteEnabled === true ? { enabled: true, hardDeleteAllowed: ctx.hardDeleteAllowed === true } : undefined,
+      input.user_explicitly_requested_deletion,
+      false,
+    );
+    if (policyError) {
+      return { success: false, error: { code: 'DELETE_DISABLED', message: policyError, recoverable: false } };
+    }
     if (!ctx.provider.deleteFolder) {
       return notSupported('Provider does not support folder management');
     }

--- a/packages/email-core/src/actions/rules.test.ts
+++ b/packages/email-core/src/actions/rules.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { EmailProvider } from '../providers/provider.js';
+import { MockEmailProvider } from '../testing/mock-provider.js';
+import { createInboxRuleAction, deleteInboxRuleAction, listInboxRulesAction } from './rules.js';
+import type { ActionContext } from './registry.js';
+
+function contextWith(methods: Partial<EmailProvider> = {}): ActionContext {
+  return { provider: Object.assign(new MockEmailProvider(), methods) };
+}
+
+describe('email-inbox-rules/List Inbox Rules', () => {
+  it('Scenario: Faithfully list an externally created forwarding rule', async () => {
+    const rules = [{
+      id: 'rule-1',
+      displayName: 'External forwarding rule',
+      actions: { forwardTo: [{ emailAddress: { address: 'external@example.com' } }] },
+      futureGraphField: { retained: true },
+    }];
+    const listInboxRules = vi.fn().mockResolvedValue(rules);
+
+    const result = await listInboxRulesAction.run(contextWith({ listInboxRules }), {});
+
+    expect(result).toEqual({ success: true, rules });
+    expect(listInboxRulesAction.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
+  });
+
+  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+    const result = await listInboxRulesAction.run(contextWith(), {});
+    expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});
+
+describe('email-inbox-rules/Create Inbox Rule', () => {
+  it('Scenario: Create an approved safe move rule', async () => {
+    const rule = { id: 'rule-1', displayName: 'GitHub', actions: { moveToFolder: 'Newsletters' } };
+    const createInboxRule = vi.fn().mockResolvedValue(rule);
+
+    const result = await createInboxRuleAction.run(contextWith({ createInboxRule }), {
+      display_name: 'GitHub',
+      is_enabled: true,
+      conditions: { senderContains: ['github.com'] },
+      actions: { moveToFolder: 'Newsletters' },
+      user_explicitly_approved: true,
+    });
+
+    expect(result).toEqual({ success: true, rule });
+    expect(createInboxRule).toHaveBeenCalledWith({
+      displayName: 'GitHub',
+      sequence: undefined,
+      isEnabled: true,
+      conditions: { senderContains: ['github.com'] },
+      exceptions: undefined,
+      actions: { moveToFolder: 'Newsletters' },
+    });
+  });
+
+  it('Scenario: Missing human approval returns APPROVAL_REQUIRED', async () => {
+    const createInboxRule = vi.fn();
+    const result = await createInboxRuleAction.run(contextWith({ createInboxRule }), {
+      display_name: 'GitHub',
+      is_enabled: true,
+      conditions: { senderContains: ['github.com'] },
+      actions: { moveToFolder: 'Newsletters' },
+      user_explicitly_approved: false,
+    });
+
+    expect(result).toMatchObject({ success: false, error: { code: 'APPROVAL_REQUIRED' } });
+    expect(createInboxRule).not.toHaveBeenCalled();
+  });
+
+  it.each(['forwardTo', 'forwardAsAttachmentTo', 'redirectTo', 'delete']) (
+    'Scenario: Block unsafe %s action with a typed error',
+    async (blockedAction) => {
+      const createInboxRule = vi.fn();
+      const result = await createInboxRuleAction.run(contextWith({ createInboxRule }), {
+        display_name: 'Unsafe',
+        is_enabled: true,
+        conditions: { subjectContains: ['invoice'] },
+        actions: { [blockedAction]: blockedAction === 'delete' ? true : [] },
+        user_explicitly_approved: true,
+      });
+
+      expect(result).toMatchObject({ success: false, error: { code: 'UNSAFE_RULE_ACTION' } });
+      expect(createInboxRule).not.toHaveBeenCalled();
+    },
+  );
+
+  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+    const result = await createInboxRuleAction.run(contextWith(), {
+      display_name: 'GitHub',
+      is_enabled: true,
+      conditions: { senderContains: ['github.com'] },
+      actions: { moveToFolder: 'Newsletters' },
+      user_explicitly_approved: true,
+    });
+    expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});
+
+describe('email-inbox-rules/Delete Inbox Rule', () => {
+  it('Scenario: Delete a rule', async () => {
+    const deleteInboxRule = vi.fn().mockResolvedValue(undefined);
+    const result = await deleteInboxRuleAction.run(contextWith({ deleteInboxRule }), { id: 'rule-1' });
+
+    expect(result).toEqual({ success: true });
+    expect(deleteInboxRule).toHaveBeenCalledWith('rule-1');
+    expect(deleteInboxRuleAction.annotations.destructiveHint).toBe(true);
+  });
+
+  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+    const result = await deleteInboxRuleAction.run(contextWith(), { id: 'rule-1' });
+    expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});

--- a/packages/email-core/src/actions/rules.test.ts
+++ b/packages/email-core/src/actions/rules.test.ts
@@ -4,8 +4,10 @@ import { MockEmailProvider } from '../testing/mock-provider.js';
 import { createInboxRuleAction, deleteInboxRuleAction, listInboxRulesAction } from './rules.js';
 import type { ActionContext } from './registry.js';
 
-function contextWith(methods: Partial<EmailProvider> = {}): ActionContext {
-  return { provider: Object.assign(new MockEmailProvider(), methods) };
+function contextWith(methods: Partial<EmailProvider> = {}, overrides: Partial<ActionContext> = {}): ActionContext {
+  // Rule deletion is gated by the same operator policy as delete_email;
+  // default to enabled here so non-deletion scenarios stay focused.
+  return { provider: Object.assign(new MockEmailProvider(), methods), deleteEnabled: true, ...overrides };
 }
 
 describe('email-inbox-rules/List Inbox Rules', () => {
@@ -100,15 +102,75 @@ describe('email-inbox-rules/Create Inbox Rule', () => {
 describe('email-inbox-rules/Delete Inbox Rule', () => {
   it('Scenario: Delete a rule', async () => {
     const deleteInboxRule = vi.fn().mockResolvedValue(undefined);
-    const result = await deleteInboxRuleAction.run(contextWith({ deleteInboxRule }), { id: 'rule-1' });
+    const result = await deleteInboxRuleAction.run(contextWith({ deleteInboxRule }), { id: 'rule-1', user_explicitly_requested_deletion: true });
 
     expect(result).toEqual({ success: true });
     expect(deleteInboxRule).toHaveBeenCalledWith('rule-1');
     expect(deleteInboxRuleAction.annotations.destructiveHint).toBe(true);
   });
 
+  it('Scenario: Deletion is disabled by default without operator opt-in', async () => {
+    const deleteInboxRule = vi.fn().mockResolvedValue(undefined);
+    const result = await deleteInboxRuleAction.run(
+      contextWith({ deleteInboxRule }, { deleteEnabled: false }),
+      { id: 'rule-1', user_explicitly_requested_deletion: true },
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: 'DELETE_DISABLED' } });
+    expect(deleteInboxRule).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Deletion requires an explicit caller affirmation', async () => {
+    const deleteInboxRule = vi.fn().mockResolvedValue(undefined);
+    const result = await deleteInboxRuleAction.run(
+      contextWith({ deleteInboxRule }),
+      { id: 'rule-1', user_explicitly_requested_deletion: false },
+    );
+
+    expect(result).toMatchObject({ success: false, error: { code: 'DELETE_DISABLED' } });
+    expect(deleteInboxRule).not.toHaveBeenCalled();
+  });
+
   it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
-    const result = await deleteInboxRuleAction.run(contextWith(), { id: 'rule-1' });
+    const result = await deleteInboxRuleAction.run(contextWith(), { id: 'rule-1', user_explicitly_requested_deletion: true });
     expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
+  });
+});
+
+describe('create_inbox_rule destructive destinations (PR #106 review)', () => {
+  it('Scenario: Rejects moveToFolder destinations that discard mail', async () => {
+    const createInboxRule = vi.fn();
+    const ctx = { provider: { createInboxRule } } as never;
+
+    for (const destination of ['trash', 'Deleted', 'DELETEDITEMS', ' trash ']) {
+      const result = await createInboxRuleAction.run(ctx, {
+        display_name: 'Discard everything',
+        conditions: {},
+        actions: { moveToFolder: destination },
+        is_enabled: true,
+        user_explicitly_approved: true,
+      });
+      expect(result).toMatchObject({
+        success: false,
+        error: { code: 'UNSAFE_RULE_DESTINATION' },
+      });
+    }
+    expect(createInboxRule).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Still allows moves to ordinary custom folders', async () => {
+    const createInboxRule = vi.fn().mockResolvedValue({ id: 'rule-1', displayName: 'GitHub' });
+    const ctx = { provider: { createInboxRule } } as never;
+
+    const result = await createInboxRuleAction.run(ctx, {
+      display_name: 'GitHub',
+      conditions: { senderContains: ['github.com'] },
+      actions: { moveToFolder: 'Inbox/Notifications' },
+      is_enabled: true,
+      user_explicitly_approved: true,
+    });
+
+    expect(result).toMatchObject({ success: true });
+    expect(createInboxRule).toHaveBeenCalled();
   });
 });

--- a/packages/email-core/src/actions/rules.ts
+++ b/packages/email-core/src/actions/rules.ts
@@ -77,13 +77,21 @@ const CreateInboxRuleOutput = z.object({
 
 const BLOCKED_ACTIONS = ['forwardTo', 'forwardAsAttachmentTo', 'redirectTo', 'delete'] as const;
 // Destinations that discard mail — filing into these is equivalent to `delete`.
-// Covers the user-facing aliases providers map onto the deleted-items folder.
+// Covers the user-facing aliases plus the system-managed non-user folders the
+// provider also rejects (kept in sync with DESTRUCTIVE_RULE_DESTINATIONS in the
+// Microsoft provider). This is a fast, provider-independent reject; the provider
+// re-checks by resolved id in case a custom folder name maps onto one of these.
 const DESTRUCTIVE_DESTINATIONS = new Set([
   'trash',
   'deleted',
   'deleteditems',
   'deleted items',
   'recoverableitemsdeletions',
+  'scheduled',
+  'serverfailures',
+  'localfailures',
+  'syncissues',
+  'conflicts',
 ]);
 const SAFE_ACTIONS = new Set([
   'assignCategories',
@@ -137,8 +145,11 @@ export const createInboxRuleAction: EmailAction<
     // aliases; this is the fast, provider-independent rejection.
     for (const folderAction of ['moveToFolder', 'copyToFolder'] as const) {
       const destination = input.actions[folderAction];
+      // Normalize the same way the provider resolves (strip surrounding slashes
+      // + lowercase), so alias tricks like `/trash/` don't slip past this
+      // fast-path pre-filter. The provider re-checks the fully resolved folder.
       if (typeof destination === 'string'
-        && DESTRUCTIVE_DESTINATIONS.has(destination.trim().toLowerCase())) {
+        && DESTRUCTIVE_DESTINATIONS.has(destination.trim().replace(/^\/+|\/+$/g, '').toLowerCase())) {
         return actionError(
           'UNSAFE_RULE_DESTINATION',
           `Inbox rule destination '${destination}' discards mail and is blocked for security`,

--- a/packages/email-core/src/actions/rules.ts
+++ b/packages/email-core/src/actions/rules.ts
@@ -2,6 +2,7 @@
 import { z } from 'zod';
 import type { EmailAction } from './registry.js';
 import { ProviderError } from '../providers/provider.js';
+import { checkDeletePolicy } from '../security/receive-allowlist.js';
 
 const ActionError = z.object({
   code: z.string(),
@@ -60,6 +61,10 @@ const CreateInboxRuleInput = z.object({
   conditions: JsonObject,
   exceptions: JsonObject.optional(),
   actions: JsonObject,
+  // NOTE: this is an intent affirmation, NOT a security boundary. The calling
+  // model supplies it, so it cannot enforce human approval on its own — it
+  // forces a deliberate second step and leaves an audit signal. Real
+  // human-in-the-loop must come from the MCP client's tool-approval UI.
   user_explicitly_approved: z.boolean().optional().default(false),
   mailbox: z.string().optional(),
 });
@@ -71,6 +76,15 @@ const CreateInboxRuleOutput = z.object({
 });
 
 const BLOCKED_ACTIONS = ['forwardTo', 'forwardAsAttachmentTo', 'redirectTo', 'delete'] as const;
+// Destinations that discard mail — filing into these is equivalent to `delete`.
+// Covers the user-facing aliases providers map onto the deleted-items folder.
+const DESTRUCTIVE_DESTINATIONS = new Set([
+  'trash',
+  'deleted',
+  'deleteditems',
+  'deleted items',
+  'recoverableitemsdeletions',
+]);
 const SAFE_ACTIONS = new Set([
   'assignCategories',
   'copyToFolder',
@@ -85,7 +99,7 @@ export const createInboxRuleAction: EmailAction<
   z.infer<typeof CreateInboxRuleOutput>
 > = {
   name: 'create_inbox_rule',
-  description: 'Create a human-approved server-side inbox rule using safe actions only; forwarding, redirection, and deletion are blocked',
+  description: 'Create a persistent server-side inbox rule using safe actions only; forwarding, redirection, and deletion are blocked. Confirm with the user before calling — this creates a rule that keeps acting on the mailbox 24/7 after the session ends.',
   input: CreateInboxRuleInput,
   output: CreateInboxRuleOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -93,7 +107,7 @@ export const createInboxRuleAction: EmailAction<
     if (!input.user_explicitly_approved) {
       return actionError(
         'APPROVAL_REQUIRED',
-        'A human must explicitly approve the inbox rule before creation',
+        'Set user_explicitly_approved once the user has confirmed this specific rule',
       );
     }
 
@@ -115,6 +129,21 @@ export const createInboxRuleAction: EmailAction<
 
     if (Object.keys(input.actions).length === 0) {
       return actionError('MISSING_RULE_ACTION', 'At least one safe inbox rule action is required');
+    }
+
+    // A rule filing mail into Deleted Items is the blocked `delete` action
+    // wearing a `moveToFolder` costume — and with empty conditions it would
+    // discard the whole mailbox. Providers re-check this after resolving
+    // aliases; this is the fast, provider-independent rejection.
+    for (const folderAction of ['moveToFolder', 'copyToFolder'] as const) {
+      const destination = input.actions[folderAction];
+      if (typeof destination === 'string'
+        && DESTRUCTIVE_DESTINATIONS.has(destination.trim().toLowerCase())) {
+        return actionError(
+          'UNSAFE_RULE_DESTINATION',
+          `Inbox rule destination '${destination}' discards mail and is blocked for security`,
+        );
+      }
     }
 
     if (!ctx.provider.createInboxRule) {
@@ -139,6 +168,7 @@ export const createInboxRuleAction: EmailAction<
 
 const DeleteInboxRuleInput = z.object({
   id: z.string().min(1),
+  user_explicitly_requested_deletion: z.boolean(),
   mailbox: z.string().optional(),
 });
 
@@ -152,11 +182,22 @@ export const deleteInboxRuleAction: EmailAction<
   z.infer<typeof DeleteInboxRuleOutput>
 > = {
   name: 'delete_inbox_rule',
-  description: 'Delete a server-side inbox rule by id',
+  description: 'Delete a server-side inbox rule by id (disabled by default, requires explicit configuration). Removing a rule can silently re-expose the mailbox to mail the rule was filtering.',
   input: DeleteInboxRuleInput,
   output: DeleteInboxRuleOutput,
   annotations: { readOnlyHint: false, destructiveHint: true },
   run: async (ctx, input) => {
+    // Same operator gate as delete_email / delete_folder: deleting a rule is a
+    // destructive, security-relevant change (it can remove an organization or
+    // anti-abuse rule), so it must not be an ungated capability.
+    const policyError = checkDeletePolicy(
+      ctx.deleteEnabled === true ? { enabled: true, hardDeleteAllowed: ctx.hardDeleteAllowed === true } : undefined,
+      input.user_explicitly_requested_deletion,
+      false,
+    );
+    if (policyError) {
+      return actionError('DELETE_DISABLED', policyError);
+    }
     if (!ctx.provider.deleteInboxRule) {
       return notSupported();
     }

--- a/packages/email-core/src/actions/rules.ts
+++ b/packages/email-core/src/actions/rules.ts
@@ -1,0 +1,185 @@
+// Server-side inbox rule actions
+import { z } from 'zod';
+import type { EmailAction } from './registry.js';
+import { ProviderError } from '../providers/provider.js';
+
+const ActionError = z.object({
+  code: z.string(),
+  message: z.string(),
+  recoverable: z.boolean(),
+});
+
+const JsonObject = z.object({}).catchall(z.unknown());
+
+// Listing is deliberately permissive: Graph can add fields and can return
+// unsafe actions on rules created outside this tool. Do not strip either.
+const InboxRuleSchema = z.object({
+  id: z.string().optional(),
+  displayName: z.string().optional(),
+  sequence: z.number().optional(),
+  isEnabled: z.boolean().optional(),
+  hasError: z.boolean().optional(),
+  isReadOnly: z.boolean().optional(),
+  conditions: JsonObject.optional(),
+  exceptions: JsonObject.optional(),
+  actions: JsonObject.optional(),
+}).catchall(z.unknown());
+
+const ListInboxRulesInput = z.object({
+  mailbox: z.string().optional(),
+});
+
+const ListInboxRulesOutput = z.object({
+  success: z.boolean(),
+  rules: z.array(InboxRuleSchema).optional(),
+  error: ActionError.optional(),
+});
+
+export const listInboxRulesAction: EmailAction<
+  z.infer<typeof ListInboxRulesInput>,
+  z.infer<typeof ListInboxRulesOutput>
+> = {
+  name: 'list_inbox_rules',
+  description: 'List server-side inbox rules with all fields reported by the provider',
+  input: ListInboxRulesInput,
+  output: ListInboxRulesOutput,
+  annotations: { readOnlyHint: true, destructiveHint: false },
+  run: async (ctx) => {
+    if (!ctx.provider.listInboxRules) {
+      return notSupported();
+    }
+    const rules = await ctx.provider.listInboxRules();
+    return { success: true, rules };
+  },
+};
+
+const CreateInboxRuleInput = z.object({
+  display_name: z.string().min(1),
+  sequence: z.number().int().nonnegative().optional(),
+  is_enabled: z.boolean().optional().default(true),
+  conditions: JsonObject,
+  exceptions: JsonObject.optional(),
+  actions: JsonObject,
+  user_explicitly_approved: z.boolean().optional().default(false),
+  mailbox: z.string().optional(),
+});
+
+const CreateInboxRuleOutput = z.object({
+  success: z.boolean(),
+  rule: InboxRuleSchema.optional(),
+  error: ActionError.optional(),
+});
+
+const BLOCKED_ACTIONS = ['forwardTo', 'forwardAsAttachmentTo', 'redirectTo', 'delete'] as const;
+const SAFE_ACTIONS = new Set([
+  'assignCategories',
+  'copyToFolder',
+  'markAsRead',
+  'markImportance',
+  'moveToFolder',
+  'stopProcessingRules',
+]);
+
+export const createInboxRuleAction: EmailAction<
+  z.infer<typeof CreateInboxRuleInput>,
+  z.infer<typeof CreateInboxRuleOutput>
+> = {
+  name: 'create_inbox_rule',
+  description: 'Create a human-approved server-side inbox rule using safe actions only; forwarding, redirection, and deletion are blocked',
+  input: CreateInboxRuleInput,
+  output: CreateInboxRuleOutput,
+  annotations: { readOnlyHint: false, destructiveHint: false },
+  run: async (ctx, input) => {
+    if (!input.user_explicitly_approved) {
+      return actionError(
+        'APPROVAL_REQUIRED',
+        'A human must explicitly approve the inbox rule before creation',
+      );
+    }
+
+    const blocked = BLOCKED_ACTIONS.find(action => Object.hasOwn(input.actions, action));
+    if (blocked) {
+      return actionError(
+        'UNSAFE_RULE_ACTION',
+        `Inbox rule action '${blocked}' is blocked for security`,
+      );
+    }
+
+    const unsupported = Object.keys(input.actions).find(action => !SAFE_ACTIONS.has(action));
+    if (unsupported) {
+      return actionError(
+        'UNSUPPORTED_RULE_ACTION',
+        `Inbox rule action '${unsupported}' is not supported for creation`,
+      );
+    }
+
+    if (Object.keys(input.actions).length === 0) {
+      return actionError('MISSING_RULE_ACTION', 'At least one safe inbox rule action is required');
+    }
+
+    if (!ctx.provider.createInboxRule) {
+      return notSupported();
+    }
+
+    try {
+      const rule = await ctx.provider.createInboxRule({
+        displayName: input.display_name,
+        sequence: input.sequence,
+        isEnabled: input.is_enabled,
+        conditions: input.conditions,
+        exceptions: input.exceptions,
+        actions: input.actions,
+      });
+      return { success: true, rule };
+    } catch (err) {
+      return providerErrorResult(err);
+    }
+  },
+};
+
+const DeleteInboxRuleInput = z.object({
+  id: z.string().min(1),
+  mailbox: z.string().optional(),
+});
+
+const DeleteInboxRuleOutput = z.object({
+  success: z.boolean(),
+  error: ActionError.optional(),
+});
+
+export const deleteInboxRuleAction: EmailAction<
+  z.infer<typeof DeleteInboxRuleInput>,
+  z.infer<typeof DeleteInboxRuleOutput>
+> = {
+  name: 'delete_inbox_rule',
+  description: 'Delete a server-side inbox rule by id',
+  input: DeleteInboxRuleInput,
+  output: DeleteInboxRuleOutput,
+  annotations: { readOnlyHint: false, destructiveHint: true },
+  run: async (ctx, input) => {
+    if (!ctx.provider.deleteInboxRule) {
+      return notSupported();
+    }
+    try {
+      await ctx.provider.deleteInboxRule(input.id);
+      return { success: true };
+    } catch (err) {
+      return providerErrorResult(err);
+    }
+  },
+};
+
+function notSupported(): { success: false; error: { code: string; message: string; recoverable: boolean } } {
+  return actionError('NOT_SUPPORTED', 'Provider does not support server-side inbox rules');
+}
+
+function actionError(code: string, message: string): { success: false; error: { code: string; message: string; recoverable: boolean } } {
+  return { success: false, error: { code, message, recoverable: false } };
+}
+
+function providerErrorResult(err: unknown): { success: false; error: { code: string; message: string; recoverable: boolean } } {
+  if (err instanceof ProviderError) {
+    return actionError(err.code, err.message);
+  }
+  throw err;
+}

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -20,11 +20,16 @@ export type {
   EmailSubscriber,
   EmailCategorizer,
   EmailAttachmentHandler,
+  EmailFolder,
+  EmailFolderManager,
+  InboxRule,
+  CreateInboxRule,
+  EmailRuleManager,
   DownloadedAttachment,
   EmailProvider,
   AuthManager,
 } from './providers/provider.js';
-export { AttachmentNotSupportedError, AttachmentNotFoundError } from './providers/provider.js';
+export { ProviderError, AttachmentNotSupportedError, AttachmentNotFoundError } from './providers/provider.js';
 export {
   isAllowedSender,
   loadReceiveAllowlist,
@@ -54,6 +59,16 @@ export { getThreadAction } from './actions/conversation.js';
 export { listAttachmentsAction, downloadAttachmentAction } from './actions/attachments.js';
 export { labelEmailAction, flagEmailAction, markReadAction, deleteEmailAction } from './actions/label.js';
 export { moveToFolderAction } from './actions/move.js';
+export {
+  listFoldersAction, // list_folders
+  createFolderAction, // create_folder
+  deleteFolderAction, // delete_folder
+} from './actions/folders.js';
+export {
+  listInboxRulesAction, // list_inbox_rules
+  createInboxRuleAction, // create_inbox_rule
+  deleteInboxRuleAction, // delete_inbox_rule
+} from './actions/rules.js';
 export { parseFrontmatter } from './content/frontmatter.js';
 export type { FrontmatterFields } from './content/frontmatter.js';
 export { resolveBodyFile, truncateBody, BODY_SIZE_LIMIT } from './content/body-loader.js';

--- a/packages/email-core/src/providers/provider.ts
+++ b/packages/email-core/src/providers/provider.ts
@@ -53,8 +53,60 @@ export interface EmailAttachmentHandler {
   downloadAttachment(messageId: string, attachmentId: string): Promise<DownloadedAttachment>;
 }
 
+export interface EmailFolder {
+  id: string;
+  displayName: string;
+  path: string;
+  parentFolderId?: string;
+  childFolderCount?: number;
+  unreadItemCount?: number;
+  totalItemCount?: number;
+  isHidden?: boolean;
+  [key: string]: unknown;
+}
+
+export interface EmailFolderManager {
+  listFolders(): Promise<EmailFolder[]>;
+  createFolder(displayName: string, parentFolder?: string): Promise<EmailFolder>;
+  deleteFolder(folder: string): Promise<void>;
+}
+
+export interface InboxRule {
+  id?: string;
+  displayName?: string;
+  sequence?: number;
+  isEnabled?: boolean;
+  hasError?: boolean;
+  isReadOnly?: boolean;
+  conditions?: Record<string, unknown>;
+  exceptions?: Record<string, unknown>;
+  actions?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface CreateInboxRule {
+  displayName: string;
+  sequence?: number;
+  isEnabled?: boolean;
+  conditions: Record<string, unknown>;
+  exceptions?: Record<string, unknown>;
+  actions: Record<string, unknown>;
+}
+
+export interface EmailRuleManager {
+  listInboxRules(): Promise<InboxRule[]>;
+  createInboxRule(rule: CreateInboxRule): Promise<InboxRule>;
+  deleteInboxRule(id: string): Promise<void>;
+}
+
 // Combined provider type — providers implement what they support
-export type EmailProvider = EmailReader & EmailSender & Partial<EmailSubscriber> & Partial<EmailCategorizer> & Partial<EmailAttachmentHandler>;
+export type EmailProvider = EmailReader
+  & EmailSender
+  & Partial<EmailSubscriber>
+  & Partial<EmailCategorizer>
+  & Partial<EmailAttachmentHandler>
+  & Partial<EmailFolderManager>
+  & Partial<EmailRuleManager>;
 
 // Provider metadata for registration
 export interface ProviderInfo {
@@ -65,7 +117,7 @@ export interface ProviderInfo {
   // support both. Note: no provider currently exports a ProviderInfo value —
   // this is a forward-compat type surface; wiring a real metadata surface
   // that declares these is a follow-up.
-  capabilities: ('read' | 'send' | 'subscribe' | 'categorize' | 'attachments' | 'outbound-attachments')[];
+  capabilities: ('read' | 'send' | 'subscribe' | 'categorize' | 'attachments' | 'outbound-attachments' | 'folders' | 'rules')[];
 }
 
 // Error normalization

--- a/packages/email-mcp/src/integration.test.ts
+++ b/packages/email-mcp/src/integration.test.ts
@@ -23,6 +23,12 @@ describe('provider-interface/Dynamic discovery — dist exports', () => {
     expect(emailCore.markReadAction).toBeDefined();
     expect(emailCore.moveToFolderAction).toBeDefined();
     expect(emailCore.deleteEmailAction).toBeDefined();
+    expect(emailCore.listFoldersAction).toBeDefined();
+    expect(emailCore.createFolderAction).toBeDefined();
+    expect(emailCore.deleteFolderAction).toBeDefined();
+    expect(emailCore.listInboxRulesAction).toBeDefined();
+    expect(emailCore.createInboxRuleAction).toBeDefined();
+    expect(emailCore.deleteInboxRuleAction).toBeDefined();
   });
 
   it('Scenario: Microsoft provider exports all public symbols', async () => {

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -293,8 +293,8 @@ describe('mcp-transport/Lazy Provider State', () => {
     // No init has been triggered — state is still 'pending'.
     const actions = await buildLazyActions(state, noAllowlist);
 
-    // 4 custom tools + 13 email-core actions = 17 tools, no auth performed.
-    expect(actions.length).toBe(17);
+    // 4 custom tools + 19 email-core actions = 23 tools, no auth performed.
+    expect(actions.length).toBe(23);
     expect(state.status).toBe('pending');
     expect(state.initPromise).toBeNull();
     expect(state.provider).toBeNull();
@@ -305,6 +305,14 @@ describe('mcp-transport/Lazy Provider State', () => {
     expect(tools.map(t => t.name)).toContain('list_attachments');
     expect(tools.map(t => t.name)).toContain('download_attachment');
     expect(tools.map(t => t.name)).toContain('send_email');
+    expect(tools.map(t => t.name)).toEqual(expect.arrayContaining([
+      'list_folders',
+      'create_folder',
+      'delete_folder',
+      'list_inbox_rules',
+      'create_inbox_rule',
+      'delete_inbox_rule',
+    ]));
   });
 
   it('Scenario: get_mailbox_status is non-blocking during pending/connecting', async () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -680,6 +680,12 @@ export async function buildLazyActions(
     markReadAction,
     moveToFolderAction,
     deleteEmailAction,
+    listFoldersAction,
+    createFolderAction,
+    deleteFolderAction,
+    listInboxRulesAction,
+    createInboxRuleAction,
+    deleteInboxRuleAction,
   } = await import('@usejunior/email-core');
 
   // Structured "provider unavailable" error — matches the shape of email-core errors.
@@ -975,6 +981,12 @@ export async function buildLazyActions(
     wrapAction(markReadAction),
     wrapAction(moveToFolderAction),
     wrapAction(deleteEmailAction),
+    wrapAction(listFoldersAction),
+    wrapAction(createFolderAction),
+    wrapAction(deleteFolderAction),
+    wrapAction(listInboxRulesAction),
+    wrapAction(createInboxRuleAction),
+    wrapAction(deleteInboxRuleAction),
   ];
 }
 

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { DelegatedAuthManager, ClientCredentialsAuthManager, toFilesystemSafeKey, listConfiguredMailboxesWithMetadata, getConfigDir, isAuthError } from './auth.js';
+import { DelegatedAuthManager, ClientCredentialsAuthManager, toFilesystemSafeKey, listConfiguredMailboxesWithMetadata, getConfigDir, GRAPH_SCOPES, GRAPH_SCOPES_FULL, isAuthError } from './auth.js';
 import { GraphApiError } from './email-graph-provider.js';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
@@ -58,6 +58,13 @@ vi.mock('@azure/identity', () => {
 vi.mock('@azure/identity-cache-persistence', () => ({
   cachePersistencePlugin: {},
 }));
+
+describe('provider-interface/Microsoft Mailbox Settings Consent', () => {
+  it('Scenario: Both delegated scope lists request MailboxSettings.ReadWrite', () => {
+    expect(GRAPH_SCOPES).toContain('MailboxSettings.ReadWrite');
+    expect(GRAPH_SCOPES_FULL).toContain('https://graph.microsoft.com/MailboxSettings.ReadWrite');
+  });
+});
 
 describe('provider-microsoft/Delegated OAuth Authentication', () => {
   let savedAgentEmailHome: string | undefined;

--- a/packages/provider-microsoft/src/auth.ts
+++ b/packages/provider-microsoft/src/auth.ts
@@ -11,12 +11,13 @@ import { GraphApiError } from './email-graph-provider.js';
 // Enable MSAL persistent cache (OS keychain on macOS, DPAPI on Windows, libsecret on Linux)
 useIdentityPlugin(cachePersistencePlugin);
 
-export const GRAPH_SCOPES = ['Mail.Read', 'Mail.ReadWrite', 'Mail.Send', 'User.Read', 'offline_access'];
+export const GRAPH_SCOPES = ['Mail.Read', 'Mail.ReadWrite', 'Mail.Send', 'MailboxSettings.ReadWrite', 'User.Read', 'offline_access'];
 // Full URL scopes for device code flow (ensures correct audience in the token)
 export const GRAPH_SCOPES_FULL = [
   'https://graph.microsoft.com/Mail.Read',
   'https://graph.microsoft.com/Mail.ReadWrite',
   'https://graph.microsoft.com/Mail.Send',
+  'https://graph.microsoft.com/MailboxSettings.ReadWrite',
   'https://graph.microsoft.com/User.Read',
   'offline_access',
 ];

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -1125,6 +1125,12 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     // exist beyond the request budget), so refuse to guess — returning a
     // visible-but-maybe-not-unique match could misroute a write. Ids only.
     if (truncated) {
+      // The exact id might simply lie beyond the truncated prefix. An id is
+      // globally unique, so a direct GET is a safe, O(1) way to honor
+      // "exact ids resolve without depending on a full traversal".
+      const directId = await this.tryResolveFolderById(trimmed);
+      if (directId) return directId;
+
       throw new ProviderError(
         'FOLDER_TRAVERSAL_LIMIT',
         `Folder '${folder}' could not be uniquely resolved: this mailbox has more folders than a single traversal enumerates (${MAX_FOLDER_REQUESTS_PER_SNAPSHOT} requests). Specify the folder by id.`,
@@ -1158,6 +1164,25 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     }
 
     throw new ProviderError('FOLDER_NOT_FOUND', `Folder '${folder}' was not found`, 'microsoft', false);
+  }
+
+  /**
+   * Verify a string is a real folder id via a direct GET. Returns the id on a
+   * 200, undefined on 404 (not an id / no such folder). Used only as a fallback
+   * when the tree was truncated, so a valid id past the budget still resolves.
+   */
+  private async tryResolveFolderById(id: string): Promise<string | undefined> {
+    try {
+      const folder = await this.client.get(
+        `${this.basePath}/mailFolders/${encodeGraphPathId(id)}?$select=id`,
+      ) as unknown as GraphMailFolder;
+      return folder.id ?? undefined;
+    } catch (err) {
+      if (err instanceof GraphApiError && (err.status === 404 || err.status === 400)) {
+        return undefined;
+      }
+      throw err;
+    }
   }
 
   /**

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -138,6 +138,40 @@ const SYSTEM_FOLDER_NAME_SET = new Set<string>([
   ...Object.keys(WELL_KNOWN_FOLDER_ALIASES),
 ]);
 const FOLDER_CACHE_TTL_MS = 60_000;
+// Cap on Graph requests for a single folder-tree snapshot. Pagination is capped
+// per collection, but recursion across a deep/wide mailbox would otherwise
+// issue one request per folder — enough to blow the MCP request timeout or trip
+// Graph throttling. Exceeding this TRUNCATES the listing rather than failing:
+// a partial folder list is still useful, whereas a hard error would break
+// list_folders outright on legitimately large mailboxes. Truncated snapshots
+// are never cached, so the next call retries from scratch, and name resolution
+// refuses to answer from a truncated tree (see resolveFolderId).
+const MAX_FOLDER_REQUESTS_PER_SNAPSHOT = 400;
+// Filing mail into these is equivalent to the blocked `delete` rule action.
+const DESTRUCTIVE_RULE_DESTINATIONS = new Set([
+  'deleteditems',
+  'recoverableitemsdeletions',
+  'scheduled',
+  'serverfailures',
+  'localfailures',
+  'syncissues',
+  'conflicts',
+]);
+// Graph accepts rule action keys case-insensitively; compare normalized keys.
+const BLOCKED_RULE_ACTIONS = new Set([
+  'forwardto',
+  'forwardasattachmentto',
+  'redirectto',
+  'delete',
+]);
+const SAFE_RULE_ACTIONS = new Set([
+  'assigncategories',
+  'copytofolder',
+  'markasread',
+  'markimportance',
+  'movetofolder',
+  'stopprocessingrules',
+]);
 const FOLDER_SELECT = '$select=id,displayName,parentFolderId,childFolderCount,unreadItemCount,totalItemCount,isHidden';
 
 export interface GraphApiClient {
@@ -515,7 +549,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
 
   async moveToFolder(messageId: string, folder: string): Promise<string> {
     // Graph POST /move returns the moved message with a NEW id
-    const destinationId = await this.resolveFolderId(folder);
+    const destinationId = await this.resolveFolderId(folder, true);
     const result = await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(messageId)}/move`, {
       destinationId,
     });
@@ -523,7 +557,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async listFolders(): Promise<EmailFolder[]> {
-    const folders = await this.getFolderSnapshot();
+    const { folders } = await this.getFolderSnapshot();
     return folders.map(folder => ({ ...folder }));
   }
 
@@ -533,7 +567,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       throw new ProviderError('INVALID_FOLDER_NAME', 'Folder display name cannot be empty', 'microsoft', false);
     }
 
-    const parentId = await this.resolveFolderId(parentFolder);
+    const parentId = await this.resolveFolderId(parentFolder, true);
     const parentPath = await this.folderPathFor(parentFolder, parentId);
     const created = await this.client.post(
       `${this.basePath}/mailFolders/${encodeGraphPathId(parentId)}/childFolders`,
@@ -550,7 +584,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       throw systemFolderProtectedError(folder);
     }
 
-    const folderId = await this.resolveFolderId(folder);
+    const folderId = await this.resolveFolderId(folder, true);
     const systemFolderIds = await this.getSystemFolderIds();
     if (systemFolderIds.has(folderId)) {
       throw systemFolderProtectedError(folder);
@@ -579,11 +613,26 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async createInboxRule(rule: CreateInboxRule): Promise<InboxRule> {
-    for (const blocked of ['forwardTo', 'forwardAsAttachmentTo', 'redirectTo', 'delete']) {
-      if (Object.hasOwn(rule.actions, blocked)) {
+    // Defense in depth: the create_inbox_rule action already enforces an
+    // allowlist, but this method is part of the public EmailRuleManager
+    // interface and must be safe when called directly. Graph treats JSON keys
+    // case-insensitively, so a case-sensitive blocklist alone would let
+    // `ForwardTo` through — match on the normalized key and allowlist rather
+    // than blocklist, so unknown future Graph actions fail closed.
+    for (const key of Object.keys(rule.actions)) {
+      const normalized = key.trim().toLowerCase();
+      if (BLOCKED_RULE_ACTIONS.has(normalized)) {
         throw new ProviderError(
           'UNSAFE_RULE_ACTION',
-          `Inbox rule action '${blocked}' is blocked for security`,
+          `Inbox rule action '${key}' is blocked for security`,
+          'microsoft',
+          false,
+        );
+      }
+      if (!SAFE_RULE_ACTIONS.has(normalized)) {
+        throw new ProviderError(
+          'UNSUPPORTED_RULE_ACTION',
+          `Inbox rule action '${key}' is not supported for creation`,
           'microsoft',
           false,
         );
@@ -594,7 +643,31 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     for (const folderAction of ['moveToFolder', 'copyToFolder'] as const) {
       const destination = actions[folderAction];
       if (typeof destination === 'string') {
-        actions[folderAction] = await this.resolveFolderId(destination);
+        // A rule that files mail into Deleted Items (or the recoverable-items
+        // dumpster) is functionally the blocked `delete` action, so the
+        // destination has to be policed after alias resolution — `trash`,
+        // `deleted`, and `deleteditems` all normalize to the same folder.
+        const wellKnown = normalizeFolderId(destination).toLowerCase();
+        if (DESTRUCTIVE_RULE_DESTINATIONS.has(wellKnown)) {
+          throw new ProviderError(
+            'UNSAFE_RULE_DESTINATION',
+            `Inbox rule destination '${destination}' discards mail and is blocked for security`,
+            'microsoft',
+            false,
+          );
+        }
+        const resolvedId = await this.resolveFolderId(destination, true);
+        // Re-check by resolved id: a custom folder name could still map onto a
+        // system folder id that the alias check above never sees.
+        if ((await this.getSystemFolderIds()).has(resolvedId)) {
+          throw new ProviderError(
+            'UNSAFE_RULE_DESTINATION',
+            `Inbox rule destination '${destination}' resolves to a system folder and is blocked for security`,
+            'microsoft',
+            false,
+          );
+        }
+        actions[folderAction] = resolvedId;
       }
     }
 
@@ -946,25 +1019,34 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       : [];
   }
 
-  private async getFolderSnapshot(): Promise<EmailFolder[]> {
+  private async getFolderSnapshot(): Promise<{ folders: EmailFolder[]; truncated: boolean }> {
     const now = Date.now();
     if (this.folderCache && this.folderCache.expiresAt > now) {
-      return this.folderCache.folders;
+      return { folders: this.folderCache.folders, truncated: false };
     }
 
+    const budget = { remaining: MAX_FOLDER_REQUESTS_PER_SNAPSHOT, truncated: false };
     const folders = await this.fetchFolderCollection(
       `${this.basePath}/mailFolders?${FOLDER_SELECT}&$top=100&includeHiddenFolders=true`,
       '',
       new Set<string>(),
+      budget,
     );
-    this.folderCache = { expiresAt: now + FOLDER_CACHE_TTL_MS, folders };
-    return folders;
+    // Never cache a partial tree — a truncated snapshot would otherwise make
+    // "folder not found" sticky for 60s on a folder that does exist.
+    if (!budget.truncated) {
+      this.folderCache = { expiresAt: now + FOLDER_CACHE_TTL_MS, folders };
+    }
+    return { folders, truncated: budget.truncated };
   }
 
   private async fetchFolderCollection(
     initialUrl: string,
     parentPath: string,
     visitedFolderIds: Set<string>,
+    // Shared across the whole recursive traversal, not per collection, so a
+    // wide/deep folder tree can't fan out into hundreds of Graph requests.
+    budget: { remaining: number; truncated: boolean },
   ): Promise<EmailFolder[]> {
     const folders: EmailFolder[] = [];
     const visitedUrls = new Set<string>();
@@ -974,7 +1056,13 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       if (visitedUrls.has(url) || visitedUrls.size >= 100) {
         throw new ProviderError('PAGINATION_LIMIT', 'Folder pagination exceeded its safety limit', 'microsoft', false);
       }
+      if (budget.remaining <= 0) {
+        // Truncate rather than throw — see MAX_FOLDER_REQUESTS_PER_SNAPSHOT.
+        budget.truncated = true;
+        return folders;
+      }
       visitedUrls.add(url);
+      budget.remaining -= 1;
       const response = await this.client.get(url) as GraphFolderPageResponse;
 
       for (const graphFolder of response.value ?? []) {
@@ -988,6 +1076,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
             `${this.basePath}/mailFolders/${encodeGraphPathId(graphFolder.id)}/childFolders?${FOLDER_SELECT}&$top=100&includeHiddenFolders=true`,
             path,
             visitedFolderIds,
+            budget,
           ));
         }
       }
@@ -998,14 +1087,24 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     return folders;
   }
 
-  private async resolveFolderId(folder: string): Promise<string> {
+  /**
+   * Resolve a folder name/path/id to a Graph folder id.
+   *
+   * `forWrite` callers (moves, rule destinations, folder create/delete) must
+   * pass true: resolving a *write* target from the 60s cache can silently
+   * target a folder that was renamed or moved out from under the cached path,
+   * landing mail somewhere the user didn't ask for. Reads tolerate a stale
+   * snapshot; writes re-fetch so the path→id mapping is current.
+   */
+  private async resolveFolderId(folder: string, forWrite = false): Promise<string> {
     const trimmed = folder.trim();
     const normalized = normalizeFolderLookup(trimmed);
     const wellKnown = WELL_KNOWN_FOLDER_ALIASES[normalized]
       ?? (SYSTEM_FOLDER_NAME_SET.has(normalized) ? normalized : undefined);
     if (wellKnown) return wellKnown;
 
-    const folders = await this.getFolderSnapshot();
+    if (forWrite) this.invalidateFolderCaches();
+    const { folders, truncated } = await this.getFolderSnapshot();
     const idMatch = folders.find(candidate => candidate.id === trimmed);
     if (idMatch) return idMatch.id;
 
@@ -1025,6 +1124,17 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       );
     }
 
+    // A truncated tree cannot prove absence — reporting FOLDER_NOT_FOUND here
+    // would be a lie that could route a write to the wrong place on retry.
+    if (truncated) {
+      throw new ProviderError(
+        'FOLDER_TRAVERSAL_LIMIT',
+        `Folder '${folder}' could not be resolved: this mailbox has more folders than a single traversal enumerates (${MAX_FOLDER_REQUESTS_PER_SNAPSHOT} requests). Specify the folder by id.`,
+        'microsoft',
+        false,
+      );
+    }
+
     throw new ProviderError('FOLDER_NOT_FOUND', `Folder '${folder}' was not found`, 'microsoft', false);
   }
 
@@ -1034,7 +1144,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       ?? (SYSTEM_FOLDER_NAME_SET.has(normalized) ? normalized : undefined);
     if (wellKnown) return displayNameForWellKnownFolder(wellKnown);
 
-    const folders = await this.getFolderSnapshot();
+    const { folders } = await this.getFolderSnapshot();
     return folders.find(candidate => candidate.id === folderId)?.path ?? folder.trim();
   }
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -14,9 +14,14 @@ import type {
   EmailSender,
   EmailCategorizer,
   EmailAttachmentHandler,
+  EmailFolderManager,
+  EmailRuleManager,
+  EmailFolder,
+  InboxRule,
+  CreateInboxRule,
   DownloadedAttachment,
 } from '@usejunior/email-core';
-import { AttachmentNotSupportedError, AttachmentNotFoundError } from '@usejunior/email-core';
+import { AttachmentNotSupportedError, AttachmentNotFoundError, ProviderError } from '@usejunior/email-core';
 
 const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 const SUBJECT_MAX_LENGTH = 255;
@@ -107,6 +112,33 @@ const WELL_KNOWN_FOLDER_ALIASES: Record<string, string> = {
   spam: 'junkemail',
   trash: 'deleteditems',
 };
+
+const SYSTEM_FOLDER_NAMES = [
+  'archive',
+  'clutter',
+  'conflicts',
+  'conversationhistory',
+  'deleteditems',
+  'drafts',
+  'inbox',
+  'junkemail',
+  'localfailures',
+  'msgfolderroot',
+  'outbox',
+  'recoverableitemsdeletions',
+  'scheduled',
+  'searchfolders',
+  'sentitems',
+  'serverfailures',
+  'syncissues',
+] as const;
+
+const SYSTEM_FOLDER_NAME_SET = new Set<string>([
+  ...SYSTEM_FOLDER_NAMES,
+  ...Object.keys(WELL_KNOWN_FOLDER_ALIASES),
+]);
+const FOLDER_CACHE_TTL_MS = 60_000;
+const FOLDER_SELECT = '$select=id,displayName,parentFolderId,childFolderCount,unreadItemCount,totalItemCount,isHidden';
 
 export interface GraphApiClient {
   get(url: string): Promise<{ value?: unknown[]; [key: string]: unknown }>;
@@ -231,9 +263,11 @@ export class GraphApiError extends Error {
   }
 }
 
-export class GraphEmailProvider implements EmailReader, EmailSender, EmailCategorizer, EmailAttachmentHandler {
+export class GraphEmailProvider implements EmailReader, EmailSender, EmailCategorizer, EmailAttachmentHandler, EmailFolderManager, EmailRuleManager {
   private client: GraphApiClient;
   private basePath: string;
+  private folderCache?: { expiresAt: number; folders: EmailFolder[] };
+  private systemFolderIdsCache?: { expiresAt: number; ids: Set<string> };
 
   constructor(client: GraphApiClient, userId = 'me') {
     this.client = client;
@@ -481,10 +515,99 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
 
   async moveToFolder(messageId: string, folder: string): Promise<string> {
     // Graph POST /move returns the moved message with a NEW id
+    const destinationId = await this.resolveFolderId(folder);
     const result = await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(messageId)}/move`, {
-      destinationId: normalizeFolderId(folder),
+      destinationId,
     });
     return result.id ?? messageId;
+  }
+
+  async listFolders(): Promise<EmailFolder[]> {
+    const folders = await this.getFolderSnapshot();
+    return folders.map(folder => ({ ...folder }));
+  }
+
+  async createFolder(displayName: string, parentFolder = 'inbox'): Promise<EmailFolder> {
+    const trimmedName = displayName.trim();
+    if (!trimmedName) {
+      throw new ProviderError('INVALID_FOLDER_NAME', 'Folder display name cannot be empty', 'microsoft', false);
+    }
+
+    const parentId = await this.resolveFolderId(parentFolder);
+    const parentPath = await this.folderPathFor(parentFolder, parentId);
+    const created = await this.client.post(
+      `${this.basePath}/mailFolders/${encodeGraphPathId(parentId)}/childFolders`,
+      { displayName: trimmedName },
+    ) as unknown as GraphMailFolder;
+
+    this.invalidateFolderCaches();
+    return mapGraphFolder(created, parentPath ? `${parentPath}/${trimmedName}` : trimmedName);
+  }
+
+  async deleteFolder(folder: string): Promise<void> {
+    const normalizedInput = normalizeFolderLookup(folder);
+    if (SYSTEM_FOLDER_NAME_SET.has(normalizedInput)) {
+      throw systemFolderProtectedError(folder);
+    }
+
+    const folderId = await this.resolveFolderId(folder);
+    const systemFolderIds = await this.getSystemFolderIds();
+    if (systemFolderIds.has(folderId)) {
+      throw systemFolderProtectedError(folder);
+    }
+
+    await this.client.delete(`${this.basePath}/mailFolders/${encodeGraphPathId(folderId)}`);
+    this.invalidateFolderCaches();
+  }
+
+  async listInboxRules(): Promise<InboxRule[]> {
+    const rules: InboxRule[] = [];
+    const visitedUrls = new Set<string>();
+    let url: string | undefined = `${this.basePath}/mailFolders/inbox/messageRules`;
+
+    while (url) {
+      if (visitedUrls.has(url) || visitedUrls.size >= 100) {
+        throw new ProviderError('PAGINATION_LIMIT', 'Inbox rule pagination exceeded its safety limit', 'microsoft', false);
+      }
+      visitedUrls.add(url);
+      const response = await this.client.get(url) as GraphRulePageResponse;
+      rules.push(...(response.value ?? []));
+      url = response['@odata.nextLink'];
+    }
+
+    return rules;
+  }
+
+  async createInboxRule(rule: CreateInboxRule): Promise<InboxRule> {
+    for (const blocked of ['forwardTo', 'forwardAsAttachmentTo', 'redirectTo', 'delete']) {
+      if (Object.hasOwn(rule.actions, blocked)) {
+        throw new ProviderError(
+          'UNSAFE_RULE_ACTION',
+          `Inbox rule action '${blocked}' is blocked for security`,
+          'microsoft',
+          false,
+        );
+      }
+    }
+
+    const actions = { ...rule.actions };
+    for (const folderAction of ['moveToFolder', 'copyToFolder'] as const) {
+      const destination = actions[folderAction];
+      if (typeof destination === 'string') {
+        actions[folderAction] = await this.resolveFolderId(destination);
+      }
+    }
+
+    return await this.client.post(`${this.basePath}/mailFolders/inbox/messageRules`, {
+      ...rule,
+      actions,
+    }) as InboxRule;
+  }
+
+  async deleteInboxRule(id: string): Promise<void> {
+    await this.client.delete(
+      `${this.basePath}/mailFolders/inbox/messageRules/${encodeGraphPathId(id)}`,
+    );
   }
 
   async deleteMessage(messageId: string, hard = false): Promise<void> {
@@ -822,6 +945,127 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       ? response.categories.filter((value): value is string => typeof value === 'string')
       : [];
   }
+
+  private async getFolderSnapshot(): Promise<EmailFolder[]> {
+    const now = Date.now();
+    if (this.folderCache && this.folderCache.expiresAt > now) {
+      return this.folderCache.folders;
+    }
+
+    const folders = await this.fetchFolderCollection(
+      `${this.basePath}/mailFolders?${FOLDER_SELECT}&$top=100&includeHiddenFolders=true`,
+      '',
+      new Set<string>(),
+    );
+    this.folderCache = { expiresAt: now + FOLDER_CACHE_TTL_MS, folders };
+    return folders;
+  }
+
+  private async fetchFolderCollection(
+    initialUrl: string,
+    parentPath: string,
+    visitedFolderIds: Set<string>,
+  ): Promise<EmailFolder[]> {
+    const folders: EmailFolder[] = [];
+    const visitedUrls = new Set<string>();
+    let url: string | undefined = initialUrl;
+
+    while (url) {
+      if (visitedUrls.has(url) || visitedUrls.size >= 100) {
+        throw new ProviderError('PAGINATION_LIMIT', 'Folder pagination exceeded its safety limit', 'microsoft', false);
+      }
+      visitedUrls.add(url);
+      const response = await this.client.get(url) as GraphFolderPageResponse;
+
+      for (const graphFolder of response.value ?? []) {
+        if (!graphFolder.id || visitedFolderIds.has(graphFolder.id)) continue;
+        visitedFolderIds.add(graphFolder.id);
+        const path = parentPath ? `${parentPath}/${graphFolder.displayName}` : graphFolder.displayName;
+        folders.push(mapGraphFolder(graphFolder, path));
+
+        if ((graphFolder.childFolderCount ?? 0) > 0) {
+          folders.push(...await this.fetchFolderCollection(
+            `${this.basePath}/mailFolders/${encodeGraphPathId(graphFolder.id)}/childFolders?${FOLDER_SELECT}&$top=100&includeHiddenFolders=true`,
+            path,
+            visitedFolderIds,
+          ));
+        }
+      }
+
+      url = response['@odata.nextLink'];
+    }
+
+    return folders;
+  }
+
+  private async resolveFolderId(folder: string): Promise<string> {
+    const trimmed = folder.trim();
+    const normalized = normalizeFolderLookup(trimmed);
+    const wellKnown = WELL_KNOWN_FOLDER_ALIASES[normalized]
+      ?? (SYSTEM_FOLDER_NAME_SET.has(normalized) ? normalized : undefined);
+    if (wellKnown) return wellKnown;
+
+    const folders = await this.getFolderSnapshot();
+    const idMatch = folders.find(candidate => candidate.id === trimmed);
+    if (idMatch) return idMatch.id;
+
+    const pathMatches = folders.filter(candidate => normalizeFolderLookup(candidate.path) === normalized);
+    if (pathMatches.length === 1) return pathMatches[0]!.id;
+
+    const nameMatches = folders.filter(
+      candidate => normalizeFolderLookup(candidate.displayName) === normalized,
+    );
+    if (nameMatches.length === 1) return nameMatches[0]!.id;
+    if (nameMatches.length > 1) {
+      throw new ProviderError(
+        'AMBIGUOUS_FOLDER',
+        `Folder name '${folder}' is ambiguous; use a full folder path`,
+        'microsoft',
+        false,
+      );
+    }
+
+    throw new ProviderError('FOLDER_NOT_FOUND', `Folder '${folder}' was not found`, 'microsoft', false);
+  }
+
+  private async folderPathFor(folder: string, folderId: string): Promise<string> {
+    const normalized = normalizeFolderLookup(folder);
+    const wellKnown = WELL_KNOWN_FOLDER_ALIASES[normalized]
+      ?? (SYSTEM_FOLDER_NAME_SET.has(normalized) ? normalized : undefined);
+    if (wellKnown) return displayNameForWellKnownFolder(wellKnown);
+
+    const folders = await this.getFolderSnapshot();
+    return folders.find(candidate => candidate.id === folderId)?.path ?? folder.trim();
+  }
+
+  private async getSystemFolderIds(): Promise<Set<string>> {
+    const now = Date.now();
+    if (this.systemFolderIdsCache && this.systemFolderIdsCache.expiresAt > now) {
+      return this.systemFolderIdsCache.ids;
+    }
+
+    const ids = new Set<string>();
+    for (const name of SYSTEM_FOLDER_NAMES) {
+      try {
+        const folder = await this.client.get(
+          `${this.basePath}/mailFolders/${encodeGraphPathId(name)}?${FOLDER_SELECT}`,
+        ) as unknown as GraphMailFolder;
+        if (folder.id) ids.add(folder.id);
+      } catch (err) {
+        // Some tenants do not provision every optional system folder.
+        if (err instanceof GraphApiError && err.status === 404) continue;
+        throw err;
+      }
+    }
+
+    this.systemFolderIdsCache = { expiresAt: now + FOLDER_CACHE_TTL_MS, ids };
+    return ids;
+  }
+
+  private invalidateFolderCaches(): void {
+    this.folderCache = undefined;
+    this.systemFolderIdsCache = undefined;
+  }
 }
 
 interface GraphMessage {
@@ -845,6 +1089,27 @@ interface GraphMessage {
 
 interface GraphMessagePageResponse {
   value?: GraphMessage[];
+  '@odata.nextLink'?: string;
+}
+
+interface GraphMailFolder {
+  id: string;
+  displayName: string;
+  parentFolderId?: string;
+  childFolderCount?: number;
+  unreadItemCount?: number;
+  totalItemCount?: number;
+  isHidden?: boolean;
+  [key: string]: unknown;
+}
+
+interface GraphFolderPageResponse {
+  value?: GraphMailFolder[];
+  '@odata.nextLink'?: string;
+}
+
+interface GraphRulePageResponse {
+  value?: InboxRule[];
   '@odata.nextLink'?: string;
 }
 
@@ -918,6 +1183,36 @@ function mapGraphMessage(msg: GraphMessage): EmailMessage {
 
 function normalizeFolderId(folder: string): string {
   return WELL_KNOWN_FOLDER_ALIASES[folder.trim().toLowerCase()] ?? folder;
+}
+
+function normalizeFolderLookup(folder: string): string {
+  return folder.trim().replace(/^\/+|\/+$/g, '').toLowerCase();
+}
+
+function displayNameForWellKnownFolder(folder: string): string {
+  const names: Record<string, string> = {
+    archive: 'Archive',
+    deleteditems: 'Deleted Items',
+    drafts: 'Drafts',
+    inbox: 'Inbox',
+    junkemail: 'Junk Email',
+    outbox: 'Outbox',
+    sentitems: 'Sent Items',
+  };
+  return names[folder] ?? folder;
+}
+
+function mapGraphFolder(folder: GraphMailFolder, path: string): EmailFolder {
+  return { ...folder, path };
+}
+
+function systemFolderProtectedError(folder: string): ProviderError {
+  return new ProviderError(
+    'SYSTEM_FOLDER_PROTECTED',
+    `System folder '${folder}' cannot be deleted`,
+    'microsoft',
+    false,
+  );
 }
 
 /**

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -164,14 +164,17 @@ const BLOCKED_RULE_ACTIONS = new Set([
   'redirectto',
   'delete',
 ]);
-const SAFE_RULE_ACTIONS = new Set([
-  'assigncategories',
-  'copytofolder',
-  'markasread',
-  'markimportance',
-  'movetofolder',
-  'stopprocessingrules',
-]);
+// Normalized (lowercased) safe action key -> canonical Graph camelCase key.
+// Doubles as the allowlist: a key absent here is rejected. Keys are normalized
+// before lookup so `MoveToFolder`/`MOVETOFOLDER` all map to `moveToFolder`.
+const CANONICAL_RULE_ACTIONS: Record<string, string> = {
+  assigncategories: 'assignCategories',
+  copytofolder: 'copyToFolder',
+  markasread: 'markAsRead',
+  markimportance: 'markImportance',
+  movetofolder: 'moveToFolder',
+  stopprocessingrules: 'stopProcessingRules',
+};
 const FOLDER_SELECT = '$select=id,displayName,parentFolderId,childFolderCount,unreadItemCount,totalItemCount,isHidden';
 
 export interface GraphApiClient {
@@ -301,7 +304,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   private client: GraphApiClient;
   private basePath: string;
   private folderCache?: { expiresAt: number; folders: EmailFolder[] };
-  private systemFolderIdsCache?: { expiresAt: number; ids: Set<string> };
+  private systemFolderIdsCache?: { expiresAt: number; idsByName: Map<string, string> };
 
   constructor(client: GraphApiClient, userId = 'me') {
     this.client = client;
@@ -548,8 +551,13 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   }
 
   async moveToFolder(messageId: string, folder: string): Promise<string> {
-    // Graph POST /move returns the moved message with a NEW id
-    const destinationId = await this.resolveFolderId(folder, true);
+    // Graph POST /move returns the moved message with a NEW id.
+    // Resolve against the cache (not forWrite): a move does not alter the folder
+    // tree, and a triage loop can move dozens of messages per pass — forcing a
+    // fresh traversal per move would trip Graph throttling. The residual risk is
+    // the same 60s rename-race we accept for reads: at worst a message lands in
+    // a renamed-but-valid folder, which is recoverable, not lost.
+    const destinationId = await this.resolveFolderId(folder);
     const result = await this.client.post(`${this.basePath}/messages/${encodeGraphPathId(messageId)}/move`, {
       destinationId,
     });
@@ -619,7 +627,14 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     // case-insensitively, so a case-sensitive blocklist alone would let
     // `ForwardTo` through — match on the normalized key and allowlist rather
     // than blocklist, so unknown future Graph actions fail closed.
-    for (const key of Object.keys(rule.actions)) {
+    // Rebuild the actions object with canonical camelCase keys. Graph accepts
+    // keys case-insensitively, so a caller passing `MoveToFolder` would pass
+    // the normalized allowlist check yet slip past a case-sensitive
+    // `actions['moveToFolder']` destructive-destination check below. Normalizing
+    // keys up front closes that bypass and guarantees the payload we POST uses
+    // exactly the safe keys we validated.
+    const actions: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(rule.actions)) {
       const normalized = key.trim().toLowerCase();
       if (BLOCKED_RULE_ACTIONS.has(normalized)) {
         throw new ProviderError(
@@ -629,7 +644,8 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
           false,
         );
       }
-      if (!SAFE_RULE_ACTIONS.has(normalized)) {
+      const canonical = CANONICAL_RULE_ACTIONS[normalized];
+      if (!canonical) {
         throw new ProviderError(
           'UNSUPPORTED_RULE_ACTION',
           `Inbox rule action '${key}' is not supported for creation`,
@@ -637,40 +653,32 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
           false,
         );
       }
+      // Validate value shapes locally instead of forwarding wrong-typed values
+      // to Graph. A non-string moveToFolder would otherwise skip the
+      // destructive-destination inspection entirely (it only fires on strings).
+      if (!isValidRuleActionValue(canonical, value)) {
+        throw new ProviderError(
+          'INVALID_RULE_ACTION_VALUE',
+          `Inbox rule action '${key}' has an invalid value for its type`,
+          'microsoft',
+          false,
+        );
+      }
+      actions[canonical] = value;
     }
 
-    const actions = { ...rule.actions };
+    // Resolve folder destinations to opaque ids and reject mail-discarding ones.
+    // resolveRuleDestinationId does the destructive check on the canonical
+    // resolved folder, closing alias/slash/case bypasses like `/trash/`.
     for (const folderAction of ['moveToFolder', 'copyToFolder'] as const) {
       const destination = actions[folderAction];
       if (typeof destination === 'string') {
-        // A rule that files mail into Deleted Items (or the recoverable-items
-        // dumpster) is functionally the blocked `delete` action, so the
-        // destination has to be policed after alias resolution — `trash`,
-        // `deleted`, and `deleteditems` all normalize to the same folder.
-        const wellKnown = normalizeFolderId(destination).toLowerCase();
-        if (DESTRUCTIVE_RULE_DESTINATIONS.has(wellKnown)) {
-          throw new ProviderError(
-            'UNSAFE_RULE_DESTINATION',
-            `Inbox rule destination '${destination}' discards mail and is blocked for security`,
-            'microsoft',
-            false,
-          );
-        }
-        const resolvedId = await this.resolveFolderId(destination, true);
-        // Re-check by resolved id: a custom folder name could still map onto a
-        // system folder id that the alias check above never sees.
-        if ((await this.getSystemFolderIds()).has(resolvedId)) {
-          throw new ProviderError(
-            'UNSAFE_RULE_DESTINATION',
-            `Inbox rule destination '${destination}' resolves to a system folder and is blocked for security`,
-            'microsoft',
-            false,
-          );
-        }
-        actions[folderAction] = resolvedId;
+        actions[folderAction] = await this.resolveRuleDestinationId(destination);
       }
     }
 
+    // Spread `actions` last so the canonicalized/resolved actions replace the
+    // caller's original (possibly mis-cased) actions in the payload.
     return await this.client.post(`${this.basePath}/mailFolders/inbox/messageRules`, {
       ...rule,
       actions,
@@ -1090,11 +1098,13 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
   /**
    * Resolve a folder name/path/id to a Graph folder id.
    *
-   * `forWrite` callers (moves, rule destinations, folder create/delete) must
-   * pass true: resolving a *write* target from the 60s cache can silently
-   * target a folder that was renamed or moved out from under the cached path,
-   * landing mail somewhere the user didn't ask for. Reads tolerate a stale
-   * snapshot; writes re-fetch so the path→id mapping is current.
+   * `forWrite` is reserved for operations that MUTATE the folder tree
+   * (createFolder's parent, deleteFolder's target): these are low-frequency and
+   * high-harm — deleting or nesting under a stale-cached id is unrecoverable —
+   * so they re-fetch to get a current path→id mapping. Message moves and rule
+   * destinations deliberately do NOT pass forWrite: they don't change the tree,
+   * they run in high-volume loops, and their worst-case staleness (the 60s
+   * rename race) is the same recoverable risk we already accept for reads.
    */
   private async resolveFolderId(folder: string, forWrite = false): Promise<string> {
     const trimmed = folder.trim();
@@ -1105,11 +1115,34 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
 
     if (forWrite) this.invalidateFolderCaches();
     const { folders, truncated } = await this.getFolderSnapshot();
+
+    // Exact id match is safe even against a truncated tree — ids are globally
+    // unique, so a visible match is THE match regardless of unseen folders.
     const idMatch = folders.find(candidate => candidate.id === trimmed);
     if (idMatch) return idMatch.id;
 
+    // A truncated tree cannot prove a NAME or PATH is unique (a duplicate could
+    // exist beyond the request budget), so refuse to guess — returning a
+    // visible-but-maybe-not-unique match could misroute a write. Ids only.
+    if (truncated) {
+      throw new ProviderError(
+        'FOLDER_TRAVERSAL_LIMIT',
+        `Folder '${folder}' could not be uniquely resolved: this mailbox has more folders than a single traversal enumerates (${MAX_FOLDER_REQUESTS_PER_SNAPSHOT} requests). Specify the folder by id.`,
+        'microsoft',
+        false,
+      );
+    }
+
     const pathMatches = folders.filter(candidate => normalizeFolderLookup(candidate.path) === normalized);
     if (pathMatches.length === 1) return pathMatches[0]!.id;
+    if (pathMatches.length > 1) {
+      throw new ProviderError(
+        'AMBIGUOUS_FOLDER',
+        `Folder path '${folder}' is ambiguous; use the folder id`,
+        'microsoft',
+        false,
+      );
+    }
 
     const nameMatches = folders.filter(
       candidate => normalizeFolderLookup(candidate.displayName) === normalized,
@@ -1124,18 +1157,56 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       );
     }
 
-    // A truncated tree cannot prove absence — reporting FOLDER_NOT_FOUND here
-    // would be a lie that could route a write to the wrong place on retry.
-    if (truncated) {
+    throw new ProviderError('FOLDER_NOT_FOUND', `Folder '${folder}' was not found`, 'microsoft', false);
+  }
+
+  /**
+   * Resolve a rule-action destination to an OPAQUE Graph folder id.
+   *
+   * Unlike the /messages/{id}/move endpoint (which accepts well-known names),
+   * Graph's messageRule action contract wants a folder id — so well-known names
+   * are mapped through to their ids here. Resolution is `forWrite` (fresh): a
+   * rule persists and acts 24/7, so a stale destination is worth one traversal
+   * to avoid. The destructive check runs on the CANONICAL resolved value, so
+   * alias/slash/case tricks (`/trash/`, `DeletedItems`) that reach the same
+   * folder are all rejected.
+   */
+  private async resolveRuleDestinationId(destination: string): Promise<string> {
+    const normalized = normalizeFolderLookup(destination);
+    const wellKnown = WELL_KNOWN_FOLDER_ALIASES[normalized]
+      ?? (SYSTEM_FOLDER_NAME_SET.has(normalized) ? normalized : undefined);
+
+    if (wellKnown) {
+      if (DESTRUCTIVE_RULE_DESTINATIONS.has(wellKnown)) {
+        throw new ProviderError(
+          'UNSAFE_RULE_DESTINATION',
+          `Inbox rule destination '${destination}' discards mail and is blocked for security`,
+          'microsoft',
+          false,
+        );
+      }
+      const id = (await this.getSystemFolderIdMap()).get(wellKnown);
+      if (!id) {
+        throw new ProviderError(
+          'FOLDER_NOT_FOUND',
+          `Inbox rule destination '${destination}' is not provisioned on this mailbox`,
+          'microsoft',
+          false,
+        );
+      }
+      return id;
+    }
+
+    const resolvedId = await this.resolveFolderId(destination, true);
+    if ((await this.getDestructiveFolderIds()).has(resolvedId)) {
       throw new ProviderError(
-        'FOLDER_TRAVERSAL_LIMIT',
-        `Folder '${folder}' could not be resolved: this mailbox has more folders than a single traversal enumerates (${MAX_FOLDER_REQUESTS_PER_SNAPSHOT} requests). Specify the folder by id.`,
+        'UNSAFE_RULE_DESTINATION',
+        `Inbox rule destination '${destination}' resolves to a mail-discarding system folder and is blocked for security`,
         'microsoft',
         false,
       );
     }
-
-    throw new ProviderError('FOLDER_NOT_FOUND', `Folder '${folder}' was not found`, 'microsoft', false);
+    return resolvedId;
   }
 
   private async folderPathFor(folder: string, folderId: string): Promise<string> {
@@ -1148,19 +1219,20 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     return folders.find(candidate => candidate.id === folderId)?.path ?? folder.trim();
   }
 
-  private async getSystemFolderIds(): Promise<Set<string>> {
+  /** Well-known-name -> resolved id for every provisioned system folder. */
+  private async getSystemFolderIdMap(): Promise<Map<string, string>> {
     const now = Date.now();
     if (this.systemFolderIdsCache && this.systemFolderIdsCache.expiresAt > now) {
-      return this.systemFolderIdsCache.ids;
+      return this.systemFolderIdsCache.idsByName;
     }
 
-    const ids = new Set<string>();
+    const idsByName = new Map<string, string>();
     for (const name of SYSTEM_FOLDER_NAMES) {
       try {
         const folder = await this.client.get(
           `${this.basePath}/mailFolders/${encodeGraphPathId(name)}?${FOLDER_SELECT}`,
         ) as unknown as GraphMailFolder;
-        if (folder.id) ids.add(folder.id);
+        if (folder.id) idsByName.set(name, folder.id);
       } catch (err) {
         // Some tenants do not provision every optional system folder.
         if (err instanceof GraphApiError && err.status === 404) continue;
@@ -1168,7 +1240,27 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       }
     }
 
-    this.systemFolderIdsCache = { expiresAt: now + FOLDER_CACHE_TTL_MS, ids };
+    this.systemFolderIdsCache = { expiresAt: now + FOLDER_CACHE_TTL_MS, idsByName };
+    return idsByName;
+  }
+
+  /** Ids of ALL system folders — none may be deleted. */
+  private async getSystemFolderIds(): Promise<Set<string>> {
+    return new Set((await this.getSystemFolderIdMap()).values());
+  }
+
+  /**
+   * Ids of only the mail-discarding system folders. Rule destinations are
+   * checked against THIS set, not the full system set: filing into Archive or
+   * Junk via a rule is legitimate, so blocking every system folder would reject
+   * ordinary rules. Derived from the same cached sweep as getSystemFolderIds.
+   */
+  private async getDestructiveFolderIds(): Promise<Set<string>> {
+    const idsByName = await this.getSystemFolderIdMap();
+    const ids = new Set<string>();
+    for (const [name, id] of idsByName) {
+      if (DESTRUCTIVE_RULE_DESTINATIONS.has(name)) ids.add(id);
+    }
     return ids;
   }
 
@@ -1293,6 +1385,27 @@ function mapGraphMessage(msg: GraphMessage): EmailMessage {
 
 function normalizeFolderId(folder: string): string {
   return WELL_KNOWN_FOLDER_ALIASES[folder.trim().toLowerCase()] ?? folder;
+}
+
+// Graph's messageRuleActions value contract. Wrong-typed values (e.g. a boolean
+// moveToFolder, or a string markAsRead) are rejected locally rather than sent to
+// Graph — and a non-string folder value would otherwise dodge the destructive
+// destination check, which only inspects strings.
+function isValidRuleActionValue(canonicalKey: string, value: unknown): boolean {
+  switch (canonicalKey) {
+    case 'moveToFolder':
+    case 'copyToFolder':
+      return typeof value === 'string' && value.trim().length > 0;
+    case 'markAsRead':
+    case 'stopProcessingRules':
+      return typeof value === 'boolean';
+    case 'markImportance':
+      return value === 'low' || value === 'normal' || value === 'high';
+    case 'assignCategories':
+      return Array.isArray(value) && value.every(item => typeof item === 'string');
+    default:
+      return false;
+  }
 }
 
 function normalizeFolderLookup(folder: string): string {

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GraphEmailProvider, type GraphApiClient } from './email-graph-provider.js';
+
+function createMockClient(overrides: Partial<GraphApiClient> = {}): GraphApiClient {
+  return {
+    get: vi.fn().mockResolvedValue({ value: [] }),
+    post: vi.fn().mockResolvedValue({ id: 'new-id' }),
+    patch: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('provider-microsoft/Folder Management', () => {
+  it('Scenario: Recursively traverses paginated roots and children with computed paths', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?')) {
+        return {
+          value: [{ id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 }],
+          '@odata.nextLink': 'https://graph.microsoft.com/root-page-2',
+        };
+      }
+      if (url === 'https://graph.microsoft.com/root-page-2') {
+        return { value: [{ id: 'archive-id', displayName: 'Archive', childFolderCount: 0 }] };
+      }
+      if (url.includes('/mailFolders/inbox-id/childFolders?')) {
+        return {
+          value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 1 }],
+          '@odata.nextLink': 'https://graph.microsoft.com/inbox-children-page-2',
+        };
+      }
+      if (url === 'https://graph.microsoft.com/inbox-children-page-2') {
+        return { value: [{ id: 'receipts-id', displayName: 'Receipts', childFolderCount: 0 }] };
+      }
+      if (url.includes('/mailFolders/news-id/childFolders?')) {
+        return { value: [{ id: 'promos-id', displayName: 'Promotions', childFolderCount: 0 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const provider = new GraphEmailProvider(createMockClient({ get }));
+
+    const folders = await provider.listFolders();
+
+    expect(folders.map(folder => [folder.id, folder.path])).toEqual([
+      ['inbox-id', 'Inbox'],
+      ['news-id', 'Inbox/Newsletters'],
+      ['promos-id', 'Inbox/Newsletters/Promotions'],
+      ['receipts-id', 'Inbox/Receipts'],
+      ['archive-id', 'Archive'],
+    ]);
+  });
+
+  it('Scenario: Custom moves resolve a path and reuse the 60-second folder cache', async () => {
+    const get = vi.fn().mockResolvedValue({
+      value: [
+        { id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 },
+      ],
+    });
+    get.mockImplementation(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?')) {
+        return { value: [{ id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 }] };
+      }
+      if (url.includes('/mailFolders/inbox-id/childFolders?')) {
+        return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const client = createMockClient({ get });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.moveToFolder('msg-1', 'Inbox/Newsletters');
+    await provider.moveToFolder('msg-2', 'newsletters');
+
+    expect(client.post).toHaveBeenNthCalledWith(1, '/me/messages/msg-1/move', { destinationId: 'news-id' });
+    expect(client.post).toHaveBeenNthCalledWith(2, '/me/messages/msg-2/move', { destinationId: 'news-id' });
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('Scenario: Well-known moves retain alias behavior without folder traversal', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.moveToFolder('msg-1', 'trash');
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(client.post).toHaveBeenCalledWith('/me/messages/msg-1/move', { destinationId: 'deleteditems' });
+  });
+
+  it('Scenario: Creating a child folder invalidates the resolver cache', async () => {
+    let rootReads = 0;
+    const get = vi.fn(async (url: string) => {
+      if (!url.startsWith('/me/mailFolders?')) throw new Error(`Unexpected URL: ${url}`);
+      rootReads++;
+      return { value: [{ id: 'custom-id', displayName: 'Parent', childFolderCount: 0 }] };
+    });
+    const post = vi.fn().mockResolvedValue({
+      id: 'child-id',
+      displayName: 'Child',
+      parentFolderId: 'custom-id',
+      childFolderCount: 0,
+    });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await provider.listFolders();
+    const created = await provider.createFolder('Child', 'Parent');
+    await provider.listFolders();
+
+    expect(created.path).toBe('Parent/Child');
+    expect(post).toHaveBeenCalledWith('/me/mailFolders/custom-id/childFolders', { displayName: 'Child' });
+    expect(rootReads).toBe(2);
+  });
+
+  it('Scenario: Refuses system folder deletion by well-known name', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.deleteFolder('sentitems')).rejects.toMatchObject({
+      code: 'SYSTEM_FOLDER_PROTECTED',
+    });
+    expect(client.get).not.toHaveBeenCalled();
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Refuses system folder deletion by resolved id', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?')) {
+        return { value: [{ id: 'inbox-opaque-id', displayName: 'Inbox', childFolderCount: 0 }] };
+      }
+      const match = url.match(/\/mailFolders\/([^?]+)/);
+      const wellKnown = decodeURIComponent(match?.[1] ?? '');
+      return {
+        id: wellKnown === 'inbox' ? 'inbox-opaque-id' : `${wellKnown}-opaque-id`,
+        displayName: wellKnown,
+      };
+    });
+    const client = createMockClient({ get });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.deleteFolder('inbox-opaque-id')).rejects.toMatchObject({
+      code: 'SYSTEM_FOLDER_PROTECTED',
+    });
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('provider-microsoft/Inbox Rule Management', () => {
+  it('Scenario: Lists every paginated rule without stripping fields', async () => {
+    const firstRule = {
+      id: 'rule-1',
+      actions: { forwardTo: [{ emailAddress: { address: 'outside@example.com' } }] },
+      futureField: 'preserved',
+    };
+    const get = vi.fn()
+      .mockResolvedValueOnce({ value: [firstRule], '@odata.nextLink': 'https://graph.microsoft.com/rules-page-2' })
+      .mockResolvedValueOnce({ value: [{ id: 'rule-2', actions: { markAsRead: true } }] });
+    const provider = new GraphEmailProvider(createMockClient({ get }));
+
+    const rules = await provider.listInboxRules();
+
+    expect(rules).toEqual([firstRule, { id: 'rule-2', actions: { markAsRead: true } }]);
+    expect(get).toHaveBeenNthCalledWith(1, '/me/mailFolders/inbox/messageRules');
+    expect(get).toHaveBeenNthCalledWith(2, 'https://graph.microsoft.com/rules-page-2');
+  });
+
+  it('Scenario: Creates a rule after resolving its custom move destination', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?')) {
+        return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const post = vi.fn().mockResolvedValue({ id: 'rule-1', displayName: 'GitHub' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await provider.createInboxRule({
+      displayName: 'GitHub',
+      conditions: { senderContains: ['github.com'] },
+      actions: { moveToFolder: 'Newsletters', markAsRead: true },
+    });
+
+    expect(post).toHaveBeenCalledWith('/me/mailFolders/inbox/messageRules', {
+      displayName: 'GitHub',
+      conditions: { senderContains: ['github.com'] },
+      actions: { moveToFolder: 'news-id', markAsRead: true },
+    });
+  });
+
+  it('Scenario: Rejects unsafe actions even when the provider is called directly', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.createInboxRule({
+      displayName: 'Unsafe',
+      conditions: {},
+      actions: { redirectTo: [] },
+    })).rejects.toMatchObject({ code: 'UNSAFE_RULE_ACTION' });
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Deletes a rule using an encoded id', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.deleteInboxRule('rule/+=id');
+
+    expect(client.delete).toHaveBeenCalledWith(
+      '/me/mailFolders/inbox/messageRules/rule%2F%2B%3Did',
+    );
+  });
+});

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -50,7 +50,7 @@ describe('provider-microsoft/Folder Management', () => {
     ]);
   });
 
-  it('Scenario: Custom moves re-resolve the folder tree on every write', async () => {
+  it('Scenario: Repeated custom moves reuse the cached folder tree', async () => {
     const get = vi.fn().mockResolvedValue({
       value: [
         { id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 },
@@ -73,11 +73,12 @@ describe('provider-microsoft/Folder Management', () => {
 
     expect(client.post).toHaveBeenNthCalledWith(1, '/me/messages/msg-1/move', { destinationId: 'news-id' });
     expect(client.post).toHaveBeenNthCalledWith(2, '/me/messages/msg-2/move', { destinationId: 'news-id' });
-    // Writes deliberately bypass the 60s cache: a cached path->id mapping can
-    // point at a folder that was renamed/moved out from under it, which would
-    // silently file mail somewhere the user never asked for. Each move costs
-    // one extra traversal; reads still use the cache.
-    expect(get).toHaveBeenCalledTimes(4);
+    // A move does not alter the folder tree, and triage loops move many
+    // messages per pass — so moves resolve against the 60s cache. The first
+    // move populates it (root + inbox children = 2 gets); the second is a cache
+    // hit with no further traversal. Re-resolving per move would trip Graph
+    // throttling on the exact high-volume loop this feature targets.
+    expect(get).toHaveBeenCalledTimes(2);
   });
 
   it('Scenario: Well-known moves retain alias behavior without folder traversal', async () => {
@@ -299,5 +300,151 @@ describe('provider-microsoft/Destructive rule destinations (PR #106 review)', ()
     // A cached truncated tree would have made the second call free — and would
     // have made "folder not found" sticky for 60s on folders that do exist.
     expect(get.mock.calls.length).toBeGreaterThan(before);
+  });
+});
+
+describe('provider-microsoft/Round-2 review hardening (PR #106)', () => {
+  it('Scenario: Case-variant moveToFolder to trash cannot bypass the destructive check', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    // Graph is case-insensitive, so `MoveToFolder` passes the normalized
+    // allowlist. The destructive-destination check must see it too — a
+    // case-sensitive lookup here would let it file the mailbox into trash.
+    for (const key of ['MoveToFolder', 'MOVETOFOLDER', 'movetofolder']) {
+      await expect(provider.createInboxRule({
+        displayName: 'Discard via case trick',
+        conditions: {},
+        actions: { [key]: 'trash' },
+      })).rejects.toMatchObject({ code: 'UNSAFE_RULE_DESTINATION' });
+    }
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Rules moving mail to Archive or Junk are allowed, not over-blocked', async () => {
+    // getSystemFolderIdMap resolves each well-known name; archive/junkemail are
+    // legitimate rule destinations and must survive the destructive-id re-check.
+    const get = vi.fn(async (url: string) => {
+      const m = /\/me\/mailFolders\/([a-z]+)\?/.exec(url);
+      if (m) return { id: `system-${m[1]}` };
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const post = vi.fn().mockResolvedValue({ id: 'rule-1', displayName: 'Archive old' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    for (const destination of ['archive', 'junkemail']) {
+      const rule = await provider.createInboxRule({
+        displayName: `File to ${destination}`,
+        conditions: {},
+        actions: { moveToFolder: destination },
+      });
+      expect(rule).toMatchObject({ id: 'rule-1' });
+    }
+    // Rule destinations resolve to opaque ids (Graph's rule contract wants an
+    // id, not a well-known name). Archive/Junk are legitimate and must NOT be
+    // rejected by the destructive re-check, which covers only deleted-items.
+    expect(post).toHaveBeenNthCalledWith(1, '/me/mailFolders/inbox/messageRules',
+      expect.objectContaining({ actions: { moveToFolder: 'system-archive' } }));
+    expect(post).toHaveBeenNthCalledWith(2, '/me/mailFolders/inbox/messageRules',
+      expect.objectContaining({ actions: { moveToFolder: 'system-junkemail' } }));
+  });
+
+  it('Scenario: Mis-cased action keys are canonicalized before hitting Graph', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?')) {
+        return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
+      }
+      const m = /\/me\/mailFolders\/([a-z]+)\?/.exec(url);
+      if (m) return { id: `system-${m[1]}` };
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const post = vi.fn().mockResolvedValue({ id: 'rule-1', displayName: 'GitHub' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await provider.createInboxRule({
+      displayName: 'GitHub',
+      conditions: {},
+      actions: { MoveToFolder: 'Newsletters', MarkAsRead: true },
+    });
+
+    expect(post).toHaveBeenCalledWith('/me/mailFolders/inbox/messageRules',
+      expect.objectContaining({ actions: { moveToFolder: 'news-id', markAsRead: true } }));
+  });
+});
+
+describe('provider-microsoft/Round-2 Codex probes (PR #106)', () => {
+  const systemIdMock = (extra?: (url: string) => unknown) => vi.fn(async (url: string) => {
+    if (extra) {
+      const r = extra(url);
+      if (r !== undefined) return r;
+    }
+    const m = /\/me\/mailFolders\/([a-z]+)\?/.exec(url);
+    if (m) return { id: `system-${m[1]}` };
+    throw new Error(`Unexpected URL: ${url}`);
+  });
+
+  it('Scenario: Slash/alias-padded destructive destinations cannot bypass the check', async () => {
+    // `/trash/`, `/deleteditems/` etc. normalize to the deleted-items folder
+    // once surrounding slashes are stripped — they must be rejected.
+    for (const destination of ['/trash/', '/deleteditems/', '  /Deleted/  ', '/recoverableitemsdeletions/']) {
+      const post = vi.fn();
+      const provider = new GraphEmailProvider(createMockClient({ get: systemIdMock(), post }));
+      await expect(provider.createInboxRule({
+        displayName: 'Slash bypass',
+        conditions: {},
+        actions: { moveToFolder: destination },
+      })).rejects.toMatchObject({ code: 'UNSAFE_RULE_DESTINATION' });
+      expect(post).not.toHaveBeenCalled();
+    }
+  });
+
+  it('Scenario: Wrong-typed action values fail closed before hitting Graph', async () => {
+    const cases: Array<Record<string, unknown>> = [
+      { moveToFolder: true },
+      { markAsRead: 'false' },
+      { markImportance: 'urgent' },
+      { assignCategories: 'work' },
+      { copyToFolder: 42 },
+    ];
+    for (const actions of cases) {
+      const post = vi.fn();
+      const provider = new GraphEmailProvider(createMockClient({ get: systemIdMock(), post }));
+      await expect(provider.createInboxRule({
+        displayName: 'Bad value', conditions: {}, actions,
+      })).rejects.toMatchObject({ code: 'INVALID_RULE_ACTION_VALUE' });
+      expect(post).not.toHaveBeenCalled();
+    }
+  });
+
+  it('Scenario: A truncated tree refuses a name match rather than misrouting a move', async () => {
+    // Every folder claims a child so the traversal truncates; the target name
+    // is visible but cannot be proven unique, so resolution must refuse.
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?') || url.includes('/childFolders?')) {
+        return { value: [{ id: `f-${get.mock.calls.length}`, displayName: 'Target', childFolderCount: 1 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const provider = new GraphEmailProvider(createMockClient({ get }));
+
+    await expect(provider.moveToFolder('msg-1', 'Target')).rejects.toMatchObject({
+      code: 'FOLDER_TRAVERSAL_LIMIT',
+    });
+  });
+
+  it('Scenario: An exact folder id still resolves against a truncated tree', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?') || url.includes('/childFolders?')) {
+        const n = get.mock.calls.length;
+        return { value: [{ id: n === 1 ? 'wanted-id' : `f-${n}`, displayName: `F${n}`, childFolderCount: 1 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const post = vi.fn().mockResolvedValue({ id: 'moved-id' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    const newId = await provider.moveToFolder('msg-1', 'wanted-id');
+    expect(newId).toBe('moved-id');
+    expect(post).toHaveBeenCalledWith('/me/messages/msg-1/move', { destinationId: 'wanted-id' });
   });
 });

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -50,7 +50,7 @@ describe('provider-microsoft/Folder Management', () => {
     ]);
   });
 
-  it('Scenario: Custom moves resolve a path and reuse the 60-second folder cache', async () => {
+  it('Scenario: Custom moves re-resolve the folder tree on every write', async () => {
     const get = vi.fn().mockResolvedValue({
       value: [
         { id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 },
@@ -73,7 +73,11 @@ describe('provider-microsoft/Folder Management', () => {
 
     expect(client.post).toHaveBeenNthCalledWith(1, '/me/messages/msg-1/move', { destinationId: 'news-id' });
     expect(client.post).toHaveBeenNthCalledWith(2, '/me/messages/msg-2/move', { destinationId: 'news-id' });
-    expect(get).toHaveBeenCalledTimes(2);
+    // Writes deliberately bypass the 60s cache: a cached path->id mapping can
+    // point at a folder that was renamed/moved out from under it, which would
+    // silently file mail somewhere the user never asked for. Each move costs
+    // one extra traversal; reads still use the cache.
+    expect(get).toHaveBeenCalledTimes(4);
   });
 
   it('Scenario: Well-known moves retain alias behavior without folder traversal', async () => {
@@ -107,7 +111,9 @@ describe('provider-microsoft/Folder Management', () => {
 
     expect(created.path).toBe('Parent/Child');
     expect(post).toHaveBeenCalledWith('/me/mailFolders/custom-id/childFolders', { displayName: 'Child' });
-    expect(rootReads).toBe(2);
+    // 1: initial listFolders. 2: write-path re-resolve of the parent.
+    // 3: post-create listFolders, the cache having been invalidated.
+    expect(rootReads).toBe(3);
   });
 
   it('Scenario: Refuses system folder deletion by well-known name', async () => {
@@ -167,6 +173,10 @@ describe('provider-microsoft/Inbox Rule Management', () => {
       if (url.startsWith('/me/mailFolders?')) {
         return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
       }
+      // The destination is re-checked against resolved system folder ids, so a
+      // custom folder can't sneak through by mapping onto a system folder.
+      const systemLookup = /^\/me\/mailFolders\/([a-z]+)\?/.exec(url);
+      if (systemLookup) return { id: `system-${systemLookup[1]}` };
       throw new Error(`Unexpected URL: ${url}`);
     });
     const post = vi.fn().mockResolvedValue({ id: 'rule-1', displayName: 'GitHub' });
@@ -206,5 +216,88 @@ describe('provider-microsoft/Inbox Rule Management', () => {
     expect(client.delete).toHaveBeenCalledWith(
       '/me/mailFolders/inbox/messageRules/rule%2F%2B%3Did',
     );
+  });
+});
+
+describe('provider-microsoft/Peer-review hardening (PR #106)', () => {
+  it('Scenario: Rejects case-variant forwarding actions called directly on the provider', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    // Graph treats JSON keys case-insensitively, so a case-sensitive blocklist
+    // would let these provision a real exfiltrating rule.
+    for (const key of ['ForwardTo', 'REDIRECTTO', 'forwardAsAttachmentTo', ' Delete ']) {
+      await expect(provider.createInboxRule({
+        displayName: 'Bypass attempt',
+        conditions: {},
+        actions: { [key]: [{ emailAddress: { address: 'attacker@evil.com' } }] },
+      })).rejects.toMatchObject({ code: 'UNSAFE_RULE_ACTION' });
+    }
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Fails closed on rule actions outside the safe allowlist', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.createInboxRule({
+      displayName: 'Unknown future Graph action',
+      conditions: {},
+      actions: { someFutureAction: true },
+    })).rejects.toMatchObject({ code: 'UNSUPPORTED_RULE_ACTION' });
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Caps total Graph requests across a wide recursive folder tree', async () => {
+    // Every folder claims a child, so an uncapped traversal recurses forever.
+    const get = vi.fn(async () => ({
+      value: [{ id: `f-${get.mock.calls.length}`, displayName: `F${get.mock.calls.length}`, childFolderCount: 1 }],
+    }));
+    const provider = new GraphEmailProvider(createMockClient({ get }));
+
+    // Truncates rather than throwing: a partial list beats a hard failure.
+    const folders = await provider.listFolders();
+    expect(folders.length).toBeGreaterThan(0);
+    // Budget is shared across the recursion, not reset per collection.
+    expect(get.mock.calls.length).toBeLessThanOrEqual(400);
+  });
+});
+
+describe('provider-microsoft/Destructive rule destinations (PR #106 review)', () => {
+  it('Scenario: Blocks a rule that files mail into Deleted Items via any alias', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    // `trash`/`deleted` both resolve to deleteditems — a `delete` action in
+    // disguise, and with empty conditions it would discard the whole mailbox.
+    for (const destination of ['trash', 'deleted', 'DeletedItems', ' Trash ']) {
+      await expect(provider.createInboxRule({
+        displayName: 'Discard everything',
+        conditions: {},
+        actions: { moveToFolder: destination },
+      })).rejects.toMatchObject({ code: 'UNSAFE_RULE_DESTINATION' });
+    }
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Does not cache a truncated folder snapshot', async () => {
+    let calls = 0;
+    const get = vi.fn(async () => {
+      calls += 1;
+      // First traversal is unbounded-wide (forces truncation); afterwards the
+      // mailbox settles into a single small folder.
+      if (calls < 405) {
+        return { value: [{ id: `f-${calls}`, displayName: `F${calls}`, childFolderCount: 1 }] };
+      }
+      return { value: [{ id: 'real-id', displayName: 'Newsletters', childFolderCount: 0 }] };
+    });
+    const provider = new GraphEmailProvider(createMockClient({ get }));
+
+    await provider.listFolders();
+    const before = get.mock.calls.length;
+    await provider.listFolders();
+    // A cached truncated tree would have made the second call free — and would
+    // have made "folder not found" sticky for 60s on folders that do exist.
+    expect(get.mock.calls.length).toBeGreaterThan(before);
   });
 });

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { GraphEmailProvider, type GraphApiClient } from './email-graph-provider.js';
+import { GraphEmailProvider, GraphApiError, type GraphApiClient } from './email-graph-provider.js';
 
 function createMockClient(overrides: Partial<GraphApiClient> = {}): GraphApiClient {
   return {
@@ -423,7 +423,8 @@ describe('provider-microsoft/Round-2 Codex probes (PR #106)', () => {
       if (url.startsWith('/me/mailFolders?') || url.includes('/childFolders?')) {
         return { value: [{ id: `f-${get.mock.calls.length}`, displayName: 'Target', childFolderCount: 1 }] };
       }
-      throw new Error(`Unexpected URL: ${url}`);
+      // 'Target' is a name, not an id — the direct-GET fallback 404s.
+      throw new GraphApiError(404, 'ErrorItemNotFound');
     });
     const provider = new GraphEmailProvider(createMockClient({ get }));
 
@@ -432,12 +433,17 @@ describe('provider-microsoft/Round-2 Codex probes (PR #106)', () => {
     });
   });
 
-  it('Scenario: An exact folder id still resolves against a truncated tree', async () => {
+  it('Scenario: An exact folder id resolves even when it lies beyond the truncation prefix', async () => {
+    // The wanted id is NEVER in the traversed tree (every listed folder is a
+    // decoy that claims a child, forcing truncation). Resolution must fall back
+    // to a direct GET of the id rather than failing with FOLDER_TRAVERSAL_LIMIT.
     const get = vi.fn(async (url: string) => {
       if (url.startsWith('/me/mailFolders?') || url.includes('/childFolders?')) {
         const n = get.mock.calls.length;
-        return { value: [{ id: n === 1 ? 'wanted-id' : `f-${n}`, displayName: `F${n}`, childFolderCount: 1 }] };
+        return { value: [{ id: `decoy-${n}`, displayName: `F${n}`, childFolderCount: 1 }] };
       }
+      // Direct single-folder GET fallback for the exact id.
+      if (url.includes('/mailFolders/wanted-id')) return { id: 'wanted-id' };
       throw new Error(`Unexpected URL: ${url}`);
     });
     const post = vi.fn().mockResolvedValue({ id: 'moved-id' });
@@ -446,5 +452,24 @@ describe('provider-microsoft/Round-2 Codex probes (PR #106)', () => {
     const newId = await provider.moveToFolder('msg-1', 'wanted-id');
     expect(newId).toBe('moved-id');
     expect(post).toHaveBeenCalledWith('/me/messages/msg-1/move', { destinationId: 'wanted-id' });
+  });
+
+  it('Scenario: A non-id name beyond the truncation prefix still fails closed', async () => {
+    // The direct-GET fallback 404s for a name, so we must NOT misroute — the
+    // move fails with FOLDER_TRAVERSAL_LIMIT rather than guessing.
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?') || url.includes('/childFolders?')) {
+        const n = get.mock.calls.length;
+        return { value: [{ id: `decoy-${n}`, displayName: `F${n}`, childFolderCount: 1 }] };
+      }
+      throw new GraphApiError(404, 'ErrorItemNotFound');
+    });
+    const post = vi.fn();
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await expect(provider.moveToFolder('msg-1', 'Some Folder Name')).rejects.toMatchObject({
+      code: 'FOLDER_TRAVERSAL_LIMIT',
+    });
+    expect(post).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Adds six MCP tools for folder CRUD and server-side inbox rules, plus custom-folder-name resolution for `move_to_folder`. Motivation is the production VIP-inbox-watch gap in #14: message-level sweeps re-process the same recurring senders every session, whereas a server-side rule stops the noise at the source at zero per-message token cost.

## Implementation
- **Provider interfaces**: `EmailFolderManager` + `EmailRuleManager`, composed into `EmailProvider` as `Partial<...>`.
- **Actions** (`email-core`): `folders.ts` / `rules.ts` with Zod v4 schemas and `NOT_SUPPORTED` degradation. MCP server stays a thin adapter — registration only.
- **Graph**: recursive `/mailFolders` traversal with `@odata.nextLink` pagination and computed paths; `messageRules` list/create/delete; 60s-TTL resolver cache (reads only).
- **Gmail**: intentionally unimplemented — degrades via `NOT_SUPPORTED`.

## Security posture (V1 + peer-review hardening)
- `create_inbox_rule`: safe-action **allowlist** (case-normalized) enforced at **both** the action and provider layers; blocks `forwardTo` / `forwardAsAttachmentTo` / `redirectTo` / `delete` and any unknown action (fail-closed).
- **Destructive destinations blocked**: a rule filing mail into Deleted Items (or `trash`/`deleted` aliases) is rejected — it is `delete` in disguise.
- **`delete_folder` / `delete_inbox_rule` gated** behind the same operator deletion policy as `delete_email` (`deleteEnabled` + `user_explicitly_requested_deletion`).
- **`delete_folder`** additionally refuses system folders by resolved id.
- **Writes bypass the cache**: folder resolution for moves / create / delete / rule destinations re-fetches so a renamed folder can't misroute mail.
- **Bounded traversal**: large mailboxes truncate (never hard-fail, never cache a partial tree); name lookups on a truncated tree return `FOLDER_TRAVERSAL_LIMIT`, not a false `FOLDER_NOT_FOUND`.
- `user_explicitly_approved` is **caller attestation / audit metadata, not a human-approval gate** — real human-in-the-loop must come from the MCP client's tool-approval UI. Documented as such.

## ⚠️ Requires re-consent
Adds `MailboxSettings.ReadWrite` to `GRAPH_SCOPES`. **Existing users must re-authenticate** — cached tokens will not silently gain the scope. App-only/client-credentials deployments additionally need the corresponding application permission + admin grant.

## Verification
- [x] `openspec validate add-folder-and-rule-management --strict` — valid
- [x] Build clean across all workspaces
- [x] Full suite green (852 tests); existing `move_to_folder` + `delete_email` tests pass unchanged
- [x] Lint clean
- [x] Peer review (agy + Codex) — complete; 6 findings fixed with regression tests (see comment below)

Note: root-wide `tsc --noEmit` exits non-zero on **pre-existing** test-file errors in unrelated files; no new errors from this change.

## Closes
- #14
- #107