### PR TITLE
fix(openspec): restore Requirements section headers so specs are visible to the CLI

### DIFF
--- a/openspec/specs/content-engine/spec.md
+++ b/openspec/specs/content-engine/spec.md
@@ -6,7 +6,7 @@ feature: AI-Ready Email Transformation
 ## Purpose
 
 Transforms raw email content (HTML or plaintext) into a token-efficient representation optimized for LLM consumption. Handles HTML sanitization, signature stripping, encoding normalization, and attachment summarization. Thread dedup is stubbed for v1 — rely on limit parameters instead.
-
+## Requirements
 ### Requirement: HTML to Token-Efficient Markdown
 
 The system SHALL convert HTML email bodies to token-efficient markdown, preserving tables, lists, links, and non-tracking images while stripping tracking pixels, data URI images, CSS, scripts, and hidden elements.

--- a/openspec/specs/email-attachments/spec.md
+++ b/openspec/specs/email-attachments/spec.md
@@ -6,7 +6,7 @@ feature: Attachment Handling
 ## Purpose
 
 Defines attachment operations: downloading from inbound emails, attaching to outbound emails, embedded image handling, binary file detection, filename sanitization, and size/type validation. Outbound attachments are file-based only (no CID embedding in v1).
-
+## Requirements
 ### Requirement: Download Attachments
 
 The system SHALL download attachments from inbound emails using provider-specific retrieval and return metadata (filename, MIME type, size, contentId).

--- a/openspec/specs/email-categorize/spec.md
+++ b/openspec/specs/email-categorize/spec.md
@@ -6,7 +6,7 @@ feature: Email Classification & Labeling
 ## Purpose
 
 Defines actions for classifying and organizing existing emails: labeling, flagging, marking read/unread, and moving to folders. The MCP applies labels as directed — the AI agent does the thinking. No delete in v1. Provider mapping: Graph categories/flags to Gmail labels/stars.
-
+## Requirements
 ### Requirement: Label Email
 
 The system SHALL provide a `label_email` action that applies a label or category to an email as directed by the agent.

--- a/openspec/specs/email-security/spec.md
+++ b/openspec/specs/email-security/spec.md
@@ -6,7 +6,7 @@ feature: Email Security Controls
 ## Purpose
 
 Defines security controls for email operations: send allowlist (gates all outbound including replies), receive allowlist (gates watcher triggers), delete policy, anti-spoofing (SPF/DKIM/DMARC), and rate limiting. Security-first defaults: all outbound blocked until explicitly configured.
-
+## Requirements
 ### Requirement: Send Allowlist
 
 The system SHALL gate ALL outbound email (both `send_email` and `reply_to_email`) against a configurable allowlist. The allowlist supports exact email addresses, domain wildcards (`*@example.com`), or both. Default is EMPTY — blocks all outbound until configured.

--- a/openspec/specs/email-threading/spec.md
+++ b/openspec/specs/email-threading/spec.md
@@ -6,7 +6,7 @@ feature: Conversation Threading
 ## Purpose
 
 Defines conversation thread retrieval and assembly. Uses provider-native thread IDs (Graph `conversationId`, Gmail `threadId`) with RFC header fallback (`Message-ID`, `In-Reply-To`, `References`) when provider IDs fail. Flattens multi-message threads into agent-friendly format.
-
+## Requirements
 ### Requirement: Get Thread
 
 The system SHALL provide a `get_thread` action that returns all messages in a conversation, ordered chronologically, with content engine transformations applied per message. The action SHALL retrieve the complete conversation from the provider (paging through provider continuation tokens rather than returning only the provider's first page), so the newest messages are never silently omitted. When the result is capped below the true conversation size, the action SHALL set `isTruncated: true` and report the true `messageCount`; when the whole conversation is returned it SHALL set `isTruncated: false`. The message identified by the passed `message_id` SHALL always be present in the result, even when it falls outside the newest window of a very long thread. Each returned message SHALL surface recipient topology — `to`, `cc`, and `bcc` — as explicit arrays of `Name <email>` strings, returning an empty array `[]` (never a missing key) when a field has no recipients, so a caller reasoning about reply-all scope can see who was on each message.

--- a/openspec/specs/email-watcher/spec.md
+++ b/openspec/specs/email-watcher/spec.md
@@ -6,7 +6,7 @@ feature: Email Arrival Detection
 ## Purpose
 
 Defines the email watcher that monitors configured mailboxes for new emails and triggers agent wake via authenticated webhook POST. Uses timestamp-based polling to detect new messages. Monitors all configured mailboxes and includes mailbox email address in wake payloads. Wake payloads use text-only format for OpenClaw `/hooks/wake` compatibility. The watcher uses `receivedDateTime ge {since}` filtering with a checkpoint that advances only after a successful wake POST.
-
+## Requirements
 ### Requirement: Timestamp-Based Polling Protocol
 
 The watcher SHALL use timestamp-based polling to detect new emails. On first run, the checkpoint is set to the current time (no historical backfill). Subsequent polls filter messages using `receivedDateTime ge {since}`. The checkpoint advances only after a successful wake POST, ensuring no messages are lost on transient failures.

--- a/openspec/specs/email-write/spec.md
+++ b/openspec/specs/email-write/spec.md
@@ -6,7 +6,7 @@ feature: Write Actions
 ## Purpose
 
 Defines outbound email operations: replying to and sending emails. All outbound operations are gated by the send allowlist. Write actions REQUIRE the `mailbox` parameter when multiple mailboxes are configured to prevent accidentally sending from the wrong account. Supports composing from a local file (`body_file`) for iterative draft editing.
-
+## Requirements
 ### Requirement: Reply to Email
 
 The system SHALL provide a `reply_to_email` action that replies within an existing thread, preserving In-Reply-To headers and threading metadata. The reply recipient MUST be checked against the send allowlist.

--- a/openspec/specs/mcp-transport/spec.md
+++ b/openspec/specs/mcp-transport/spec.md
@@ -6,7 +6,7 @@ feature: MCP Server Adapter
 ## Purpose
 
 Defines the thin MCP transport adapter that maps the email-core action registry to MCP tools. Uses stdio transport. Auto-registers actions — adding a new action in email-core auto-exposes it as an MCP tool. The adapter is ~100 lines and contains no business logic.
-
+## Requirements
 ### Requirement: Action to Tool Mapping
 
 The system SHALL iterate the action registry and generate an MCP tool for each action, using Zod v4's built-in JSON Schema generation for input schemas.

--- a/openspec/specs/observability/spec.md
+++ b/openspec/specs/observability/spec.md
@@ -6,7 +6,7 @@ feature: Observability & Logging
 ## Purpose
 
 Defines logging, error reporting, optional telemetry, and metrics for the email MCP server. Critical constraint: MUST log to stderr, NEVER stdout (stdout is the MCP stdio transport — logging there corrupts the protocol). Includes error sanitization to prevent exposing internal paths, API keys, or stack traces in MCP tool responses.
-
+## Requirements
 ### Requirement: Log Destination
 
 The system SHALL log exclusively to stderr. Logging to stdout SHALL be treated as a critical bug.

--- a/openspec/specs/provider-microsoft/spec.md
+++ b/openspec/specs/provider-microsoft/spec.md
@@ -6,7 +6,7 @@ feature: Microsoft Graph Provider
 ## Purpose
 
 Implements the provider interface for Microsoft Graph API email operations. Supports delegated OAuth (device code/PKCE for end users) and client credentials (for daemon deployments). Handles Graph-specific concerns: createReplyAll for threading, validation token handling (GET + POST), webhook deduplication, zombie subscription detection, size limits, and anti-spoofing via authentication headers.
-
+## Requirements
 ### Requirement: Delegated OAuth Authentication
 
 The system SHALL support delegated OAuth as the primary auth mode for end users, using device code flow or authorization code flow with PKCE. This avoids requiring users to register an Azure AD daemon app. Refresh tokens SHALL be persisted (encrypted) for session continuity across restarts.
@@ -93,7 +93,7 @@ The system SHALL test that the validation endpoint responds correctly before cre
 
 ### Requirement: Size Limits
 
-Email body max 3.5MB (Graph allows ~4MB, leave headroom for JSON envelope). Attachment max 25MB. Subject max 255 characters.
+The system SHALL enforce an email body maximum of 3.5MB (Graph allows ~4MB; the remainder is headroom for the JSON envelope), an attachment maximum of 25MB, and a subject maximum of 255 characters.
 
 #### Scenario: Body size enforcement
 - **WHEN** email body exceeds 3.5MB


### PR DESCRIPTION
## The problem

Ten of seventeen canonical spec files are missing the `## Requirements` header. OpenSpec only parses requirements **inside** that section, so **70 requirements** are invisible to `validate`, `list`, `show`, and — the one that bites — `archive`:

```
Requirement header "### Requirement: Draft Workflow" appears outside the main
## Requirements section. Main specs only parse requirements inside that
section, so this requirement is currently invisible to validate, list, and archive.
Aborted. No files were changed.
```

A change proposal can be authored against one of these capabilities, pass `openspec validate <id> --strict`, and then **fail to archive**. `validate` on the change does not catch it.

The four changes archived on 2026-07-22 happened to touch only compliant files (`cli`, `email-read`, `mailbox-config`, `provider-gmail`, `provider-interface`), which is why this went unnoticed. Four of the five change proposals currently pending are blocked by it.

Affected: `content-engine`, `email-attachments`, `email-categorize`, `email-security`, `email-threading`, `email-watcher`, `email-write`, `mcp-transport`, `observability`, `provider-microsoft`.

## The change

Mechanical. Ten blank lines become `## Requirements`, placed exactly where the seven already-compliant files put it. **No requirement text is added, removed, or reordered** — the whole diff is:

```
  10 +## Requirements
  10 -
```

Plus one content fix: making `provider-microsoft`'s requirements visible exposed a pre-existing defect that had never been validated. `Size Limits` stated its limits without a SHALL/MUST keyword and fails `validate --specs --strict` the moment it becomes visible. Reworded to declare the same three limits normatively — no semantic change. It ships here because this PR is what surfaces it.

## Verification

| Check | Before | After |
|---|---|---|
| `openspec validate --specs --strict` | 16 passed / 1 failed¹ | **17 passed / 0 failed** |
| `openspec show email-write --json` | emits no valid JSON | 7 requirements |
| `npm run check:spec-coverage` | 249/249 | 249/249 |

¹ provider-microsoft fails only once its requirements become visible — the defect was always there, just unparsed.

End-to-end: all five pending change proposals (`update-mailbox-required-recovery`, `add-create-draft-reply-all`, `update-list-emails-thread-ids`, `update-read-email-strip-signatures`, `update-reply-draft-preview-quoted-history`) archive cleanly in sequence against the fixed baseline in a scratch copy. Against `main` they abort.

This was found by actually running `openspec archive` in a throwaway copy rather than trusting `validate`.

https://claude.ai/code/session_016ceV6FiQSuoBAhvME2eC97