### PR TITLE
fix(graph): auto-assign inbox-rule sequence when omitted

### DIFF
--- a/packages/email-core/src/actions/rules.test.ts
+++ b/packages/email-core/src/actions/rules.test.ts
@@ -33,6 +33,18 @@ describe('email-inbox-rules/List Inbox Rules', () => {
 });
 
 describe('email-inbox-rules/Create Inbox Rule', () => {
+  it('Scenario: Schema rejects sequence 0 and out-of-range values (Graph requires 1..Int32)', () => {
+    const base = {
+      display_name: 'X', conditions: {}, actions: { markAsRead: true }, user_explicitly_approved: true,
+    };
+    for (const bad of [0, -1, 1.5, 2_147_483_648]) {
+      expect(createInboxRuleAction.input.safeParse({ ...base, sequence: bad }).success).toBe(false);
+    }
+    // Omitted and valid positive sequences pass.
+    expect(createInboxRuleAction.input.safeParse(base).success).toBe(true);
+    expect(createInboxRuleAction.input.safeParse({ ...base, sequence: 5 }).success).toBe(true);
+  });
+
   it('Scenario: Create an approved safe move rule', async () => {
     const rule = { id: 'rule-1', displayName: 'GitHub', actions: { moveToFolder: 'Newsletters' } };
     const createInboxRule = vi.fn().mockResolvedValue(rule);

--- a/packages/email-core/src/actions/rules.ts
+++ b/packages/email-core/src/actions/rules.ts
@@ -56,7 +56,10 @@ export const listInboxRulesAction: EmailAction<
 
 const CreateInboxRuleInput = z.object({
   display_name: z.string().min(1),
-  sequence: z.number().int().nonnegative().optional(),
+  // Graph rejects sequence 0 and requires an Int32; forbid the invalid range at
+  // the boundary so a schema-valid request can't still fail live. Omit it to let
+  // the provider auto-assign the next sequence.
+  sequence: z.number().int().min(1).max(2_147_483_647).optional(),
   is_enabled: z.boolean().optional().default(true),
   conditions: JsonObject,
   exceptions: JsonObject.optional(),

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -677,10 +677,22 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       }
     }
 
+    // Graph rejects sequence 0 (`MessageRuleValidationError` on Field 'Sequence'),
+    // which is exactly the value it assigns when a POST omits sequence. The tool
+    // exists so an agent can propose a rule without knowing Exchange internals,
+    // so when the caller doesn't specify one, append the rule after the existing
+    // rules (max existing sequence + 1, or 1 for an empty mailbox).
+    let sequence = rule.sequence;
+    if (sequence === undefined || sequence === null) {
+      const existing = await this.listInboxRules();
+      sequence = existing.reduce((max, r) => Math.max(max, r.sequence ?? 0), 0) + 1;
+    }
+
     // Spread `actions` last so the canonicalized/resolved actions replace the
     // caller's original (possibly mis-cased) actions in the payload.
     return await this.client.post(`${this.basePath}/mailFolders/inbox/messageRules`, {
       ...rule,
+      sequence,
       actions,
     }) as InboxRule;
   }

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -682,10 +682,24 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     // exists so an agent can propose a rule without knowing Exchange internals,
     // so when the caller doesn't specify one, append the rule after the existing
     // rules (max existing sequence + 1, or 1 for an empty mailbox).
+    const GRAPH_MAX_SEQUENCE = 2_147_483_647; // Graph stores sequence as Int32.
     let sequence = rule.sequence;
     if (sequence === undefined || sequence === null) {
       const existing = await this.listInboxRules();
-      sequence = existing.reduce((max, r) => Math.max(max, r.sequence ?? 0), 0) + 1;
+      const maxExisting = existing.reduce((max, r) => Math.max(max, r.sequence ?? 0), 0);
+      // Defensive: never exceed Int32 (a pathological existing sequence at the
+      // ceiling would otherwise overflow to an invalid value).
+      sequence = Math.min(maxExisting + 1, GRAPH_MAX_SEQUENCE);
+    } else if (!Number.isInteger(sequence) || sequence < 1 || sequence > GRAPH_MAX_SEQUENCE) {
+      // The action schema already enforces this, but the provider is a public
+      // interface — reject an out-of-range explicit sequence rather than letting
+      // Graph fail it with an opaque 400.
+      throw new ProviderError(
+        'INVALID_RULE_SEQUENCE',
+        `Inbox rule sequence must be an integer between 1 and ${GRAPH_MAX_SEQUENCE}; received ${sequence}`,
+        'microsoft',
+        false,
+      );
     }
 
     // Spread `actions` last so the canonicalized/resolved actions replace the

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -519,3 +519,33 @@ describe('provider-microsoft/Round-2 Codex probes (PR #106)', () => {
     expect(post).not.toHaveBeenCalled();
   });
 });
+
+describe('provider-microsoft/Rule sequence bounds (PR #109 review)', () => {
+  it('Scenario: Rejects an explicit out-of-range sequence at the provider', async () => {
+    const post = vi.fn();
+    const provider = new GraphEmailProvider(createMockClient({ post }));
+
+    for (const bad of [0, -1, 1.5, 2_147_483_648]) {
+      await expect(provider.createInboxRule({
+        displayName: 'Bad seq', sequence: bad, conditions: {}, actions: { markAsRead: true },
+      })).rejects.toMatchObject({ code: 'INVALID_RULE_SEQUENCE' });
+    }
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Auto-assigned sequence never exceeds the Int32 ceiling', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url === '/me/mailFolders/inbox/messageRules') {
+        return { value: [{ id: 'r', sequence: 2_147_483_647 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const post = vi.fn().mockResolvedValue({ id: 'rule-1' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await provider.createInboxRule({ displayName: 'Ceiling', conditions: {}, actions: { markAsRead: true } });
+
+    const body = post.mock.calls[0]![1] as { sequence: number };
+    expect(body.sequence).toBe(2_147_483_647);
+  });
+});

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -174,6 +174,10 @@ describe('provider-microsoft/Inbox Rule Management', () => {
       if (url.startsWith('/me/mailFolders?')) {
         return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
       }
+      // No sequence supplied → the provider lists existing rules to append.
+      if (url === '/me/mailFolders/inbox/messageRules') {
+        return { value: [{ id: 'r1', sequence: 1 }, { id: 'r2', sequence: 3 }] };
+      }
       // The destination is re-checked against resolved system folder ids, so a
       // custom folder can't sneak through by mapping onto a system folder.
       const systemLookup = /^\/me\/mailFolders\/([a-z]+)\?/.exec(url);
@@ -191,9 +195,49 @@ describe('provider-microsoft/Inbox Rule Management', () => {
 
     expect(post).toHaveBeenCalledWith('/me/mailFolders/inbox/messageRules', {
       displayName: 'GitHub',
+      // Appended after the existing max sequence (3) → 4, never Graph's
+      // invalid default of 0.
+      sequence: 4,
       conditions: { senderContains: ['github.com'] },
       actions: { moveToFolder: 'news-id', markAsRead: true },
     });
+  });
+
+  it('Scenario: Omitted sequence is auto-assigned, never 0 (live Graph rejects 0)', async () => {
+    // Empty mailbox → first rule gets sequence 1.
+    const get = vi.fn(async (url: string) => {
+      if (url === '/me/mailFolders/inbox/messageRules') return { value: [] };
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const post = vi.fn().mockResolvedValue({ id: 'rule-1' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await provider.createInboxRule({
+      displayName: 'First rule',
+      conditions: {},
+      actions: { markAsRead: true },
+    });
+
+    const body = post.mock.calls[0]![1] as { sequence: number };
+    expect(body.sequence).toBe(1);
+    expect(body.sequence).not.toBe(0);
+  });
+
+  it('Scenario: An explicit sequence is preserved and skips the rule lookup', async () => {
+    const get = vi.fn(async () => { throw new Error('should not list rules when sequence is explicit'); });
+    const post = vi.fn().mockResolvedValue({ id: 'rule-1' });
+    const provider = new GraphEmailProvider(createMockClient({ get, post }));
+
+    await provider.createInboxRule({
+      displayName: 'Explicit',
+      sequence: 7,
+      conditions: {},
+      actions: { markAsRead: true },
+    });
+
+    expect(get).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith('/me/mailFolders/inbox/messageRules',
+      expect.objectContaining({ sequence: 7 }));
   });
 
   it('Scenario: Rejects unsafe actions even when the provider is called directly', async () => {
@@ -325,6 +369,7 @@ describe('provider-microsoft/Round-2 review hardening (PR #106)', () => {
     // getSystemFolderIdMap resolves each well-known name; archive/junkemail are
     // legitimate rule destinations and must survive the destructive-id re-check.
     const get = vi.fn(async (url: string) => {
+      if (url === '/me/mailFolders/inbox/messageRules') return { value: [] };
       const m = /\/me\/mailFolders\/([a-z]+)\?/.exec(url);
       if (m) return { id: `system-${m[1]}` };
       throw new Error(`Unexpected URL: ${url}`);
@@ -354,6 +399,7 @@ describe('provider-microsoft/Round-2 review hardening (PR #106)', () => {
       if (url.startsWith('/me/mailFolders?')) {
         return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
       }
+      if (url === '/me/mailFolders/inbox/messageRules') return { value: [] };
       const m = /\/me\/mailFolders\/([a-z]+)\?/.exec(url);
       if (m) return { id: `system-${m[1]}` };
       throw new Error(`Unexpected URL: ${url}`);


### PR DESCRIPTION
## Summary
`create_inbox_rule` failed against **live Exchange** whenever the caller omitted `sequence`: Graph assigns the omitted value `0`, then rejects `0` as invalid (`MessageRuleValidationError`, Field `Sequence`, Value `0`). Since the tool's whole purpose is to let an agent propose a rule without knowing Exchange internals, the most natural call was broken.

## How it was found
The post-merge **live end-to-end** run of #106 against a real mailbox. #106's unit tests mock the provider, so they never exercised Graph's server-side validation — this only surfaces against real Exchange.

## Fix
When `sequence` is omitted, list existing rules and append after them (`max(existing sequence) + 1`, or `1` on an empty mailbox). Explicit sequences are preserved and skip the lookup.

## Verification
- [x] Unit tests: omitted→append (`4` after max `3`), empty→`1`, explicit→preserved & no lookup
- [x] Build + full suite green (862 tests), lint clean
- [x] **Live**: the previously-failing call now creates a rule with auto-assigned sequence `11` (mailbox had 10 rules); artifacts cleaned up afterward

## Context
Follow-up to #106 (issue #14). Independent of the deferred concurrency work in #108.