### PR TITLE
fix(oauth-broker): close claim() interleaving window in the in-memory store

### DIFF
--- a/apps/oauth-broker/lib/store.test.ts
+++ b/apps/oauth-broker/lib/store.test.ts
@@ -63,7 +63,9 @@ describe('provider-gmail/OAuth2 Authentication (broker store)', () => {
   });
 
   it('Scenario: Atomic one-shot ticket claim', async () => {
-    // setReady → claim succeeds once and only once.
+    // setReady → claim succeeds once and only once — including when two
+    // claims race concurrently (claim() awaits a hash computation before
+    // deleting the session, so a real interleaving window exists).
     const store = getStore();
     const id = 'c'.repeat(40);
     const secret = 'secret-success';
@@ -74,13 +76,21 @@ describe('provider-gmail/OAuth2 Authentication (broker store)', () => {
       expires_in: 3600,
     });
 
-    const a = await store.claim(id, secret);
-    expect(a.ok).toBe(true);
-    if (a.ok) expect(a.tokens.access_token).toBe('at');
+    const [a, b] = await Promise.all([store.claim(id, secret), store.claim(id, secret)]);
+    const results = [a, b];
+    const succeeded = results.filter(r => r.ok);
+    const failed = results.filter(r => !r.ok);
 
-    const b = await store.claim(id, secret);
-    expect(b.ok).toBe(false);
-    if (!b.ok) expect(['consumed', 'not_found']).toContain(b.reason);
+    expect(succeeded).toHaveLength(1);
+    expect(failed).toHaveLength(1);
+    if (succeeded[0]!.ok) expect(succeeded[0]!.tokens.access_token).toBe('at');
+    if (!failed[0]!.ok) expect(['consumed', 'not_found']).toContain(failed[0]!.reason);
+
+    // A third claim after both have resolved must also fail — the session
+    // is gone, not merely "in use".
+    const c = await store.claim(id, secret);
+    expect(c.ok).toBe(false);
+    if (!c.ok) expect(['consumed', 'not_found']).toContain(c.reason);
   });
 
   it('Scenario: Public session_id is not a bearer credential', async () => {
@@ -106,16 +116,34 @@ describe('provider-gmail/OAuth2 Authentication (broker store)', () => {
     // setFailed surfaces denied vs exchange_failed distinctly; sibling
     // tests in this file cover the pending and expired terminal states.
     const store = getStore();
-    const id = 'e'.repeat(40);
+    const deniedId = 'e'.repeat(40);
     const secret = 'sec';
-    await store.create(id, freshSession(secret));
-    await store.setFailed(id, 'denied', 'user cancelled');
+    await store.create(deniedId, freshSession(secret));
+    await store.setFailed(deniedId, 'denied', 'user cancelled');
 
-    const result = await store.claim(id, secret);
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe('denied');
-      expect(result.errorMessage).toBe('user cancelled');
+    const deniedResult = await store.claim(deniedId, secret);
+    expect(deniedResult.ok).toBe(false);
+    if (!deniedResult.ok) {
+      expect(deniedResult.reason).toBe('denied');
+      expect(deniedResult.errorMessage).toBe('user cancelled');
+    }
+
+    const exchangeFailedId = 'a1'.repeat(20);
+    await store.create(exchangeFailedId, freshSession(secret));
+    await store.setFailed(exchangeFailedId, 'exchange_failed', 'invalid_grant');
+
+    const exchangeFailedResult = await store.claim(exchangeFailedId, secret);
+    expect(exchangeFailedResult.ok).toBe(false);
+    if (!exchangeFailedResult.ok) {
+      expect(exchangeFailedResult.reason).toBe('exchange_failed');
+      expect(exchangeFailedResult.errorMessage).toBe('invalid_grant');
+    }
+
+    // The two failure modes must be distinguishable from one another, not
+    // just each distinguishable from success.
+    expect(deniedResult.ok || exchangeFailedResult.ok).toBe(false);
+    if (!deniedResult.ok && !exchangeFailedResult.ok) {
+      expect(deniedResult.reason).not.toBe(exchangeFailedResult.reason);
     }
   });
 

--- a/apps/oauth-broker/lib/store.ts
+++ b/apps/oauth-broker/lib/store.ts
@@ -92,7 +92,7 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 class MemoryStore implements SessionStore {
-  private map = new Map<string, { session: Session; expiresAt: number }>();
+  private map = new Map<string, { session: Session; expiresAt: number; claiming?: boolean }>();
 
   async create(sessionId: string, session: Session): Promise<CreateResult> {
     if (this.map.has(sessionId) && this.map.get(sessionId)!.expiresAt > Date.now()) {
@@ -142,12 +142,21 @@ class MemoryStore implements SessionStore {
     }
     if (session.state !== 'ready') return { ok: false, reason: 'consumed' };
 
+    // sha256Hex awaits, which yields the event loop — a second concurrent
+    // claim() for the same session can run its own checks in that window.
+    // Synchronously stake a claim BEFORE the await so at most one caller
+    // ever reaches the hash comparison; everyone else fails closed as if
+    // the session were already consumed. On an invalid secret we release
+    // the stake so a subsequent correct attempt can still succeed.
+    if (entry.claiming) return { ok: false, reason: 'consumed' };
+    entry.claiming = true;
+
     const expectedHash = session.pickupHash;
     const presentedHash = await sha256Hex(pickupSecret);
     if (!constantTimeEqual(expectedHash, presentedHash)) {
+      entry.claiming = false;
       return { ok: false, reason: 'invalid_secret' };
     }
-    // Single-threaded JS: get-then-delete is atomic between awaits.
     this.map.delete(sessionId);
     if (!session.tokens) return { ok: false, reason: 'consumed' };
     return { ok: true, tokens: session.tokens };


### PR DESCRIPTION
Split out of #114 so this gets reviewed on its own merits instead of inside an archival chore.

> **Stacked PR** — based on `chore/archive-completed-openspec-changes` (#114), because the test this modifies is introduced there. Merge #114 first; this will retarget to `main` automatically.

## The bug

`MemoryStore.claim()` checked session state, then `await`ed `sha256Hex()` to verify the presented pickup secret, then deleted the session:

```ts
if (session.state !== 'ready') return { ok: false, reason: 'consumed' };
const presentedHash = await sha256Hex(pickupSecret);   // <-- yields the event loop
if (!constantTimeEqual(expectedHash, presentedHash)) { ... }
this.map.delete(sessionId);
// Single-threaded JS: get-then-delete is atomic between awaits.
```

That trailing comment asserted an atomicity the `await` had already broken. Two concurrent `claim()` calls for the same session could both pass the state check before either reached the delete — and **both would be handed the same session's OAuth tokens**.

## The fix

Stake a claim *synchronously*, before the await, so at most one caller ever reaches the hash comparison; concurrent callers fail closed as `consumed`. On an invalid secret the stake is released so a later correct attempt still succeeds.

## Evidence it's real

The existing "Atomic one-shot ticket claim" test ran its two claims **sequentially**, so it passed against the buggy code. Rewritten to race them via `Promise.all`, it fails against the unfixed store:

```
× Scenario: Atomic one-shot ticket claim
AssertionError: expected [ Array(2) ] to have a length of 1 but got 2
Test Files  1 failed | 2 passed (3)
```

With the fix: 877/877 tests pass across all five workspaces.

## Scope

In-memory backend only. The production KV backend uses an atomic Redis `GETDEL` and was never affected.

**Known gap (pre-existing, not introduced here):** the KV/Redis `claim()` path has no dedicated atomicity test — only the in-memory backend is exercised by this repo's suite. Worth a follow-up issue.

https://claude.ai/code/session_016ceV6FiQSuoBAhvME2eC97