### PR TITLE
chore(openspec): archive completed change proposals

### DIFF
--- a/apps/oauth-broker/api/routes.test.ts
+++ b/apps/oauth-broker/api/routes.test.ts
@@ -78,8 +78,11 @@ function stubFetchOnce(impl: (input: string, init?: RequestInit) => Promise<Resp
   vi.spyOn(globalThis, 'fetch').mockImplementation(((input, init) => impl(String(input), init as RequestInit | undefined)) as typeof fetch);
 }
 
-describe('broker/routes happy path', () => {
-  it('register → start → callback → claim returns tokens once', async () => {
+describe('provider-gmail/OAuth2 Authentication (broker routes)', () => {
+  it('Scenario: Gmail OAuth via hosted broker', async () => {
+    // register → start → callback → claim returns tokens once: the broker
+    // exchanges Google's authorization code for tokens server-side and the
+    // CLI never sees the broker's client_secret.
     const sessionId = urlSafeRandom();
     const pickupSecret = urlSafeRandom();
     const pickupHash = createHash('sha256').update(pickupSecret).digest('hex');

--- a/apps/oauth-broker/lib/config.test.ts
+++ b/apps/oauth-broker/lib/config.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { _resetConfigForTests, getConfig } from './config.js';
+
+function setEnv(env: Record<string, string | undefined>) {
+  for (const [k, v] of Object.entries(env)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+}
+
+const baseEnv = {
+  GMAIL_OAUTH_CLIENT_ID: 'fake-client',
+  GMAIL_OAUTH_CLIENT_SECRET: 'fake-secret',
+  BROKER_PUBLIC_ORIGIN: 'https://broker.test',
+  KV_REST_API_URL: undefined,
+  BROKER_REQUIRE_KV: undefined,
+  VERCEL_ENV: undefined,
+};
+
+beforeEach(() => {
+  setEnv(baseEnv);
+  _resetConfigForTests();
+});
+
+afterEach(() => {
+  for (const k of Object.keys(baseEnv)) delete process.env[k];
+  delete process.env['VERCEL_ENV'];
+  _resetConfigForTests();
+});
+
+describe('provider-gmail/OAuth2 Authentication (broker config)', () => {
+  it('Scenario: Broker requires Redis in production', () => {
+    // VERCEL_ENV=production with no KV_REST_API_URL must fail fast rather
+    // than silently falling back to in-memory state that is not shared
+    // across function invocations.
+    setEnv({ VERCEL_ENV: 'production' });
+
+    expect(() => getConfig()).toThrow(/require.*Redis|KV_REST_API_URL/i);
+  });
+
+  it('BROKER_REQUIRE_KV=true forces the same failure outside production', () => {
+    setEnv({ BROKER_REQUIRE_KV: 'true' });
+
+    expect(() => getConfig()).toThrow(/require.*Redis|KV_REST_API_URL/i);
+  });
+
+  it('BROKER_REQUIRE_KV=false opts out even in production', () => {
+    setEnv({ VERCEL_ENV: 'production', BROKER_REQUIRE_KV: 'false' });
+
+    expect(() => getConfig()).not.toThrow();
+  });
+
+  it('production with KV_REST_API_URL set does not throw', () => {
+    setEnv({ VERCEL_ENV: 'production', KV_REST_API_URL: 'https://kv.example.com' });
+
+    expect(() => getConfig()).not.toThrow();
+    expect(getConfig().useKv).toBe(true);
+  });
+});

--- a/apps/oauth-broker/lib/store.test.ts
+++ b/apps/oauth-broker/lib/store.test.ts
@@ -43,7 +43,7 @@ function freshSession(secret: string): Session {
   };
 }
 
-describe('broker/store memory backend', () => {
+describe('provider-gmail/OAuth2 Authentication (broker store)', () => {
   it('refuses session_id collisions', async () => {
     const store = getStore();
     const r1 = await store.create('a'.repeat(40), freshSession('secret-1'));
@@ -62,7 +62,8 @@ describe('broker/store memory backend', () => {
     if (!result.ok) expect(result.reason).toBe('pending');
   });
 
-  it('setReady → claim succeeds once and only once (atomic)', async () => {
+  it('Scenario: Atomic one-shot ticket claim', async () => {
+    // setReady → claim succeeds once and only once.
     const store = getStore();
     const id = 'c'.repeat(40);
     const secret = 'secret-success';
@@ -82,7 +83,9 @@ describe('broker/store memory backend', () => {
     if (!b.ok) expect(['consumed', 'not_found']).toContain(b.reason);
   });
 
-  it('claim with wrong secret does NOT consume the session', async () => {
+  it('Scenario: Public session_id is not a bearer credential', async () => {
+    // A wrong-secret claim attempt (the session_id alone is not enough)
+    // must fail without consuming or destroying the session.
     const store = getStore();
     const id = 'd'.repeat(40);
     const secret = 'right';
@@ -99,7 +102,9 @@ describe('broker/store memory backend', () => {
     expect(good.ok).toBe(true);
   });
 
-  it('setFailed surfaces denied vs exchange_failed distinctly', async () => {
+  it('Scenario: Distinguishable terminal states', async () => {
+    // setFailed surfaces denied vs exchange_failed distinctly; sibling
+    // tests in this file cover the pending and expired terminal states.
     const store = getStore();
     const id = 'e'.repeat(40);
     const secret = 'sec';

--- a/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/design.md
+++ b/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Folder and rule behavior differs sharply between Microsoft Graph and Gmail. Graph exposes hierarchical mail folders and Exchange inbox rules, while Gmail's closest primitives are labels and filters. The action registry must remain the single source of truth and transport adapters must remain generic.
+
+## Goals / Non-Goals
+
+- Goals: hierarchical folder CRUD, faithful rule listing, safe minimal rule creation, server-side rule deletion, and custom-folder moves for Microsoft Graph.
+- Goals: typed graceful degradation for providers that omit either capability.
+- Non-goals: Gmail label/filter emulation, client-side rule execution, unsafe forwarding/redirection/deletion actions, and transport-specific business logic.
+
+## Decisions
+
+### Optional provider capabilities
+
+`EmailFolderManager` and `EmailRuleManager` are composed into `EmailProvider` with `Partial<...>`, matching existing optional categorization and attachment capabilities. Core actions test for method presence and return `NOT_SUPPORTED` when absent.
+
+### Folder shape and traversal
+
+`listFolders` returns a flat recursive list. Each folder retains Graph folder fields used by callers and gains a computed slash-delimited `path`. Traversal follows `@odata.nextLink` for roots and every `childFolders` collection. A visited-id guard prevents pathological cycles.
+
+### Folder resolution and caching
+
+Resolution checks well-known aliases first to preserve existing behavior and avoid unnecessary calls. Custom input then matches ids, case-insensitive paths, or a unique case-insensitive display name. Ambiguous display names return a typed provider error asking for a path. The recursive folder list is cached for 60 seconds per provider instance and invalidated after successful create/delete.
+
+### System-folder deletion protection
+
+Deletion rejects known system aliases before resolution. It also loads the well-known folders and rejects a custom request if its resolved id equals a system-folder id. This closes the alias/id bypass while still permitting custom descendants.
+
+### Faithful list, minimal create
+
+`listInboxRules` returns Graph rule objects without discarding fields, including externally created rules containing unsafe actions. `createInboxRule` accepts Graph conditions/exceptions plus a deliberately small set of safe actions. Blocked action keys (`forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete`) remain representable at the action boundary so the core action can return a typed `UNSAFE_RULE_ACTION` response instead of throwing a schema-validation exception. A `user_explicitly_approved` flag is required and must be true.
+
+### Gmail behavior
+
+The Gmail provider does not implement either optional capability. Gmail has labels rather than hierarchical folders and its filter model is not treated as equivalent to Exchange inbox rules. Core actions therefore return `NOT_SUPPORTED` consistently.
+
+### Authentication
+
+Both short and full-URL delegated scope lists add `MailboxSettings.ReadWrite`. Existing cached consent may not include the new permission, so users must re-consent.
+
+## Risks / Trade-offs
+
+- Recursive traversal can make several Graph calls; pagination guards and the 60-second cache bound repeated resolver cost.
+- Display names need not be unique; ambiguous names are rejected in favor of explicit paths.
+- Faithful rule output is intentionally looser than create input so future Graph fields are not silently lost.

--- a/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/proposal.md
+++ b/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Agents can only organize messages reactively today. Microsoft 365 users cannot create custom folders or server-side inbox rules, so recurring mail must be rediscovered and moved during every agent session instead of being handled continuously by Exchange.
+
+## What Changes
+
+- Add `list_folders`, `create_folder`, and `delete_folder` actions backed by a new `EmailFolderManager` provider capability.
+- Recursively enumerate Microsoft Graph mail folders across every page, expose computed paths, and resolve custom folder names or paths for `move_to_folder`.
+- Add a 60-second folder resolver cache that is invalidated after folder creation or deletion.
+- Protect well-known/system folders from `delete_folder`, whether they are requested by well-known name or resolved Graph id.
+- Add `list_inbox_rules`, `create_inbox_rule`, and `delete_inbox_rule` actions backed by a new `EmailRuleManager` provider capability.
+- Return faithful Graph inbox-rule data when listing rules, while limiting rule creation to safe actions and rejecting `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete` with a typed error.
+- Require callers to affirm that a human approved every `create_inbox_rule` request.
+- Add the delegated Microsoft Graph `MailboxSettings.ReadWrite` scope. Existing Microsoft accounts must re-consent before using folder and inbox-rule management.
+- Leave Gmail unchanged: Gmail uses labels and does not provide the same folder/server-rule capabilities, so these actions return the standard typed `NOT_SUPPORTED` result.
+- Update the English tool reference.
+
+## Impact
+
+- Affected specs: `email-folders`, `email-inbox-rules`, `provider-interface`
+- Affected code: `packages/email-core/src/providers/provider.ts`, `packages/email-core/src/actions/`, `packages/email-core/src/index.ts`, `packages/provider-microsoft/src/email-graph-provider.ts`, `packages/provider-microsoft/src/auth.ts`, `README.md`
+- Authentication: Microsoft delegated users must re-consent to `MailboxSettings.ReadWrite`.
+- Compatibility: existing well-known `move_to_folder` destinations remain unchanged; providers without the new optional capabilities degrade with `NOT_SUPPORTED`.

--- a/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/specs/email-folders/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/specs/email-folders/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Recursive Folder Listing
+
+The system SHALL provide a `list_folders` action that recursively lists every provider mail folder across all pages and includes a computed slash-delimited path for each folder.
+
+#### Scenario: Nested paginated folders
+- **WHEN** a Microsoft mailbox has paginated root folders and nested child folders
+- **THEN** `list_folders` returns folders from every page and hierarchy level
+- **AND** a child named `Newsletters` under `Inbox` has path `Inbox/Newsletters`
+
+### Requirement: Folder Creation
+
+The system SHALL provide a `create_folder` action that creates a custom child folder beneath a caller-selected parent folder and invalidates cached folder resolution data.
+
+#### Scenario: Create an inbox child folder
+- **WHEN** `create_folder` is called with `{display_name: "Newsletters", parent_folder: "inbox"}`
+- **THEN** the provider creates `Newsletters` beneath Inbox
+- **AND** a subsequent folder lookup observes the new folder without waiting for cache expiry
+
+### Requirement: Protected Folder Deletion
+
+The system SHALL provide a destructive `delete_folder` action for custom folders and SHALL refuse to delete well-known/system folders by alias, path, or resolved id.
+
+#### Scenario: Refuse system folder id
+- **WHEN** `delete_folder` resolves its input to the Graph id of Inbox
+- **THEN** it returns a typed `SYSTEM_FOLDER_PROTECTED` error
+- **AND** it does not call the Graph delete endpoint
+
+### Requirement: Custom Folder Moves
+
+The system SHALL resolve `move_to_folder` destinations by well-known alias, custom folder id, case-insensitive path, or unambiguous case-insensitive display name, with a 60-second cache for recursive folder data.
+
+#### Scenario: Move to custom folder path
+- **WHEN** `move_to_folder` is called with `{id: "msg123", folder: "Inbox/Newsletters"}`
+- **THEN** the Microsoft provider posts the move using the resolved Graph folder id
+
+#### Scenario: Preserve well-known move behavior
+- **WHEN** `move_to_folder` is called with `inbox`, `archive`, or `trash`
+- **THEN** the provider uses the corresponding well-known Graph destination without requiring folder traversal
+
+### Requirement: Unsupported Folder Provider
+
+Folder actions SHALL return a typed `NOT_SUPPORTED` result when the selected provider does not implement `EmailFolderManager`.
+
+#### Scenario: Gmail folder request
+- **WHEN** `list_folders` is called for a Gmail provider
+- **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`
+
+### Requirement: Bounded Folder Traversal
+
+Recursive folder traversal MUST be bounded by a request budget shared across the entire traversal, not per collection. Exceeding the budget SHALL truncate the listing rather than fail it, and a truncated snapshot MUST NOT be cached.
+
+#### Scenario: Truncate rather than fail on a very large mailbox
+- **WHEN** enumerating folders would exceed the traversal request budget
+- **THEN** `list_folders` returns the folders discovered so far instead of erroring
+
+#### Scenario: Never cache a partial tree
+- **WHEN** a traversal was truncated
+- **THEN** the result is not written to the folder cache, so the next call retries from scratch
+
+#### Scenario: Refuse to infer absence from a truncated tree
+- **WHEN** a folder NAME or PATH match is the only candidate in a truncated snapshot
+- **THEN** the system returns `FOLDER_TRAVERSAL_LIMIT` rather than assuming the visible match is unique
+- **AND** an exact folder-id match still resolves, because ids are globally unique
+
+### Requirement: Fresh Resolution For Structural And Rule Writes
+
+Folder name/path resolution for operations that MUTATE the folder tree (`create_folder` parent, `delete_folder` target) and for inbox-rule destinations MUST NOT be answered from the cached folder snapshot. These are low-frequency and either unrecoverable (deleting the wrong folder) or persistent (a rule that acts 24/7), so a stale path-to-id mapping is worth one fresh traversal to avoid.
+
+#### Scenario: Re-resolve before a structural mutation
+- **WHEN** `create_folder` or `delete_folder` resolves its target folder
+- **THEN** the provider refreshes the folder tree before selecting the id
+
+#### Scenario: Re-resolve a rule destination
+- **WHEN** `create_inbox_rule` resolves a custom folder destination
+- **THEN** the provider refreshes the folder tree and resolves to an opaque folder id
+
+### Requirement: Cached Resolution For Message Moves
+
+`move_to_folder` name resolution SHALL be permitted to use the cached folder snapshot rather than forcing a fresh traversal. A move does not alter the folder tree, runs in high-volume triage loops, and its worst-case staleness (a message filed into a renamed-but-valid folder within the 60s TTL) is recoverable — so forcing a fresh traversal per move, which would trip Graph throttling on the exact workload this feature targets, is the wrong trade. An exact folder id MUST still resolve without depending on a fresh traversal.
+
+#### Scenario: Repeated moves reuse the cache
+- **WHEN** several `move_to_folder` calls target custom folders within the cache TTL
+- **THEN** only the first performs a folder traversal; the rest are served from cache
+
+#### Scenario: Reads still use the cache
+- **WHEN** `list_folders` is called twice within the cache TTL
+- **THEN** the second call is served from the cached snapshot
+
+### Requirement: Gated Folder Deletion
+
+`delete_folder` MUST be disabled by default and gated behind the same operator deletion policy as `delete_email`, because deleting a folder discards every message it contains. It MUST require an explicit `user_explicitly_requested_deletion` affirmation and MUST return a typed `DELETE_DISABLED` error when the policy is off or the affirmation is absent.
+
+#### Scenario: Folder deletion is disabled by default
+- **WHEN** `delete_folder` is called and the operator has not enabled deletion
+- **THEN** it returns `{success: false, error: {code: "DELETE_DISABLED", ...}}` without calling the provider
+
+#### Scenario: Folder deletion requires explicit affirmation
+- **WHEN** `delete_folder` is called with `user_explicitly_requested_deletion: false`
+- **THEN** it returns `DELETE_DISABLED` without calling the provider

--- a/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/specs/email-inbox-rules/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/specs/email-inbox-rules/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Faithful Inbox Rule Listing
+
+The system SHALL provide a read-only `list_inbox_rules` action that returns all fields supplied by the provider, including unsafe actions on rules created outside this system.
+
+#### Scenario: List externally created forwarding rule
+- **WHEN** Graph returns a rule containing `forwardTo`
+- **THEN** `list_inbox_rules` returns the rule and its `forwardTo` action unchanged
+
+### Requirement: Safe Approved Inbox Rule Creation
+
+The system SHALL provide `create_inbox_rule` with minimal safe actions and SHALL require the caller to affirm intent via `user_explicitly_approved` before a rule is created.
+
+This affirmation is caller attestation and audit metadata — NOT a security boundary. The flag is supplied by the calling model, which can set it without consulting a human, so it cannot enforce human approval on its own. Genuine human-in-the-loop MUST come from the MCP client's tool-approval UI. The system SHALL NOT describe this flag as human approval in user-facing text.
+
+#### Scenario: Create attested move rule
+- **WHEN** `create_inbox_rule` receives an attested rule that moves matching mail to a custom folder
+- **THEN** the system resolves the folder and creates the rule through the provider
+
+#### Scenario: Missing intent affirmation
+- **WHEN** `create_inbox_rule` is called without `user_explicitly_approved: true`
+- **THEN** it returns a typed `APPROVAL_REQUIRED` error without calling the provider
+
+### Requirement: Unsafe Rule Action Rejection
+
+The system MUST reject creation of any inbox rule whose actions contain `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, or `delete`, returning a typed error instead of throwing.
+
+#### Scenario: Reject forwarding action
+- **WHEN** `create_inbox_rule` receives an action containing `forwardTo`
+- **THEN** it returns `{success: false, error: {code: "UNSAFE_RULE_ACTION", ...}}`
+- **AND** it does not call the provider
+
+### Requirement: Inbox Rule Deletion
+
+The system SHALL provide a destructive `delete_inbox_rule` action that deletes a rule by id.
+
+#### Scenario: Delete a rule
+- **WHEN** `delete_inbox_rule` is called with `{id: "rule123"}`
+- **THEN** the provider deletes `rule123` from the inbox rules collection
+
+### Requirement: Unsupported Rule Provider
+
+Inbox-rule actions SHALL return a typed `NOT_SUPPORTED` result when the selected provider does not implement `EmailRuleManager`.
+
+#### Scenario: Gmail rule request
+- **WHEN** `list_inbox_rules` is called for a Gmail provider
+- **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`
+
+### Requirement: Destructive Rule Destination Rejection
+
+The system MUST reject creation of any inbox rule whose `moveToFolder` or `copyToFolder` destination resolves to a mail-discarding folder (Deleted Items, recoverable-items dumpster, or their aliases such as `trash`/`deleted`). Filing mail into these is functionally equivalent to the blocked `delete` action and, combined with empty conditions, would discard the entire mailbox.
+
+#### Scenario: Reject a rule that files mail into Deleted Items
+- **WHEN** `create_inbox_rule` receives `{"actions": {"moveToFolder": "trash"}}`
+- **THEN** it returns `{success: false, error: {code: "UNSAFE_RULE_DESTINATION", ...}}`
+- **AND** it does not call the provider
+
+#### Scenario: Reject aliases and case variants after resolution
+- **WHEN** a destination such as `deleted`, `DeletedItems`, or ` Trash ` normalizes to the deleted-items folder
+- **THEN** the provider rejects it with `UNSAFE_RULE_DESTINATION` before issuing any write
+
+### Requirement: Provider-Layer Rule Action Enforcement
+
+Provider implementations of `EmailRuleManager.createInboxRule` MUST independently enforce the safe-action allowlist using case-normalized keys, because Microsoft Graph accepts JSON keys case-insensitively and the interface is callable without passing through the MCP action layer.
+
+#### Scenario: Reject case-variant forwarding at the provider
+- **WHEN** `createInboxRule` is called directly with an action key of `ForwardTo` or `REDIRECTTO`
+- **THEN** the provider throws `UNSAFE_RULE_ACTION` without issuing a write
+
+#### Scenario: Fail closed on unknown actions
+- **WHEN** an action key outside the safe allowlist is supplied
+- **THEN** the provider throws `UNSUPPORTED_RULE_ACTION` rather than forwarding it to Graph
+
+### Requirement: Gated Rule Deletion
+
+`delete_inbox_rule` MUST be disabled by default and gated behind the same operator deletion policy as `delete_email`, because removing a rule can silently re-expose the mailbox to filtered mail or remove an organization/anti-abuse rule. It MUST require an explicit `user_explicitly_requested_deletion` affirmation and MUST return a typed `DELETE_DISABLED` error when the policy is off or the affirmation is absent.
+
+#### Scenario: Rule deletion is disabled by default
+- **WHEN** `delete_inbox_rule` is called and the operator has not enabled deletion
+- **THEN** it returns `{success: false, error: {code: "DELETE_DISABLED", ...}}` without calling the provider
+
+#### Scenario: Rule deletion requires explicit affirmation
+- **WHEN** `delete_inbox_rule` is called with `user_explicitly_requested_deletion: false`
+- **THEN** it returns `DELETE_DISABLED` without calling the provider

--- a/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/specs/provider-interface/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/specs/provider-interface/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Optional Folder and Rule Capabilities
+
+The provider abstraction SHALL define `EmailFolderManager` and `EmailRuleManager` as optional capabilities on the combined `EmailProvider` type and SHALL advertise `folders` and `rules` in provider capability metadata.
+
+#### Scenario: Provider omits optional capabilities
+- **WHEN** a provider implements email reading and sending but not folder or rule management
+- **THEN** it remains a valid `EmailProvider`
+- **AND** folder and rule actions can detect the missing capability
+
+### Requirement: Microsoft Mailbox Settings Consent
+
+The Microsoft delegated authentication configuration SHALL request `MailboxSettings.ReadWrite` in both the short and full-URL Graph scope lists.
+
+#### Scenario: Existing user reconnects
+- **WHEN** an existing Microsoft user reconnects after this capability is introduced
+- **THEN** the consent request includes `MailboxSettings.ReadWrite`
+- **AND** user-facing documentation states that re-consent is required

--- a/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/tasks.md
+++ b/openspec/changes/archive/2026-07-22-add-folder-and-rule-management/tasks.md
@@ -1,0 +1,9 @@
+- [x] Add and export `EmailFolderManager` and `EmailRuleManager` provider contracts and capability metadata.
+- [x] Add folder actions and unit tests for listing, creation, deletion, annotations, unsupported providers, and system-folder errors.
+- [x] Add inbox-rule actions and unit tests for faithful listing, safe creation, explicit approval, blocked actions, deletion, annotations, and unsupported providers.
+- [x] Implement recursive paginated Microsoft Graph folder traversal, computed paths, creation, deletion, and 60-second cached resolution.
+- [x] Resolve custom folder names and paths in `moveToFolder` while preserving well-known aliases.
+- [x] Implement Microsoft Graph inbox-rule list/create/delete endpoints.
+- [x] Add `MailboxSettings.ReadWrite` to both delegated scope lists and document re-consent.
+- [x] Export/register all six actions and update the English README tool reference.
+- [x] Run strict OpenSpec validation, focused action tests, move regression tests, build, full test suite, type-check, and lint.

--- a/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/proposal.md
+++ b/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+The repository now supports Gmail mailbox loading from stored refresh tokens, but the CLI still rejects `email-agent-mcp configure --provider gmail` and the wizard still describes Gmail as a manual-only path. This leaves the advertised multi-provider architecture incomplete and forces users to create token files by hand.
+
+## What Changes
+
+- Add an interactive Gmail configure flow behind `email-agent-mcp configure --provider gmail`
+- Use a localhost OAuth callback flow with PKCE to obtain Gmail refresh tokens from a Google OAuth client
+- Persist Gmail mailbox metadata under `~/.email-agent-mcp/tokens/` using the mailbox email as the canonical storage key
+- Auto-add the authenticated Gmail address to the send allowlist, matching the Microsoft configure path
+- Update the wizard and CLI docs so Gmail is presented as an available interactive provider instead of "coming soon" or manual-only
+
+## Impact
+
+- Affected specs: `cli`, `mailbox-config`, `provider-gmail`
+- Affected code: `packages/email-mcp`, `packages/provider-gmail`
+- User-visible behavior: `configure` and first-run wizard can complete Gmail setup without manual token file editing

--- a/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/specs/cli/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Subcommand
+
+The system SHALL provide a `configure` subcommand (aliased as `setup`) with an interactive setup wizard: provider picker, credentials entry, connection test, and config persistence.
+
+#### Scenario: Interactive setup
+- **WHEN** `email-agent-mcp configure` is run
+- **THEN** the system launches the interactive wizard with a provider picker for Outlook and Gmail and tests the selected connection
+
+#### Scenario: Direct Gmail configure
+- **WHEN** `email-agent-mcp configure --provider gmail` is run
+- **THEN** the system starts the Gmail OAuth flow
+- **AND** persists mailbox metadata after the callback completes successfully
+
+#### Scenario: Setup alias
+- **WHEN** `email-agent-mcp setup` is run
+- **THEN** the system behaves identically to `email-agent-mcp configure`
+
+### Requirement: Interactive Wizard
+
+The interactive wizard SHALL guide the user through provider selection, credential entry, and connection verification. It uses a provider picker presenting available options.
+
+#### Scenario: Provider picker shows available providers
+- **WHEN** the interactive wizard starts
+- **THEN** it presents a provider picker with both Outlook and Gmail as selectable providers
+
+#### Scenario: Wizard persists config on success
+- **WHEN** the wizard completes successfully (credentials validated, connection tested)
+- **THEN** it writes the configuration to `~/.email-agent-mcp/config.json`
+- **AND** the configured email address is auto-added to the send allowlist

--- a/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/specs/mailbox-config/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/specs/mailbox-config/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Mailbox
+
+The system SHALL provide a `configure_mailbox` action that connects a named mailbox to a provider with credentials. The resulting metadata SHALL include the `emailAddress` field fetched from the provider during configuration.
+
+#### Scenario: Add work mailbox
+- **WHEN** `configure_mailbox` is called with `{name: "work", provider: "microsoft", credentials: {...}, default: true}`
+- **THEN** the system connects to the Microsoft Graph API, fetches the email address, and marks "work" as the default mailbox
+- **AND** the stored metadata includes `emailAddress`
+
+#### Scenario: Add Gmail mailbox
+- **WHEN** `configure_mailbox` is called with `{name: "personal", provider: "gmail", credentials: {...}}`
+- **THEN** the system completes the Gmail OAuth exchange, fetches the Gmail account email address, and persists Gmail mailbox metadata under `~/.email-agent-mcp/tokens/`
+- **AND** the stored metadata includes `emailAddress`
+
+### Requirement: Convention-Over-Configuration Paths
+
+The system SHALL use `~/.email-agent-mcp/` as the default home directory (overridable via `EMAIL_AGENT_MCP_HOME` env var) with well-known subdirectories and files loaded by convention.
+
+#### Scenario: Default home directory
+- **WHEN** `EMAIL_AGENT_MCP_HOME` is not set
+- **THEN** the system uses `~/.email-agent-mcp/` as the home directory
+
+#### Scenario: Custom home directory via env var
+- **WHEN** `EMAIL_AGENT_MCP_HOME` is set to `/tmp/ae-test`
+- **THEN** the system uses `/tmp/ae-test/` as the home directory instead of `~/.email-agent-mcp/`
+
+#### Scenario: Tokens directory for auth metadata
+- **WHEN** the system stores authentication metadata (OAuth tokens, refresh tokens)
+- **THEN** it writes to `~/.email-agent-mcp/tokens/`
+
+#### Scenario: State directory for watcher state and locks
+- **WHEN** the system stores watcher checkpoints or lock files
+- **THEN** it writes to `~/.email-agent-mcp/state/`
+
+#### Scenario: Config file for persistent settings
+- **WHEN** the system reads or writes persistent configuration
+- **THEN** it uses `~/.email-agent-mcp/config.json` containing wakeUrl, hooksToken, and pollIntervalSeconds
+
+#### Scenario: Allowlist files loaded by convention
+- **WHEN** the system checks send or receive allowlists
+- **THEN** it loads `~/.email-agent-mcp/send-allowlist.json` and `~/.email-agent-mcp/receive-allowlist.json` by convention
+
+#### Scenario: Auto-add email to send allowlist during configure
+- **WHEN** a mailbox is successfully configured
+- **THEN** the configured email address is automatically added to `send-allowlist.json`

--- a/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/specs/provider-gmail/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/specs/provider-gmail/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: OAuth2 Authentication
+
+The system SHALL authenticate to Gmail via OAuth2 using `@googleapis/gmail` (NOT the full `googleapis` package at 200MB).
+
+#### Scenario: Gmail OAuth
+- **WHEN** `configure_mailbox` is called with `{provider: "gmail"}`
+- **THEN** the system initiates OAuth2 flow and persists refresh tokens
+
+#### Scenario: Gmail CLI OAuth callback
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with a valid Google OAuth client configuration
+- **THEN** the system opens a browser authorization URL or prints it for the user to visit
+- **AND** receives the authorization callback on a local loopback address
+- **AND** exchanges the code for tokens using PKCE before persisting the refresh token

--- a/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/tasks.md
+++ b/openspec/changes/archive/2026-07-22-add-gmail-cli-configure/tasks.md
@@ -1,0 +1,8 @@
+- [x] Update OpenSpec deltas for CLI, mailbox config, and Gmail provider
+- [x] Implement Gmail CLI configure flow with local OAuth callback and PKCE
+- [x] Persist Gmail mailbox metadata using canonical email-based filenames
+- [x] Auto-add configured Gmail addresses to the send allowlist
+- [x] Update wizard and docs to present Gmail interactive configure as available
+- [x] Add or update tests for Gmail configure, auth helpers, and wizard behavior
+- [x] Run `openspec validate add-gmail-cli-configure --strict`
+- [x] Run targeted package tests and project validation

--- a/openspec/changes/archive/2026-07-22-add-strip-quoted-history/proposal.md
+++ b/openspec/changes/archive/2026-07-22-add-strip-quoted-history/proposal.md
@@ -1,0 +1,16 @@
+## Why
+
+`read_email` returns the full MIME body including all nested reply chains. A 3-line reply in a long thread can return ~12 KB where ~99% is `>>>>>>>>>>>` history the LLM caller already has from earlier turns. There is no opt-in to strip quoted history today, even though the cost of the wasted context is borne entirely by the agent consumer.
+
+## What Changes
+
+- Add an opt-in `strip_quoted_history: boolean` parameter (default `false`) to the `read_email` action and MCP tool.
+- When `true`, detect a **terminal** quoted-history block — Gmail/Apple "On … wrote:" preamble, Outlook header cluster, or terminal `>`-prefix run — and replace it with a `[...prior thread truncated]` marker.
+- Operate on already-normalized text emitted by the existing content engine (`transformEmailContent`); do not re-process raw HTML.
+- Refactor the MCP `read_email` tool from a hand-rolled duplicate into a thin adapter that delegates to `readEmailAction.run(...)`, restoring the "actions are the single source of truth, MCP is a thin adapter" convention.
+
+## Impact
+
+- Affected specs: `email-read`
+- Affected code: `packages/email-core/src/content/`, `packages/email-core/src/actions/read.ts`, `packages/email-core/src/index.ts`, `packages/email-mcp/src/server.ts`
+- User-visible behavior: callers that pass `strip_quoted_history: true` receive a body with the terminal quoted-history block replaced by a short marker. Default behavior is unchanged. Inline blockquotes the user wrote in their latest reply are preserved.

--- a/openspec/changes/archive/2026-07-22-add-strip-quoted-history/specs/email-read/spec.md
+++ b/openspec/changes/archive/2026-07-22-add-strip-quoted-history/specs/email-read/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Optional Quoted-History Stripping
+
+The `read_email` action SHALL accept an optional `strip_quoted_history` boolean parameter. When `true`, the system SHALL detect a terminal quoted-history block — Gmail/Apple "On … wrote:" preambles, Outlook `From:/Sent:/Date:/To:/Subject:` header clusters, an Outlook-2003 `-----Original Message-----` separator followed by an Outlook header cluster, or a terminal run of `>`-prefix lines — and replace it with a single short marker (e.g. `[...prior thread truncated]`). The candidate block SHALL only be stripped when it is genuinely terminal: an inline `On … wrote:` quote followed by user-authored prose SHALL NOT be stripped. When omitted or `false`, the body SHALL be returned unchanged from current behavior. Inline blockquotes appearing within the latest reply SHALL be preserved; only a terminal quoted-history block SHALL be stripped.
+
+The detector is English-only: localized "On … wrote:" preambles (German "Am … schrieb …", French "Le … a écrit", Japanese "送信者:" headers, etc.) are NOT matched. Threads from non-English clients SHALL be returned with full quoted history.
+
+#### Scenario: Strip quoted history when flag is true
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` and the email body contains a Gmail "On … wrote:" preamble followed by a multi-line `>`-prefix quoted reply
+- **THEN** the returned body has the preamble and quoted reply replaced with the marker `[...prior thread truncated]`
+- **AND** the latest reply text and any non-quoted user content above the preamble are preserved
+
+#### Scenario: Default behavior is unchanged
+- **WHEN** `read_email` is called with `{id: "msg123"}` (flag omitted) on the same email
+- **THEN** the returned body is identical to current behavior — full quoted history is included
+
+#### Scenario: Inline blockquote in latest reply is preserved
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on an email whose latest reply contains a markdown blockquote (`> note:` line) followed by more user-authored text and no terminal quoted-history block
+- **THEN** the returned body is unchanged and no marker is inserted
+
+#### Scenario: Inline "On … wrote:" with user prose after is preserved
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on a body that contains an `On … wrote:` preamble and `>`-quoted block in the middle, followed by additional user-authored prose
+- **THEN** the returned body is unchanged and no marker is inserted

--- a/openspec/changes/archive/2026-07-22-add-strip-quoted-history/tasks.md
+++ b/openspec/changes/archive/2026-07-22-add-strip-quoted-history/tasks.md
@@ -1,0 +1,10 @@
+- [x] Add `stripQuotedHistory` helper in `packages/email-core/src/content/quotes.ts` with terminal-block detection and attachments-summary preservation
+- [x] Add unit tests in `packages/email-core/src/content/quotes.test.ts` covering Gmail, Outlook (plain + bolded + Apple Mail Date variant), Outlook-2003 separator, wrapped preambles, deep-nested, CRLF, idempotency, false-positive guards, and attachments preservation
+- [x] Wire `strip_quoted_history` flag into `readEmailAction` in `packages/email-core/src/actions/read.ts`; run order is `transformEmailContent` → `stripQuotedHistory` → `stripSignature`
+- [x] Add optional `contentId?: string` to `ReadEmailOutput.attachments` so MCP and action output shapes align
+- [x] Re-export `readEmailAction` from `packages/email-core/src/index.ts`
+- [x] Refactor MCP `read_email` tool in `packages/email-mcp/src/server.ts` to delegate the connected-provider path to `readEmailAction.run(...)`, keeping demo-mode handling local and exposing the new flag
+- [x] Extend `packages/email-core/src/actions/read.test.ts` with omitted/true/HTML-body/dual-flag/contentId scenarios
+- [x] Extend `packages/email-mcp/src/server.test.ts` `read_email` tests with input-schema, connected-path, demo-path, and no-signature-stripping scenarios
+- [x] Run `openspec validate add-strip-quoted-history --strict`
+- [x] Run `npm run test:run --workspaces` and `npm run lint --workspaces`

--- a/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/proposal.md
+++ b/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Gmail users still need to provide a Google OAuth client ID and client secret before `email-agent-mcp configure --provider gmail` can open the browser consent flow. That creates unnecessary setup friction and makes Gmail feel materially harder to connect than Microsoft, even though both ultimately use OAuth.
+
+We cannot remove that friction by bundling a default OAuth client_secret into the OSS CLI. A live probe of Google's token endpoint confirms the bundled Desktop client_id still requires `client_secret` for code exchange — even with PKCE — so any default-client design that ships the secret violates Google's OAuth policy ("never commit client credentials") with no compensating security benefit. Microsoft's path "just works" with `client_id` only because Entra ID supports public clients natively; Google does not offer an equivalent for a Node CLI.
+
+The defensible way to remove the friction is the same pattern commercial AI email clients (Superhuman, Jace, Shortwave) use: a server-side OAuth client whose secret stays on the server. We adopt that pattern with a deliberate twist — the broker only relays the OAuth dance and refreshes; **email content never touches the broker**. The CLI continues to call Gmail directly with the locally-held access token.
+
+## What Changes
+
+- Add a Vercel-deployable OAuth broker app under `apps/oauth-broker` with five routes (`POST /api/sessions`, `GET /api/start`, `GET /api/callback`, `POST /api/tickets/claim`, `POST /api/refresh`) that hold the Gmail OAuth `client_id` + `client_secret` server-side and relay the dance.
+- Split the public `session_id` (visible in URLs and Google's `state`) from a private `pickup_secret` only the CLI knows; the broker stores SHA-256 of the secret and verifies it in constant time at claim time. URL leakage alone cannot steal tokens.
+- Track session state on the broker (`pending` | `ready` | `consumed` | `denied` | `exchange_failed` | `expired`) so the CLI can surface actionable errors instead of mistaking "user clicked deny" for "still pending".
+- Use atomic Redis `GETDEL` (or single-threaded delete on the in-memory dev backend) for one-shot token claim — concurrent claims with the same correct secret cannot both succeed.
+- Refuse to start in production without Redis attached (`KV_REST_API_URL` must be set when `VERCEL_ENV=production` or `BROKER_REQUIRE_KV=true`).
+- Make broker mode the default for Gmail configure when no BYOK credentials are supplied. The bundled client_secret pattern is **removed** — the CLI no longer ships any Google client_secret.
+- Keep BYO-client (`--client-id` + `--client-secret`) as a first-class path for users who want their own quota / verification status.
+- Add `--broker-url` flag and `AGENT_EMAIL_GMAIL_BROKER_URL` env var so users can self-host the broker.
+- Reject partial BYOK credentials (only one of `--client-id` / `--client-secret`) with a clear error rather than dropping into a broker flow under a different OAuth client identity.
+- Saved mailbox metadata is now discriminated by `source: 'byok' | 'broker'`. Broker-mode metadata stores only `brokerUrl` + `refreshToken` — no `clientSecret` ever lands on disk for broker mailboxes. Pre-existing BYOK metadata (no `source` field) is parsed as `byok` for backward compatibility.
+- Saved-metadata precedence is preserved: re-running `configure` for an existing mailbox reuses whatever mode was saved, so issue #44 stays fixed and existing BYOK users are not silently switched to broker mode on reconnect.
+- Update CLI and Gmail setup documentation to describe the broker as the default path and BYOK as the override.
+
+## Impact
+
+- Affected specs: `cli`, `mailbox-config`, `provider-gmail`
+- Affected code: `packages/email-mcp`, `packages/provider-gmail`, `apps/oauth-broker` (new)
+- User-visible behavior: first-time Gmail users can run configure without entering client credentials by hand; nothing they can read or copy from the source tree authenticates as the OAuth app
+- Operational impact: the project owner (or self-hoster) is now responsible for an OAuth-fronted Vercel service and CASA Tier 2 verification of the OAuth consent screen for `https://mail.google.com/`

--- a/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/specs/cli/spec.md
+++ b/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/specs/cli/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Subcommand
+
+The system SHALL provide a `configure` subcommand (aliased as `setup`) with an interactive setup wizard: provider picker, credentials entry, connection test, and config persistence.
+
+#### Scenario: Interactive setup
+- **WHEN** `email-agent-mcp configure` is run
+- **THEN** the system launches the interactive wizard with a provider picker for Outlook and Gmail and tests the selected connection
+
+#### Scenario: Direct Gmail configure (broker default)
+- **WHEN** `email-agent-mcp configure --provider gmail` is run without `--client-id`, `--client-secret`, or Gmail BYOK env vars, and the mailbox has no prior saved metadata
+- **THEN** the system contacts the OAuth broker (default `https://oauth.usejunior.com`, override via `--broker-url` or `AGENT_EMAIL_GMAIL_BROKER_URL`)
+- **AND** registers a session at `POST /api/sessions` with a locally-generated `session_id` and the SHA-256 hash of a locally-generated `pickup_secret`
+- **AND** opens the broker's authorization URL in the browser, polls `POST /api/tickets/claim` (presenting the raw `pickup_secret` for proof of ownership), and persists mailbox metadata with `source: 'broker'` once consent completes
+
+#### Scenario: Broker URL must be https (or http loopback)
+- **WHEN** `--broker-url` or `AGENT_EMAIL_GMAIL_BROKER_URL` is set to a non-https URL that is not `http://localhost`, `http://127.0.0.1`, or `http://[::1]`
+- **THEN** the system refuses to use it and surfaces a configuration error
+
+#### Scenario: Direct Gmail configure (BYOK)
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with both `--client-id` and `--client-secret` (or both `AGENT_EMAIL_GMAIL_CLIENT_ID` and `AGENT_EMAIL_GMAIL_CLIENT_SECRET`)
+- **THEN** the system runs a local-loopback OAuth flow against Google directly using those credentials
+- **AND** persists mailbox metadata with `source: 'byok'` containing the supplied client_id and client_secret
+
+#### Scenario: Partial BYOK credentials are rejected
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with exactly one of `--client-id` or `--client-secret` (and the corresponding env var for the other half is unset)
+- **THEN** the system exits non-zero with a message stating that BYOK requires both halves and that omitting both selects the broker
+
+#### Scenario: Reconfigure preserves saved mode
+- **WHEN** `email-agent-mcp configure --provider gmail --mailbox <existing>` is run for a mailbox that already has saved metadata
+- **AND** no explicit `--client-id`/`--client-secret`/`--broker-url` flags or env vars are supplied
+- **THEN** the system reuses the saved mode and credentials (broker URL or BYOK client_id/client_secret) rather than switching modes
+- **AND** existing BYOK users on subsequent reconnects are not silently routed through the broker
+
+#### Scenario: Setup alias
+- **WHEN** `email-agent-mcp setup` is run
+- **THEN** the system behaves identically to `email-agent-mcp configure`

--- a/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/specs/mailbox-config/spec.md
+++ b/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/specs/mailbox-config/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Mailbox
+
+The system SHALL provide a `configure_mailbox` action that connects a named mailbox to a provider with credentials. The resulting metadata SHALL include the `emailAddress` field fetched from the provider during configuration.
+
+#### Scenario: Add work mailbox
+- **WHEN** `configure_mailbox` is called with `{name: "work", provider: "microsoft", credentials: {...}, default: true}`
+- **THEN** the system connects to the Microsoft Graph API, fetches the email address, and marks "work" as the default mailbox
+- **AND** the stored metadata includes `emailAddress`
+
+#### Scenario: Gmail mailbox metadata is mode-discriminated
+- **WHEN** a Gmail mailbox is configured
+- **THEN** the stored metadata records a `source` discriminator equal to `'broker'` or `'byok'`
+- **AND** for `'byok'` the metadata stores the user-supplied `clientId` and `clientSecret` plus the `refreshToken`
+- **AND** for `'broker'` the metadata stores the `brokerUrl` plus the `refreshToken` and SHALL NOT store any `clientSecret` on disk
+
+#### Scenario: Pre-broker metadata is parsed as BYOK only when unambiguous
+- **WHEN** the system loads a Gmail mailbox metadata file written before the broker change (no `source` field) that has both `clientId` and `clientSecret` and NO `brokerUrl`
+- **THEN** the system treats it as `source: 'byok'` for the purposes of subsequent loads and reconnects
+
+#### Scenario: Ambiguous mixed-shape metadata is rejected
+- **WHEN** the system loads a Gmail mailbox metadata file that contains BOTH `clientSecret` and `brokerUrl`
+- **THEN** the system refuses to interpret the record (returns null) and leaves the mailbox unconfigured, forcing the user to re-run configure
+- **AND** `source: 'broker'` records that lack `brokerUrl`, and `source: 'byok'` records that lack `clientSecret`, are likewise rejected

--- a/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/specs/provider-gmail/spec.md
+++ b/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/specs/provider-gmail/spec.md
@@ -1,12 +1,5 @@
----
-epic: Infrastructure
-feature: Gmail Provider
----
+## MODIFIED Requirements
 
-## Purpose
-
-Implements the provider interface for Gmail API email operations. Uses `@googleapis/gmail` (lightweight, ~1.1MB). Supports OAuth2 authentication, Gmail-specific label/star mapping, dual watch mode (Pub/Sub with 7-day auto-renewal + history.list polling fallback), and anti-spoofing via Authentication-Results headers.
-## Requirements
 ### Requirement: OAuth2 Authentication
 
 The system SHALL authenticate to Gmail via OAuth2 using `@googleapis/gmail` (NOT the full `googleapis` package at 200MB).
@@ -56,40 +49,3 @@ The system SHALL authenticate to Gmail via OAuth2 using `@googleapis/gmail` (NOT
 #### Scenario: Broker requires Redis in production
 - **WHEN** the broker starts with `VERCEL_ENV=production` (or `BROKER_REQUIRE_KV=true`) and `KV_REST_API_URL` is unset
 - **THEN** the broker fails fast with a configuration error rather than silently falling back to in-memory state that is not shared across function invocations
-
-### Requirement: Message Mapping
-
-The system SHALL map Gmail message format to the common `EmailMessage` type, including labels, thread IDs, and attachment metadata.
-
-#### Scenario: Gmail message to EmailMessage
-- **WHEN** a Gmail message is fetched
-- **THEN** it is mapped to `EmailMessage` with `threadId`, labels, and standard fields
-
-### Requirement: Dual Watch Mode
-
-The system SHALL support Pub/Sub push notifications (requires Google Cloud project, auto-renewal every 7 days) and `history.list` polling as a fallback for local/NAT environments.
-
-#### Scenario: Pub/Sub auto-renewal
-- **WHEN** the Pub/Sub watch registration approaches 7-day expiry
-- **THEN** the system automatically re-registers via `users.watch()`
-
-#### Scenario: history.list fallback
-- **WHEN** Pub/Sub is not configured
-- **THEN** the system polls `history.list` at a configurable interval (default 30s)
-
-### Requirement: Label Mapping
-
-The system SHALL map Gmail labels to folder/category concepts: `INBOX`, `SENT`, `TRASH`, `SPAM`, `STARRED`, `IMPORTANT`, and custom labels.
-
-#### Scenario: Label as folder
-- **WHEN** `list_emails` is called with `{folder: "junk"}`
-- **THEN** the system queries messages with the `SPAM` label
-
-### Requirement: NemoClaw Compatibility
-
-The system SHALL document required egress domains: `gmail.googleapis.com`, `oauth2.googleapis.com`, `pubsub.googleapis.com`.
-
-#### Scenario: NemoClaw egress
-- **WHEN** running in NemoClaw
-- **THEN** these domains are added to the egress policy
-

--- a/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/tasks.md
+++ b/openspec/changes/archive/2026-07-22-update-gmail-default-oauth-client/tasks.md
@@ -1,0 +1,18 @@
+- [x] Update OpenSpec deltas for CLI, mailbox config, and Gmail provider broker behavior
+- [x] Add `apps/oauth-broker` Vercel app with sessions / start / callback / tickets-claim / refresh routes
+- [x] Split public `session_id` from private `pickup_secret`; constant-time hash check at claim
+- [x] Atomic one-shot ticket claim (Redis `GETDEL` on KV; single-threaded delete in-memory)
+- [x] Server-side session state machine with distinguishable terminal states
+- [x] Fail-fast in production without `KV_REST_API_URL`
+- [x] Validate `OAuth2Client` credential discipline so `refreshHandler` is the only refresh path in broker mode (no `refresh_token` on `oauth2Client.credentials`; always-set `expiry_date`)
+- [x] Reject ambiguous mixed-shape mailbox metadata records
+- [x] Add broker-mode support to `GmailAuthManager` (startBrokerSession, pickUpTicket, broker-aware refresh)
+- [x] Discriminate saved Gmail mailbox metadata by `source: 'byok' | 'broker'`
+- [x] Replace bundled-secret resolver in `runGmailConfigure` with broker-default + BYOK paths
+- [x] Add `--broker-url` / `AGENT_EMAIL_GMAIL_BROKER_URL` plumbing
+- [x] Reject partial BYOK credentials with a clear error
+- [x] Preserve saved-metadata precedence for reconnect (issue #44 regression)
+- [x] Update wizard intro and Gmail provider README to describe broker as default
+- [x] Add tests covering: broker default for new mailbox, BYOK explicit credentials, partial-BYOK error, saved-metadata reuse for both modes
+- [x] Run `openspec validate update-gmail-default-oauth-client --strict`
+- [x] Run targeted package tests (`@usejunior/email-mcp` cli + `@usejunior/provider-gmail`)

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -6,7 +6,7 @@ feature: Command-Line Interface
 ## Purpose
 
 Defines the CLI entry point with subcommands: `serve` (MCP server), `watch` (email monitor), `configure`/`setup` (setup wizard), and `status` (account health). Includes TTY-aware default behavior, interactive wizard with provider picker, and config persistence at `~/.email-agent-mcp/config.json`. Includes NemoClaw-specific setup variant for egress policy bootstrap.
-
+## Requirements
 ### Requirement: TTY-Aware Default Behavior
 
 The system SHALL detect whether it is running in a TTY and adjust default behavior accordingly when invoked with no subcommand.
@@ -47,7 +47,32 @@ The system SHALL provide a `configure` subcommand (aliased as `setup`) with an i
 
 #### Scenario: Interactive setup
 - **WHEN** `email-agent-mcp configure` is run
-- **THEN** the system launches the interactive wizard with a provider picker (Outlook, Gmail coming soon) and tests the connection
+- **THEN** the system launches the interactive wizard with a provider picker for Outlook and Gmail and tests the selected connection
+
+#### Scenario: Direct Gmail configure (broker default)
+- **WHEN** `email-agent-mcp configure --provider gmail` is run without `--client-id`, `--client-secret`, or Gmail BYOK env vars, and the mailbox has no prior saved metadata
+- **THEN** the system contacts the OAuth broker (default `https://oauth.usejunior.com`, override via `--broker-url` or `AGENT_EMAIL_GMAIL_BROKER_URL`)
+- **AND** registers a session at `POST /api/sessions` with a locally-generated `session_id` and the SHA-256 hash of a locally-generated `pickup_secret`
+- **AND** opens the broker's authorization URL in the browser, polls `POST /api/tickets/claim` (presenting the raw `pickup_secret` for proof of ownership), and persists mailbox metadata with `source: 'broker'` once consent completes
+
+#### Scenario: Broker URL must be https (or http loopback)
+- **WHEN** `--broker-url` or `AGENT_EMAIL_GMAIL_BROKER_URL` is set to a non-https URL that is not `http://localhost`, `http://127.0.0.1`, or `http://[::1]`
+- **THEN** the system refuses to use it and surfaces a configuration error
+
+#### Scenario: Direct Gmail configure (BYOK)
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with both `--client-id` and `--client-secret` (or both `AGENT_EMAIL_GMAIL_CLIENT_ID` and `AGENT_EMAIL_GMAIL_CLIENT_SECRET`)
+- **THEN** the system runs a local-loopback OAuth flow against Google directly using those credentials
+- **AND** persists mailbox metadata with `source: 'byok'` containing the supplied client_id and client_secret
+
+#### Scenario: Partial BYOK credentials are rejected
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with exactly one of `--client-id` or `--client-secret` (and the corresponding env var for the other half is unset)
+- **THEN** the system exits non-zero with a message stating that BYOK requires both halves and that omitting both selects the broker
+
+#### Scenario: Reconfigure preserves saved mode
+- **WHEN** `email-agent-mcp configure --provider gmail --mailbox <existing>` is run for a mailbox that already has saved metadata
+- **AND** no explicit `--client-id`/`--client-secret`/`--broker-url` flags or env vars are supplied
+- **THEN** the system reuses the saved mode and credentials (broker URL or BYOK client_id/client_secret) rather than switching modes
+- **AND** existing BYOK users on subsequent reconnects are not silently routed through the broker
 
 #### Scenario: Setup alias
 - **WHEN** `email-agent-mcp setup` is run
@@ -59,7 +84,7 @@ The interactive wizard SHALL guide the user through provider selection, credenti
 
 #### Scenario: Provider picker shows available providers
 - **WHEN** the interactive wizard starts
-- **THEN** it presents a provider picker with "Outlook" as available and "Gmail (coming soon)" as disabled
+- **THEN** it presents a provider picker with both Outlook and Gmail as selectable providers
 
 #### Scenario: Wizard persists config on success
 - **WHEN** the wizard completes successfully (credentials validated, connection tested)
@@ -158,3 +183,4 @@ The system SHALL use standard exit codes: 0 for success, 1 for runtime errors (e
 #### Scenario: Configuration error
 - **WHEN** `email-agent-mcp serve` fails due to missing configuration
 - **THEN** the process exits with code 1 and a clear error message on stderr
+

--- a/openspec/specs/email-folders/spec.md
+++ b/openspec/specs/email-folders/spec.md
@@ -1,0 +1,107 @@
+# email-folders Specification
+
+## Purpose
+
+Defines mail-folder management: recursively listing every provider folder with a computed path, creating custom child folders, and deleting custom folders (gated, with well-known/system folders protected). Folder-path resolution for `move_to_folder` is served from a 60-second cache since moves don't alter the tree, while resolution for structural writes and rule destinations always forces a fresh traversal.
+
+## Requirements
+### Requirement: Recursive Folder Listing
+
+The system SHALL provide a `list_folders` action that recursively lists every provider mail folder across all pages and includes a computed slash-delimited path for each folder.
+
+#### Scenario: Nested paginated folders
+- **WHEN** a Microsoft mailbox has paginated root folders and nested child folders
+- **THEN** `list_folders` returns folders from every page and hierarchy level
+- **AND** a child named `Newsletters` under `Inbox` has path `Inbox/Newsletters`
+
+### Requirement: Folder Creation
+
+The system SHALL provide a `create_folder` action that creates a custom child folder beneath a caller-selected parent folder and invalidates cached folder resolution data.
+
+#### Scenario: Create an inbox child folder
+- **WHEN** `create_folder` is called with `{display_name: "Newsletters", parent_folder: "inbox"}`
+- **THEN** the provider creates `Newsletters` beneath Inbox
+- **AND** a subsequent folder lookup observes the new folder without waiting for cache expiry
+
+### Requirement: Protected Folder Deletion
+
+The system SHALL provide a destructive `delete_folder` action for custom folders and SHALL refuse to delete well-known/system folders by alias, path, or resolved id.
+
+#### Scenario: Refuse system folder id
+- **WHEN** `delete_folder` resolves its input to the Graph id of Inbox
+- **THEN** it returns a typed `SYSTEM_FOLDER_PROTECTED` error
+- **AND** it does not call the Graph delete endpoint
+
+### Requirement: Custom Folder Moves
+
+The system SHALL resolve `move_to_folder` destinations by well-known alias, custom folder id, case-insensitive path, or unambiguous case-insensitive display name, with a 60-second cache for recursive folder data.
+
+#### Scenario: Move to custom folder path
+- **WHEN** `move_to_folder` is called with `{id: "msg123", folder: "Inbox/Newsletters"}`
+- **THEN** the Microsoft provider posts the move using the resolved Graph folder id
+
+#### Scenario: Preserve well-known move behavior
+- **WHEN** `move_to_folder` is called with `inbox`, `archive`, or `trash`
+- **THEN** the provider uses the corresponding well-known Graph destination without requiring folder traversal
+
+### Requirement: Unsupported Folder Provider
+
+Folder actions SHALL return a typed `NOT_SUPPORTED` result when the selected provider does not implement `EmailFolderManager`.
+
+#### Scenario: Gmail folder request
+- **WHEN** `list_folders` is called for a Gmail provider
+- **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`
+
+### Requirement: Bounded Folder Traversal
+
+Recursive folder traversal MUST be bounded by a request budget shared across the entire traversal, not per collection. Exceeding the budget SHALL truncate the listing rather than fail it, and a truncated snapshot MUST NOT be cached.
+
+#### Scenario: Truncate rather than fail on a very large mailbox
+- **WHEN** enumerating folders would exceed the traversal request budget
+- **THEN** `list_folders` returns the folders discovered so far instead of erroring
+
+#### Scenario: Never cache a partial tree
+- **WHEN** a traversal was truncated
+- **THEN** the result is not written to the folder cache, so the next call retries from scratch
+
+#### Scenario: Refuse to infer absence from a truncated tree
+- **WHEN** a folder NAME or PATH match is the only candidate in a truncated snapshot
+- **THEN** the system returns `FOLDER_TRAVERSAL_LIMIT` rather than assuming the visible match is unique
+- **AND** an exact folder-id match still resolves, because ids are globally unique
+
+### Requirement: Fresh Resolution For Structural And Rule Writes
+
+Folder name/path resolution for operations that MUTATE the folder tree (`create_folder` parent, `delete_folder` target) and for inbox-rule destinations MUST NOT be answered from the cached folder snapshot. These are low-frequency and either unrecoverable (deleting the wrong folder) or persistent (a rule that acts 24/7), so a stale path-to-id mapping is worth one fresh traversal to avoid.
+
+#### Scenario: Re-resolve before a structural mutation
+- **WHEN** `create_folder` or `delete_folder` resolves its target folder
+- **THEN** the provider refreshes the folder tree before selecting the id
+
+#### Scenario: Re-resolve a rule destination
+- **WHEN** `create_inbox_rule` resolves a custom folder destination
+- **THEN** the provider refreshes the folder tree and resolves to an opaque folder id
+
+### Requirement: Cached Resolution For Message Moves
+
+`move_to_folder` name resolution SHALL be permitted to use the cached folder snapshot rather than forcing a fresh traversal. A move does not alter the folder tree, runs in high-volume triage loops, and its worst-case staleness (a message filed into a renamed-but-valid folder within the 60s TTL) is recoverable — so forcing a fresh traversal per move, which would trip Graph throttling on the exact workload this feature targets, is the wrong trade. An exact folder id MUST still resolve without depending on a fresh traversal.
+
+#### Scenario: Repeated moves reuse the cache
+- **WHEN** several `move_to_folder` calls target custom folders within the cache TTL
+- **THEN** only the first performs a folder traversal; the rest are served from cache
+
+#### Scenario: Reads still use the cache
+- **WHEN** `list_folders` is called twice within the cache TTL
+- **THEN** the second call is served from the cached snapshot
+
+### Requirement: Gated Folder Deletion
+
+`delete_folder` MUST be disabled by default and gated behind the same operator deletion policy as `delete_email`, because deleting a folder discards every message it contains. It MUST require an explicit `user_explicitly_requested_deletion` affirmation and MUST return a typed `DELETE_DISABLED` error when the policy is off or the affirmation is absent.
+
+#### Scenario: Folder deletion is disabled by default
+- **WHEN** `delete_folder` is called and the operator has not enabled deletion
+- **THEN** it returns `{success: false, error: {code: "DELETE_DISABLED", ...}}` without calling the provider
+
+#### Scenario: Folder deletion requires explicit affirmation
+- **WHEN** `delete_folder` is called with `user_explicitly_requested_deletion: false`
+- **THEN** it returns `DELETE_DISABLED` without calling the provider
+

--- a/openspec/specs/email-inbox-rules/spec.md
+++ b/openspec/specs/email-inbox-rules/spec.md
@@ -1,0 +1,91 @@
+# email-inbox-rules Specification
+
+## Purpose
+
+Defines inbox-rule management: listing existing rules faithfully (including unsafe actions created outside this system), creating attested rules limited to a safe action allowlist, and deleting rules (gated). Rule creation requires caller-attested intent, rejects unsafe actions (forwarding, redirecting, delete) and destructive destinations (Deleted Items and its aliases) both at the action layer and independently at the provider layer, since Microsoft Graph accepts action keys case-insensitively.
+
+## Requirements
+### Requirement: Faithful Inbox Rule Listing
+
+The system SHALL provide a read-only `list_inbox_rules` action that returns all fields supplied by the provider, including unsafe actions on rules created outside this system.
+
+#### Scenario: List externally created forwarding rule
+- **WHEN** Graph returns a rule containing `forwardTo`
+- **THEN** `list_inbox_rules` returns the rule and its `forwardTo` action unchanged
+
+### Requirement: Safe Approved Inbox Rule Creation
+
+The system SHALL provide `create_inbox_rule` with minimal safe actions and SHALL require the caller to affirm intent via `user_explicitly_approved` before a rule is created.
+
+This affirmation is caller attestation and audit metadata — NOT a security boundary. The flag is supplied by the calling model, which can set it without consulting a human, so it cannot enforce human approval on its own. Genuine human-in-the-loop MUST come from the MCP client's tool-approval UI. The system SHALL NOT describe this flag as human approval in user-facing text.
+
+#### Scenario: Create attested move rule
+- **WHEN** `create_inbox_rule` receives an attested rule that moves matching mail to a custom folder
+- **THEN** the system resolves the folder and creates the rule through the provider
+
+#### Scenario: Missing intent affirmation
+- **WHEN** `create_inbox_rule` is called without `user_explicitly_approved: true`
+- **THEN** it returns a typed `APPROVAL_REQUIRED` error without calling the provider
+
+### Requirement: Unsafe Rule Action Rejection
+
+The system MUST reject creation of any inbox rule whose actions contain `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, or `delete`, returning a typed error instead of throwing.
+
+#### Scenario: Reject forwarding action
+- **WHEN** `create_inbox_rule` receives an action containing `forwardTo`
+- **THEN** it returns `{success: false, error: {code: "UNSAFE_RULE_ACTION", ...}}`
+- **AND** it does not call the provider
+
+### Requirement: Inbox Rule Deletion
+
+The system SHALL provide a destructive `delete_inbox_rule` action that deletes a rule by id.
+
+#### Scenario: Delete a rule
+- **WHEN** `delete_inbox_rule` is called with `{id: "rule123"}`
+- **THEN** the provider deletes `rule123` from the inbox rules collection
+
+### Requirement: Unsupported Rule Provider
+
+Inbox-rule actions SHALL return a typed `NOT_SUPPORTED` result when the selected provider does not implement `EmailRuleManager`.
+
+#### Scenario: Gmail rule request
+- **WHEN** `list_inbox_rules` is called for a Gmail provider
+- **THEN** the action returns `{success: false, error: {code: "NOT_SUPPORTED", ...}}`
+
+### Requirement: Destructive Rule Destination Rejection
+
+The system MUST reject creation of any inbox rule whose `moveToFolder` or `copyToFolder` destination resolves to a mail-discarding folder (Deleted Items, recoverable-items dumpster, or their aliases such as `trash`/`deleted`). Filing mail into these is functionally equivalent to the blocked `delete` action and, combined with empty conditions, would discard the entire mailbox.
+
+#### Scenario: Reject a rule that files mail into Deleted Items
+- **WHEN** `create_inbox_rule` receives `{"actions": {"moveToFolder": "trash"}}`
+- **THEN** it returns `{success: false, error: {code: "UNSAFE_RULE_DESTINATION", ...}}`
+- **AND** it does not call the provider
+
+#### Scenario: Reject aliases and case variants after resolution
+- **WHEN** a destination such as `deleted`, `DeletedItems`, or ` Trash ` normalizes to the deleted-items folder
+- **THEN** the provider rejects it with `UNSAFE_RULE_DESTINATION` before issuing any write
+
+### Requirement: Provider-Layer Rule Action Enforcement
+
+Provider implementations of `EmailRuleManager.createInboxRule` MUST independently enforce the safe-action allowlist using case-normalized keys, because Microsoft Graph accepts JSON keys case-insensitively and the interface is callable without passing through the MCP action layer.
+
+#### Scenario: Reject case-variant forwarding at the provider
+- **WHEN** `createInboxRule` is called directly with an action key of `ForwardTo` or `REDIRECTTO`
+- **THEN** the provider throws `UNSAFE_RULE_ACTION` without issuing a write
+
+#### Scenario: Fail closed on unknown actions
+- **WHEN** an action key outside the safe allowlist is supplied
+- **THEN** the provider throws `UNSUPPORTED_RULE_ACTION` rather than forwarding it to Graph
+
+### Requirement: Gated Rule Deletion
+
+`delete_inbox_rule` MUST be disabled by default and gated behind the same operator deletion policy as `delete_email`, because removing a rule can silently re-expose the mailbox to filtered mail or remove an organization/anti-abuse rule. It MUST require an explicit `user_explicitly_requested_deletion` affirmation and MUST return a typed `DELETE_DISABLED` error when the policy is off or the affirmation is absent.
+
+#### Scenario: Rule deletion is disabled by default
+- **WHEN** `delete_inbox_rule` is called and the operator has not enabled deletion
+- **THEN** it returns `{success: false, error: {code: "DELETE_DISABLED", ...}}` without calling the provider
+
+#### Scenario: Rule deletion requires explicit affirmation
+- **WHEN** `delete_inbox_rule` is called with `user_explicitly_requested_deletion: false`
+- **THEN** it returns `DELETE_DISABLED` without calling the provider
+

--- a/openspec/specs/email-read/spec.md
+++ b/openspec/specs/email-read/spec.md
@@ -6,7 +6,7 @@ feature: Read Actions
 ## Purpose
 
 Defines read-only email operations: listing, reading, and searching emails across one or more configured mailboxes. All actions accept an optional `mailbox` parameter that defaults to the default mailbox or searches across all if omitted.
-
+## Requirements
 ### Requirement: List Emails
 
 The system SHALL provide a `list_emails` action that returns recent emails filtered by unread status, sender, date range, folder (inbox, sent, drafts, junk), and configurable limit with sensible defaults.
@@ -54,3 +54,27 @@ The system SHALL allow specifying a target folder for list and search operations
 #### Scenario: Include junk folder
 - **WHEN** `list_emails` is called with `{folder: "junk"}`
 - **THEN** the system returns emails from the junk/spam folder
+
+### Requirement: Optional Quoted-History Stripping
+
+The `read_email` action SHALL accept an optional `strip_quoted_history` boolean parameter. When `true`, the system SHALL detect a terminal quoted-history block — Gmail/Apple "On … wrote:" preambles, Outlook `From:/Sent:/Date:/To:/Subject:` header clusters, an Outlook-2003 `-----Original Message-----` separator followed by an Outlook header cluster, or a terminal run of `>`-prefix lines — and replace it with a single short marker (e.g. `[...prior thread truncated]`). The candidate block SHALL only be stripped when it is genuinely terminal: an inline `On … wrote:` quote followed by user-authored prose SHALL NOT be stripped. When omitted or `false`, the body SHALL be returned unchanged from current behavior. Inline blockquotes appearing within the latest reply SHALL be preserved; only a terminal quoted-history block SHALL be stripped.
+
+The detector is English-only: localized "On … wrote:" preambles (German "Am … schrieb …", French "Le … a écrit", Japanese "送信者:" headers, etc.) are NOT matched. Threads from non-English clients SHALL be returned with full quoted history.
+
+#### Scenario: Strip quoted history when flag is true
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` and the email body contains a Gmail "On … wrote:" preamble followed by a multi-line `>`-prefix quoted reply
+- **THEN** the returned body has the preamble and quoted reply replaced with the marker `[...prior thread truncated]`
+- **AND** the latest reply text and any non-quoted user content above the preamble are preserved
+
+#### Scenario: Default behavior is unchanged
+- **WHEN** `read_email` is called with `{id: "msg123"}` (flag omitted) on the same email
+- **THEN** the returned body is identical to current behavior — full quoted history is included
+
+#### Scenario: Inline blockquote in latest reply is preserved
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on an email whose latest reply contains a markdown blockquote (`> note:` line) followed by more user-authored text and no terminal quoted-history block
+- **THEN** the returned body is unchanged and no marker is inserted
+
+#### Scenario: Inline "On … wrote:" with user prose after is preserved
+- **WHEN** `read_email` is called with `{id: "msg123", strip_quoted_history: true}` on a body that contains an `On … wrote:` preamble and `>`-quoted block in the middle, followed by additional user-authored prose
+- **THEN** the returned body is unchanged and no marker is inserted
+

--- a/openspec/specs/mailbox-config/spec.md
+++ b/openspec/specs/mailbox-config/spec.md
@@ -6,7 +6,7 @@ feature: Mailbox Management
 ## Purpose
 
 Defines multi-mailbox configuration: connecting named mailboxes to providers, setting defaults, listing status, and provider discovery via dynamic import. Supports simultaneous Graph + Gmail connections. Each mailbox is canonically identified by its email address, with an optional user-defined alias for convenience.
-
+## Requirements
 ### Requirement: Mailbox Canonical Identity
 
 The canonical ID of a mailbox SHALL be its email address (e.g., `test-user@example.com`). The user MAY provide an optional alias (e.g., "work") for convenience. Tool inputs that accept a mailbox identifier SHALL accept either the email address or the alias, resolving to the same mailbox.
@@ -44,6 +44,21 @@ The system SHALL provide a `configure_mailbox` action that connects a named mail
 - **WHEN** `configure_mailbox` is called with `{name: "work", provider: "microsoft", credentials: {...}, default: true}`
 - **THEN** the system connects to the Microsoft Graph API, fetches the email address, and marks "work" as the default mailbox
 - **AND** the stored metadata includes `emailAddress`
+
+#### Scenario: Gmail mailbox metadata is mode-discriminated
+- **WHEN** a Gmail mailbox is configured
+- **THEN** the stored metadata records a `source` discriminator equal to `'broker'` or `'byok'`
+- **AND** for `'byok'` the metadata stores the user-supplied `clientId` and `clientSecret` plus the `refreshToken`
+- **AND** for `'broker'` the metadata stores the `brokerUrl` plus the `refreshToken` and SHALL NOT store any `clientSecret` on disk
+
+#### Scenario: Pre-broker metadata is parsed as BYOK only when unambiguous
+- **WHEN** the system loads a Gmail mailbox metadata file written before the broker change (no `source` field) that has both `clientId` and `clientSecret` and NO `brokerUrl`
+- **THEN** the system treats it as `source: 'byok'` for the purposes of subsequent loads and reconnects
+
+#### Scenario: Ambiguous mixed-shape metadata is rejected
+- **WHEN** the system loads a Gmail mailbox metadata file that contains BOTH `clientSecret` and `brokerUrl`
+- **THEN** the system refuses to interpret the record (returns null) and leaves the mailbox unconfigured, forcing the user to re-run configure
+- **AND** `source: 'broker'` records that lack `brokerUrl`, and `source: 'byok'` records that lack `clientSecret`, are likewise rejected
 
 ### Requirement: Default Mailbox
 
@@ -116,3 +131,4 @@ The system SHALL detect installed provider packages (`@usejunior/provider-micros
 #### Scenario: Provider not installed
 - **WHEN** `configure_mailbox` is called with `{provider: "gmail"}` but `@usejunior/provider-gmail` is not installed
 - **THEN** the system returns: "Provider 'gmail' not available. Install: npm install @usejunior/provider-gmail"
+

--- a/openspec/specs/provider-interface/spec.md
+++ b/openspec/specs/provider-interface/spec.md
@@ -6,7 +6,7 @@ feature: Provider Abstraction
 ## Purpose
 
 Defines capability-based provider interfaces (EmailReader, EmailSender, EmailSubscriber), provider registration via dynamic import, error normalization, authentication lifecycle, and rate limit handling. Providers implement the interfaces they support.
-
+## Requirements
 ### Requirement: Capability Interfaces
 
 The system SHALL define capability-based interfaces: `EmailReader` (list, get, search, getThread), `EmailSender` (send, reply, createDraft, sendDraft), and `EmailSubscriber` (subscribe, unsubscribe). Providers implement what they support. On the write path, `EmailSender` implementations SHALL inspect `ComposeMessage.bodyHtml` (and for reply methods, `ReplyOptions.bodyHtml`) to decide the transport content type: when set, send as HTML; otherwise send as plain text.
@@ -65,3 +65,22 @@ The system SHALL manage the authentication lifecycle: connect (initial auth), re
 #### Scenario: Token refresh
 - **WHEN** an access token expires during an operation
 - **THEN** the system refreshes the token using the stored refresh token and retries the operation
+
+### Requirement: Optional Folder and Rule Capabilities
+
+The provider abstraction SHALL define `EmailFolderManager` and `EmailRuleManager` as optional capabilities on the combined `EmailProvider` type and SHALL advertise `folders` and `rules` in provider capability metadata.
+
+#### Scenario: Provider omits optional capabilities
+- **WHEN** a provider implements email reading and sending but not folder or rule management
+- **THEN** it remains a valid `EmailProvider`
+- **AND** folder and rule actions can detect the missing capability
+
+### Requirement: Microsoft Mailbox Settings Consent
+
+The Microsoft delegated authentication configuration SHALL request `MailboxSettings.ReadWrite` in both the short and full-URL Graph scope lists.
+
+#### Scenario: Existing user reconnects
+- **WHEN** an existing Microsoft user reconnects after this capability is introduced
+- **THEN** the consent request includes `MailboxSettings.ReadWrite`
+- **AND** user-facing documentation states that re-consent is required
+

--- a/packages/email-core/src/actions/folders.test.ts
+++ b/packages/email-core/src/actions/folders.test.ts
@@ -26,7 +26,9 @@ describe('email-folders/List Folders', () => {
     expect(listFoldersAction.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
   });
 
-  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+  it('Scenario: Gmail folder request', async () => {
+    // MockEmailProvider without listFolders stands in for a provider (e.g.
+    // Gmail) that does not implement EmailFolderManager.
     const result = await listFoldersAction.run(contextWith(), {});
     expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
   });
@@ -65,7 +67,7 @@ describe('email-folders/Delete Folder', () => {
     expect(deleteFolderAction.annotations.destructiveHint).toBe(true);
   });
 
-  it('Scenario: Deletion is disabled by default without operator opt-in', async () => {
+  it('Scenario: Folder deletion is disabled by default', async () => {
     const deleteFolder = vi.fn().mockResolvedValue(undefined);
     const result = await deleteFolderAction.run(
       contextWith({ deleteFolder }, { deleteEnabled: false }),
@@ -76,7 +78,7 @@ describe('email-folders/Delete Folder', () => {
     expect(deleteFolder).not.toHaveBeenCalled();
   });
 
-  it('Scenario: Deletion requires an explicit caller affirmation', async () => {
+  it('Scenario: Folder deletion requires explicit affirmation', async () => {
     const deleteFolder = vi.fn().mockResolvedValue(undefined);
     const result = await deleteFolderAction.run(
       contextWith({ deleteFolder }),

--- a/packages/email-core/src/actions/read.test.ts
+++ b/packages/email-core/src/actions/read.test.ts
@@ -84,7 +84,7 @@ describe('email-read/Read Email', () => {
     expect('bcc' in result).toBe(true);
   });
 
-  it('Scenario: strip_quoted_history omitted preserves full thread', async () => {
+  it('Scenario: Default behavior is unchanged', async () => {
     provider.addMessage({
       id: 'msg-thread',
       body: [
@@ -103,7 +103,9 @@ describe('email-read/Read Email', () => {
     expect(result.body).not.toContain(QUOTE_MARKER);
   });
 
-  it('Scenario: strip_quoted_history true removes terminal Gmail-style chain', async () => {
+  it('Scenario: Strip quoted history when flag is true', async () => {
+    // Also verifies: strip_quoted_history true removes a terminal
+    // Gmail-style "On … wrote:" chain.
     provider.addMessage({
       id: 'msg-thread',
       body: [

--- a/packages/email-core/src/actions/rules.test.ts
+++ b/packages/email-core/src/actions/rules.test.ts
@@ -11,7 +11,7 @@ function contextWith(methods: Partial<EmailProvider> = {}, overrides: Partial<Ac
 }
 
 describe('email-inbox-rules/List Inbox Rules', () => {
-  it('Scenario: Faithfully list an externally created forwarding rule', async () => {
+  it('Scenario: List externally created forwarding rule', async () => {
     const rules = [{
       id: 'rule-1',
       displayName: 'External forwarding rule',
@@ -26,7 +26,9 @@ describe('email-inbox-rules/List Inbox Rules', () => {
     expect(listInboxRulesAction.annotations).toEqual({ readOnlyHint: true, destructiveHint: false });
   });
 
-  it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
+  it('Scenario: Gmail rule request', async () => {
+    // MockEmailProvider without listInboxRules stands in for a provider
+    // (e.g. Gmail) that does not implement EmailRuleManager.
     const result = await listInboxRulesAction.run(contextWith(), {});
     expect(result).toMatchObject({ success: false, error: { code: 'NOT_SUPPORTED' } });
   });
@@ -45,7 +47,7 @@ describe('email-inbox-rules/Create Inbox Rule', () => {
     expect(createInboxRuleAction.input.safeParse({ ...base, sequence: 5 }).success).toBe(true);
   });
 
-  it('Scenario: Create an approved safe move rule', async () => {
+  it('Scenario: Create attested move rule', async () => {
     const rule = { id: 'rule-1', displayName: 'GitHub', actions: { moveToFolder: 'Newsletters' } };
     const createInboxRule = vi.fn().mockResolvedValue(rule);
 
@@ -68,7 +70,7 @@ describe('email-inbox-rules/Create Inbox Rule', () => {
     });
   });
 
-  it('Scenario: Missing human approval returns APPROVAL_REQUIRED', async () => {
+  it('Scenario: Missing intent affirmation', async () => {
     const createInboxRule = vi.fn();
     const result = await createInboxRuleAction.run(contextWith({ createInboxRule }), {
       display_name: 'GitHub',
@@ -99,6 +101,23 @@ describe('email-inbox-rules/Create Inbox Rule', () => {
     },
   );
 
+  it('Scenario: Reject forwarding action', async () => {
+    // Non-parameterized instance of the it.each block above (that block's
+    // dynamic title isn't matched by the spec-coverage scanner), scoped to
+    // the exact forwardTo case the canonical scenario names.
+    const createInboxRule = vi.fn();
+    const result = await createInboxRuleAction.run(contextWith({ createInboxRule }), {
+      display_name: 'Unsafe',
+      is_enabled: true,
+      conditions: { subjectContains: ['invoice'] },
+      actions: { forwardTo: [] },
+      user_explicitly_approved: true,
+    });
+
+    expect(result).toMatchObject({ success: false, error: { code: 'UNSAFE_RULE_ACTION' } });
+    expect(createInboxRule).not.toHaveBeenCalled();
+  });
+
   it('Scenario: Unsupported provider returns NOT_SUPPORTED', async () => {
     const result = await createInboxRuleAction.run(contextWith(), {
       display_name: 'GitHub',
@@ -121,7 +140,7 @@ describe('email-inbox-rules/Delete Inbox Rule', () => {
     expect(deleteInboxRuleAction.annotations.destructiveHint).toBe(true);
   });
 
-  it('Scenario: Deletion is disabled by default without operator opt-in', async () => {
+  it('Scenario: Rule deletion is disabled by default', async () => {
     const deleteInboxRule = vi.fn().mockResolvedValue(undefined);
     const result = await deleteInboxRuleAction.run(
       contextWith({ deleteInboxRule }, { deleteEnabled: false }),
@@ -132,7 +151,7 @@ describe('email-inbox-rules/Delete Inbox Rule', () => {
     expect(deleteInboxRule).not.toHaveBeenCalled();
   });
 
-  it('Scenario: Deletion requires an explicit caller affirmation', async () => {
+  it('Scenario: Rule deletion requires explicit affirmation', async () => {
     const deleteInboxRule = vi.fn().mockResolvedValue(undefined);
     const result = await deleteInboxRuleAction.run(
       contextWith({ deleteInboxRule }),
@@ -150,7 +169,7 @@ describe('email-inbox-rules/Delete Inbox Rule', () => {
 });
 
 describe('create_inbox_rule destructive destinations (PR #106 review)', () => {
-  it('Scenario: Rejects moveToFolder destinations that discard mail', async () => {
+  it('Scenario: Reject a rule that files mail into Deleted Items', async () => {
     const createInboxRule = vi.fn();
     const ctx = { provider: { createInboxRule } } as never;
 

--- a/packages/email-core/src/content/quotes.test.ts
+++ b/packages/email-core/src/content/quotes.test.ts
@@ -3,7 +3,7 @@ import { stripQuotedHistory } from './quotes.js';
 
 const MARKER = '[...prior thread truncated]';
 
-describe('content-engine/Quoted-History Stripping', () => {
+describe('email-read/Optional Quoted-History Stripping (detector)', () => {
   it('Scenario: Strip Gmail "On … wrote:" preamble with quoted reply', () => {
     const body = [
       "Thanks, that works for me.",
@@ -69,7 +69,7 @@ describe('content-engine/Quoted-History Stripping', () => {
     expect(twice).toBe(once);
   });
 
-  it('Scenario: Inline markdown blockquote followed by user text is preserved', () => {
+  it('Scenario: Inline blockquote in latest reply is preserved', () => {
     const body = [
       "Hey team,",
       "",
@@ -331,7 +331,7 @@ describe('content-engine/Quoted-History Stripping', () => {
   // followed by user prose would collapse the user's reply to the marker only.
   // ---------------------------------------------------------------------------
 
-  it('Scenario: Inline Gmail "On … wrote:" with user prose after is preserved', () => {
+  it('Scenario: Inline "On … wrote:" with user prose after is preserved', () => {
     const body = [
       'Hi team,',
       '',

--- a/packages/email-core/src/providers/provider.test.ts
+++ b/packages/email-core/src/providers/provider.test.ts
@@ -61,6 +61,37 @@ describe('provider-interface/Capability Interfaces', () => {
   });
 });
 
+describe('provider-interface/Optional Folder and Rule Capabilities', () => {
+  it('Scenario: Provider omits optional capabilities', async () => {
+    const provider = new MockEmailProvider();
+    provider.addMessage({ id: 'msg1', subject: 'Test' });
+
+    // A provider implementing only EmailReader + EmailSender (no
+    // EmailFolderManager/EmailRuleManager) remains a valid EmailProvider —
+    // folders/rules are Partial<> on the combined type.
+    const partialProvider = {
+      listMessages: provider.listMessages.bind(provider),
+      getMessage: provider.getMessage.bind(provider),
+      searchMessages: provider.searchMessages.bind(provider),
+      getThread: provider.getThread.bind(provider),
+      sendMessage: provider.sendMessage.bind(provider),
+      replyToMessage: provider.replyToMessage.bind(provider),
+      createDraft: provider.createDraft.bind(provider),
+      sendDraft: provider.sendDraft.bind(provider),
+    } satisfies EmailProvider;
+
+    expect(partialProvider.listFolders).toBeUndefined();
+    expect(partialProvider.createInboxRule).toBeUndefined();
+
+    // Folder/rule actions detect the missing capability rather than
+    // throwing — see email-folders/Unsupported Folder Provider and
+    // email-inbox-rules/Unsupported Rule Provider for the action-level
+    // NOT_SUPPORTED contract this enables.
+    const messages = await provider.listMessages({ limit: 10 });
+    expect(messages).toHaveLength(1);
+  });
+});
+
 describe('provider-interface/Provider Registration', () => {
   it('Scenario: Dynamic discovery', async () => {
     // WHEN the MCP server starts

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -443,7 +443,9 @@ describe('cli/Configure Subcommand', () => {
     expect(opts.provider).toBe('microsoft');
   });
 
-  it('Gmail configure routes a brand-new mailbox through the OAuth broker (no client_secret on disk)', async () => {
+  it('Scenario: Direct Gmail configure (broker default)', async () => {
+    // Also verifies: routes a brand-new mailbox through the OAuth broker
+    // with no client_secret persisted to disk.
     // Isolate from the user's real ~/.email-agent-mcp so the saved-metadata
     // lookup does not pick up a default mailbox from the host machine.
     const tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-broker-'));
@@ -490,6 +492,39 @@ describe('cli/Configure Subcommand', () => {
       if (originalBrokerUrl === undefined) delete process.env['AGENT_EMAIL_GMAIL_BROKER_URL'];
       else process.env['AGENT_EMAIL_GMAIL_BROKER_URL'] = originalBrokerUrl;
       gmailMockState.profileEmail = originalProfileEmail;
+      await rm(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('Scenario: Broker URL must be https (or http loopback)', async () => {
+    const tmpHome = await mkdtemp(join(tmpdir(), 'email-agent-mcp-broker-url-'));
+    const originalHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    const originalClientId = process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'];
+    const originalClientSecret = process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'];
+    const originalBrokerUrl = process.env['AGENT_EMAIL_GMAIL_BROKER_URL'];
+    process.env['EMAIL_AGENT_MCP_HOME'] = tmpHome;
+    delete process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'];
+    delete process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'];
+    process.env['AGENT_EMAIL_GMAIL_BROKER_URL'] = 'http://evil.example.com';
+    try {
+      const exitCode = await runCli([
+        'configure',
+        '--provider',
+        'gmail',
+        '--mailbox',
+        'fresh-user@gmail.com',
+      ]);
+      expect(exitCode).toBe(1);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Broker URL must be https'),
+      );
+    } finally {
+      if (originalHome === undefined) delete process.env['EMAIL_AGENT_MCP_HOME'];
+      else process.env['EMAIL_AGENT_MCP_HOME'] = originalHome;
+      if (originalClientId !== undefined) process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'] = originalClientId;
+      if (originalClientSecret !== undefined) process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'] = originalClientSecret;
+      if (originalBrokerUrl === undefined) delete process.env['AGENT_EMAIL_GMAIL_BROKER_URL'];
+      else process.env['AGENT_EMAIL_GMAIL_BROKER_URL'] = originalBrokerUrl;
       await rm(tmpHome, { recursive: true, force: true });
     }
   });
@@ -696,7 +731,34 @@ describe('cli/Gmail Configure', () => {
     expect(httpMockState.lastResponseBody).toContain('Authentication complete');
   });
 
-  it('Scenario: Gmail configure rejects partial BYOK credentials with a clear error', async () => {
+  it('Scenario: Direct Gmail configure (BYOK)', async () => {
+    // `configure --provider gmail --client-id/--client-secret` runs a local-loopback
+    // OAuth flow directly against Google and persists source: 'byok' metadata.
+    const exitCode = await runCli([
+      'configure',
+      '--provider',
+      'gmail',
+      '--mailbox',
+      'steven.obiajulu@gmail.com',
+      '--client-id',
+      'cli-client-id',
+      '--client-secret',
+      'cli-client-secret',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(gmailMockState.authUrlOptions).toBeTruthy();
+    expect(gmailMockState.savedMetadata).toMatchObject({
+      provider: 'gmail',
+      source: 'byok',
+      mailboxName: 'steven.obiajulu@gmail.com',
+      emailAddress: 'steven.obiajulu@gmail.com',
+      clientId: 'cli-client-id',
+      clientSecret: 'cli-client-secret',
+    });
+  });
+
+  it('Scenario: Partial BYOK credentials are rejected', async () => {
     // Half-credentials are an obvious user mistake — fail fast rather
     // than silently dropping into broker mode (which would consent to a
     // different OAuth client than the user provided a clientId for).
@@ -842,6 +904,24 @@ describe('cli/Gmail Configure', () => {
     expect(gmailMockState.authUrlOptions).not.toBeNull();
     expect(vi.mocked(clackPrompts.text)).not.toHaveBeenCalled();
     expect(vi.mocked(clackPrompts.password)).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Reconfigure preserves saved mode', async () => {
+    // A mailbox that was originally configured BYOK must stay BYOK on a bare
+    // `configure --provider gmail --mailbox <existing>` with no explicit
+    // --client-id/--client-secret/--broker-url — it must not be silently
+    // routed through the broker.
+    await seedSavedGmailMetadata('personal', { source: 'byok' });
+
+    const exitCode = await runCli(['configure', '--provider', 'gmail', '--mailbox', 'personal']);
+
+    expect(exitCode).toBe(0);
+    expect(gmailMockState.savedMetadata).toMatchObject({
+      source: 'byok',
+      clientId: 'saved-client-id',
+      clientSecret: 'saved-client-secret',
+    });
+    expect(gmailMockState.savedMetadata?.['brokerUrl']).toBeUndefined();
   });
 
   it('Scenario: Gmail configure reuses saved OAuth credentials for the default mailbox when --mailbox is omitted', async () => {

--- a/packages/provider-gmail/src/auth.broker.test.ts
+++ b/packages/provider-gmail/src/auth.broker.test.ts
@@ -30,7 +30,48 @@ describe('provider-gmail/broker-mode credential discipline', () => {
     expect(client.credentials.expiry_date).toBeTypeOf('number');
   });
 
-  it('refresh() in broker mode hits the broker, never Google', async () => {
+  it('Scenario: Gmail OAuth via BYOK', async () => {
+    // BYOK mode (clientId + clientSecret, no brokerUrl) runs the
+    // configure-time local-loopback flow — generateAuthUrl + exchangeCode —
+    // directly against Google via the real OAuth2Client. The broker is
+    // never contacted (global fetch, the broker's only transport, must
+    // stay unused), and the exchanged tokens are persisted onto the auth
+    // manager for the caller to write into mailbox metadata.
+    const fetchMock = vi.fn(async () => {
+      throw new Error('BYOK mode must not hit fetch (that is the broker transport)');
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const auth = new GmailAuthManager({
+      clientId: 'byok-client',
+      clientSecret: 'byok-secret',
+      redirectUri: 'http://127.0.0.1:0/oauth2callback',
+    });
+
+    // generateAuthUrl is only available in byok mode — asserts this is
+    // the local-loopback consent flow, not startBrokerSession.
+    const authUrl = auth.generateAuthUrl({ state: 'xyz' });
+    expect(authUrl).toContain('client_id=byok-client');
+
+    const getToken = vi.spyOn(auth.getOAuth2Client(), 'getToken').mockResolvedValue({
+      tokens: {
+        access_token: 'byok-access',
+        refresh_token: 'byok-refresh',
+        expiry_date: Date.now() + 3600000,
+      },
+    } as Awaited<ReturnType<InstanceType<typeof import('google-auth-library').OAuth2Client>['getToken']>>);
+
+    await auth.exchangeCode('auth-code');
+
+    expect(getToken).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'auth-code' }),
+    );
+    expect(auth.getAccessToken()).toBe('byok-access');
+    expect(auth.getRefreshToken()).toBe('byok-refresh');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Broker-mode refresh routes through the broker', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString();
       if (url === 'https://broker.test/api/refresh') {

--- a/packages/provider-gmail/src/config.test.ts
+++ b/packages/provider-gmail/src/config.test.ts
@@ -94,12 +94,12 @@ describe('provider-gmail/Config Discovery', () => {
   });
 });
 
-describe('provider-gmail/Metadata source discrimination', () => {
+describe('mailbox-config/Configure Mailbox', () => {
   async function writeRaw(filename: string, body: Record<string, unknown>): Promise<void> {
     await writeFile(join(tempHome, 'tokens', filename), JSON.stringify(body, null, 2) + '\n');
   }
 
-  it('parses pre-broker (no source field) BYOK records as source=byok', async () => {
+  it('Scenario: Pre-broker metadata is parsed as BYOK only when unambiguous', async () => {
     await writeRaw('legacy.json', {
       provider: 'gmail',
       mailboxName: 'legacy',
@@ -114,7 +114,7 @@ describe('provider-gmail/Metadata source discrimination', () => {
     expect(loaded.clientId).toBe('old-client');
   });
 
-  it('parses broker-source records with brokerUrl', async () => {
+  it('Scenario: Gmail mailbox metadata is mode-discriminated', async () => {
     await writeRaw('broker.json', {
       provider: 'gmail',
       source: 'broker',
@@ -131,7 +131,7 @@ describe('provider-gmail/Metadata source discrimination', () => {
     expect((loaded as unknown as { clientSecret?: string }).clientSecret).toBeUndefined();
   });
 
-  it('rejects ambiguous records that mix BYOK and broker fields', async () => {
+  it('Scenario: Ambiguous mixed-shape metadata is rejected', async () => {
     // Could equally describe either mode; refuse to guess and force a re-configure.
     await writeRaw('ambiguous.json', {
       provider: 'gmail',

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -60,7 +60,9 @@ vi.mock('@azure/identity-cache-persistence', () => ({
 }));
 
 describe('provider-interface/Microsoft Mailbox Settings Consent', () => {
-  it('Scenario: Both delegated scope lists request MailboxSettings.ReadWrite', () => {
+  it('Scenario: Existing user reconnects', () => {
+    // Both delegated scope lists request MailboxSettings.ReadWrite, so a
+    // reconnect after this capability ships prompts for the new consent.
     expect(GRAPH_SCOPES).toContain('MailboxSettings.ReadWrite');
     expect(GRAPH_SCOPES_FULL).toContain('https://graph.microsoft.com/MailboxSettings.ReadWrite');
   });

--- a/packages/provider-microsoft/src/folder-rule-management.test.ts
+++ b/packages/provider-microsoft/src/folder-rule-management.test.ts
@@ -11,8 +11,10 @@ function createMockClient(overrides: Partial<GraphApiClient> = {}): GraphApiClie
   };
 }
 
-describe('provider-microsoft/Folder Management', () => {
-  it('Scenario: Recursively traverses paginated roots and children with computed paths', async () => {
+describe('email-folders/Folder Management (Microsoft Graph)', () => {
+  it('Scenario: Nested paginated folders', async () => {
+    // Also verifies: recursively traverses paginated roots and children
+    // with computed paths.
     const get = vi.fn(async (url: string) => {
       if (url.startsWith('/me/mailFolders?')) {
         return {
@@ -50,7 +52,40 @@ describe('provider-microsoft/Folder Management', () => {
     ]);
   });
 
-  it('Scenario: Repeated custom moves reuse the cached folder tree', async () => {
+  it('Scenario: Move to custom folder path', async () => {
+    const get = vi.fn(async (url: string) => {
+      if (url.startsWith('/me/mailFolders?')) {
+        return { value: [{ id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 }] };
+      }
+      if (url.includes('/mailFolders/inbox-id/childFolders?')) {
+        return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
+      }
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+    const client = createMockClient({ get });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.moveToFolder('msg123', 'Inbox/Newsletters');
+
+    expect(client.post).toHaveBeenCalledWith('/me/messages/msg123/move', { destinationId: 'news-id' });
+  });
+
+  it('Scenario: Reads still use the cache', async () => {
+    const get = vi.fn().mockResolvedValue({
+      value: [{ id: 'inbox-id', displayName: 'Inbox', childFolderCount: 0 }],
+    });
+    const provider = new GraphEmailProvider(createMockClient({ get }));
+
+    await provider.listFolders();
+    await provider.listFolders();
+
+    // The second call within the 60s TTL is served from the cached
+    // snapshot rather than re-traversing the tree.
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('Scenario: Repeated moves reuse the cache', async () => {
+    // Repeated custom moves reuse the cached folder tree.
     const get = vi.fn().mockResolvedValue({
       value: [
         { id: 'inbox-id', displayName: 'Inbox', childFolderCount: 1 },
@@ -81,7 +116,8 @@ describe('provider-microsoft/Folder Management', () => {
     expect(get).toHaveBeenCalledTimes(2);
   });
 
-  it('Scenario: Well-known moves retain alias behavior without folder traversal', async () => {
+  it('Scenario: Preserve well-known move behavior', async () => {
+    // Well-known moves retain alias behavior without folder traversal.
     const client = createMockClient();
     const provider = new GraphEmailProvider(client);
 
@@ -91,7 +127,9 @@ describe('provider-microsoft/Folder Management', () => {
     expect(client.post).toHaveBeenCalledWith('/me/messages/msg-1/move', { destinationId: 'deleteditems' });
   });
 
-  it('Scenario: Creating a child folder invalidates the resolver cache', async () => {
+  it('Scenario: Re-resolve before a structural mutation', async () => {
+    // Creating a child folder invalidates the resolver cache — the write
+    // path re-resolves the parent before selecting its id.
     let rootReads = 0;
     const get = vi.fn(async (url: string) => {
       if (!url.startsWith('/me/mailFolders?')) throw new Error(`Unexpected URL: ${url}`);
@@ -128,7 +166,8 @@ describe('provider-microsoft/Folder Management', () => {
     expect(client.delete).not.toHaveBeenCalled();
   });
 
-  it('Scenario: Refuses system folder deletion by resolved id', async () => {
+  it('Scenario: Refuse system folder id', async () => {
+    // Refuses system folder deletion by resolved id.
     const get = vi.fn(async (url: string) => {
       if (url.startsWith('/me/mailFolders?')) {
         return { value: [{ id: 'inbox-opaque-id', displayName: 'Inbox', childFolderCount: 0 }] };
@@ -150,7 +189,7 @@ describe('provider-microsoft/Folder Management', () => {
   });
 });
 
-describe('provider-microsoft/Inbox Rule Management', () => {
+describe('email-inbox-rules/Inbox Rule Management (Microsoft Graph)', () => {
   it('Scenario: Lists every paginated rule without stripping fields', async () => {
     const firstRule = {
       id: 'rule-1',
@@ -169,10 +208,16 @@ describe('provider-microsoft/Inbox Rule Management', () => {
     expect(get).toHaveBeenNthCalledWith(2, 'https://graph.microsoft.com/rules-page-2');
   });
 
-  it('Scenario: Creates a rule after resolving its custom move destination', async () => {
+  it('Scenario: Re-resolve a rule destination', async () => {
+    // Creates a rule after resolving its custom move destination. Primes a
+    // STALE cache entry for "Newsletters" first (a plain listFolders()), so
+    // this only passes if createInboxRule forces a fresh traversal rather
+    // than reusing the (now-wrong) cached id — proving it does NOT share
+    // move_to_folder's cached-resolution behavior.
+    let newslettersId = 'stale-news-id';
     const get = vi.fn(async (url: string) => {
       if (url.startsWith('/me/mailFolders?')) {
-        return { value: [{ id: 'news-id', displayName: 'Newsletters', childFolderCount: 0 }] };
+        return { value: [{ id: newslettersId, displayName: 'Newsletters', childFolderCount: 0 }] };
       }
       // No sequence supplied → the provider lists existing rules to append.
       if (url === '/me/mailFolders/inbox/messageRules') {
@@ -187,6 +232,11 @@ describe('provider-microsoft/Inbox Rule Management', () => {
     const post = vi.fn().mockResolvedValue({ id: 'rule-1', displayName: 'GitHub' });
     const provider = new GraphEmailProvider(createMockClient({ get, post }));
 
+    // Prime the 60s move-to-folder cache with the stale id, then change
+    // what Graph would return for a fresh traversal.
+    await provider.listFolders();
+    newslettersId = 'news-id';
+
     await provider.createInboxRule({
       displayName: 'GitHub',
       conditions: { senderContains: ['github.com'] },
@@ -199,6 +249,8 @@ describe('provider-microsoft/Inbox Rule Management', () => {
       // invalid default of 0.
       sequence: 4,
       conditions: { senderContains: ['github.com'] },
+      // Resolves to the freshly-traversed id, not the primed stale one —
+      // proof the rule-destination path re-resolved rather than reusing cache.
       actions: { moveToFolder: 'news-id', markAsRead: true },
     });
   });
@@ -265,7 +317,8 @@ describe('provider-microsoft/Inbox Rule Management', () => {
 });
 
 describe('provider-microsoft/Peer-review hardening (PR #106)', () => {
-  it('Scenario: Rejects case-variant forwarding actions called directly on the provider', async () => {
+  it('Scenario: Reject case-variant forwarding at the provider', async () => {
+    // Rejects case-variant forwarding actions called directly on the provider.
     const client = createMockClient();
     const provider = new GraphEmailProvider(client);
 
@@ -281,7 +334,8 @@ describe('provider-microsoft/Peer-review hardening (PR #106)', () => {
     expect(client.post).not.toHaveBeenCalled();
   });
 
-  it('Scenario: Fails closed on rule actions outside the safe allowlist', async () => {
+  it('Scenario: Fail closed on unknown actions', async () => {
+    // Fails closed on rule actions outside the safe allowlist.
     const client = createMockClient();
     const provider = new GraphEmailProvider(client);
 
@@ -293,7 +347,8 @@ describe('provider-microsoft/Peer-review hardening (PR #106)', () => {
     expect(client.post).not.toHaveBeenCalled();
   });
 
-  it('Scenario: Caps total Graph requests across a wide recursive folder tree', async () => {
+  it('Scenario: Truncate rather than fail on a very large mailbox', async () => {
+    // Caps total Graph requests across a wide recursive folder tree.
     // Every folder claims a child, so an uncapped traversal recurses forever.
     const get = vi.fn(async () => ({
       value: [{ id: `f-${get.mock.calls.length}`, displayName: `F${get.mock.calls.length}`, childFolderCount: 1 }],
@@ -309,7 +364,8 @@ describe('provider-microsoft/Peer-review hardening (PR #106)', () => {
 });
 
 describe('provider-microsoft/Destructive rule destinations (PR #106 review)', () => {
-  it('Scenario: Blocks a rule that files mail into Deleted Items via any alias', async () => {
+  it('Scenario: Reject aliases and case variants after resolution', async () => {
+    // Blocks a rule that files mail into Deleted Items via any alias.
     const client = createMockClient();
     const provider = new GraphEmailProvider(client);
 
@@ -325,7 +381,8 @@ describe('provider-microsoft/Destructive rule destinations (PR #106 review)', ()
     expect(client.post).not.toHaveBeenCalled();
   });
 
-  it('Scenario: Does not cache a truncated folder snapshot', async () => {
+  it('Scenario: Never cache a partial tree', async () => {
+    // Does not cache a truncated folder snapshot.
     let calls = 0;
     const get = vi.fn(async () => {
       calls += 1;
@@ -462,7 +519,8 @@ describe('provider-microsoft/Round-2 Codex probes (PR #106)', () => {
     }
   });
 
-  it('Scenario: A truncated tree refuses a name match rather than misrouting a move', async () => {
+  it('Scenario: Refuse to infer absence from a truncated tree', async () => {
+    // A truncated tree refuses a name match rather than misrouting a move.
     // Every folder claims a child so the traversal truncates; the target name
     // is visible but cannot be proven unique, so resolution must refuse.
     const get = vi.fn(async (url: string) => {

--- a/scripts/check-spec-coverage.mjs
+++ b/scripts/check-spec-coverage.mjs
@@ -12,7 +12,10 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = join(fileURLToPath(import.meta.url), '..', '..');
 const SPECS_DIR = join(ROOT, 'openspec', 'specs');
-const PACKAGES_DIR = join(ROOT, 'packages');
+// Both npm workspaces globs (see root package.json "workspaces") can contain
+// implementation + tests for spec-covered behavior — e.g. the OAuth broker
+// lives under apps/oauth-broker, not packages/.
+const TEST_ROOTS = [join(ROOT, 'packages'), join(ROOT, 'apps')];
 
 // ── Spec parsing ────────────────────────────────────────────────────────────
 
@@ -68,7 +71,7 @@ async function parseScenariosFromSpecs() {
 // ── Test scanning ───────────────────────────────────────────────────────────
 
 /**
- * Recursively find all *.test.ts files under packages/.
+ * Recursively find all *.test.ts files under the given directory.
  * @param {string} dir
  * @returns {Promise<string[]>}
  */
@@ -104,7 +107,9 @@ async function parseScenariosFromTests() {
   /** @type {Map<string, Set<string>>} */
   const testMap = new Map();
 
-  const testFiles = await findTestFiles(PACKAGES_DIR);
+  const testFiles = (
+    await Promise.all(TEST_ROOTS.map((root) => findTestFiles(root)))
+  ).flat();
 
   for (const filePath of testFiles) {
     const content = await readFile(filePath, 'utf-8');
@@ -114,7 +119,11 @@ async function parseScenariosFromTests() {
     const specIds = new Set(describeMatches.map((m) => m[1].trim()));
 
     // Extract scenario names: it('Scenario: name', ...)
-    const scenarioMatches = [...content.matchAll(/it\s*\(\s*['"`]Scenario:\s+([^'"`]+)['"`]/g)];
+    // Match against the SAME opening delimiter (backreference) rather than
+    // excluding all quote characters — some canonical scenario names embed
+    // a literal `"` (e.g. Inline "On … wrote:" ...), which a delimiter-
+    // agnostic exclusion would truncate at.
+    const scenarioMatches = [...content.matchAll(/it\s*\(\s*(['"`])Scenario:\s+((?:(?!\1).)+)\1/g)];
 
     for (const specId of specIds) {
       if (!testMap.has(specId)) {
@@ -122,7 +131,7 @@ async function parseScenariosFromTests() {
       }
       const set = testMap.get(specId);
       for (const match of scenarioMatches) {
-        set.add(match[1].trim());
+        set.add(match[2].trim());
       }
     }
   }


### PR DESCRIPTION
## Summary

Archives four fully-implemented and verified OpenSpec change proposals via `openspec archive <id> -y`, in the order listed below (matters because several changes touch the same canonical specs, e.g. `cli`, `mailbox-config`, `provider-gmail`):

1. `add-gmail-cli-configure`
2. `update-gmail-default-oauth-client`
3. `add-strip-quoted-history`
4. `add-folder-and-rule-management`

Each archive merges the change's spec deltas into `openspec/specs/`. No directories were moved manually.

## What else this touched (and why)

- **5 pre-existing canonical specs were missing a literal `## Requirements` wrapper** (`cli`, `mailbox-config`, `provider-gmail`, `email-read`, `provider-interface`) — a defect that predates this PR (confirmed via `openspec validate --all --strict` on `main` before touching anything: 15/15 canonical specs already failed strict validation for this exact reason). The `openspec archive` CLI refuses to write into a structurally-invalid spec, so archiving change 1 was blocked until these were fixed. The fix only inserts the missing header; no requirement/scenario text changed. The remaining 10 canonical specs untouched by these 4 changes are still in their pre-existing broken state (out of scope here).
- **`scripts/check-spec-coverage.mjs` had two real bugs**, both now fixed:
  - It only scanned `packages/**/*.test.ts`, but the OAuth broker's implementation + tests live under `apps/oauth-broker` (a legitimate `apps/*` npm workspace) — so real, existing broker tests were structurally invisible to the checker. Now scans both `packages/` and `apps/`.
  - Its scenario-title regex excluded *all* quote characters from the captured name, so it could never match a scenario whose text embeds a literal `"` (e.g. `Inline "On … wrote:" with user prose after is preserved`, introduced by `add-strip-quoted-history`). Fixed to match against the actual opening delimiter via a backreference.
- **Test traceability fixes**: per each archive, `npm run check:spec-coverage` was run and any newly-uncovered scenario was investigated. In nearly every case the behavior was already correctly implemented and tested — just under a differently-worded test title, or filed under the wrong package/spec-id (e.g. Gmail broker OAuth tests needed to declare the `provider-gmail`/`cli`/`mailbox-config` spec ids the canonical specs actually use). Those were retitled to the exact `Scenario: <name>` text. A small number of scenarios had no existing test anywhere (e.g. CLI broker-URL https validation, the broker's Redis-required-in-production config check) — trivial tests were added for those, reusing already-established test patterns in the same files.

## Validation / spec-coverage results (after each archive)

| Step | `openspec validate --strict` (touched specs) | `check:spec-coverage` |
|---|---|---|
| After 1: `add-gmail-cli-configure` | cli/mailbox-config/provider-gmail valid | 201/204 → fixed to 204/204* |
| After 2: `update-gmail-default-oauth-client` | cli/mailbox-config/provider-gmail valid | 216/216 |
| After 3: `add-strip-quoted-history` | email-read valid | 220/220 |
| After 4: `add-folder-and-rule-management` | email-folders/email-inbox-rules/provider-interface valid | 249/249 |

*After change 1, two scenarios remained genuinely cross-package (mailbox-config/provider-gmail) and weren't resolved until change 2 landed its own delta on the same requirement — final state after change 2 is 216/216 with nothing outstanding.

## Final state

- `openspec validate --all --strict`: all specs touched by these 4 changes (`cli`, `mailbox-config`, `provider-gmail`, `email-read`, `provider-interface`, `email-folders`, `email-inbox-rules`) are valid. 10 unrelated specs remain in their pre-existing (unrelated, out-of-scope) broken state.
- `npm run check:spec-coverage`: **249/249 scenarios covered**, 0 missing.
- `npm run build`: clean.
- `npm run test:run` (all workspaces incl. `apps/oauth-broker`): **877/877 tests passing**.

## Test plan

- [x] `openspec validate --all --strict` — all 7 specs touched by these changes pass
- [x] `npm run check:spec-coverage` — 249/249
- [x] `npm run build` — clean
- [x] `npm run test:run` — 877/877 passing across all workspaces
- [x] Peer-reviewed with Codex CLI (see PR comment)

https://claude.ai/code/session_016ceV6FiQSuoBAhvME2eC97