### PR TITLE
fix(graph): map cc and bcc on outbound Graph payloads (closes #48)

### DIFF
--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1914,7 +1914,8 @@ describe('provider-microsoft/Outbound Recipients', () => {
   // Issue #48: createDraft built its payload with toRecipients only, so a draft
   // created against a Graph mailbox silently lost cc/bcc. sendMessage and
   // updateDraft mapped cc but had the same bcc gap. Gmail has always honored
-  // both (buildMimeMessage), so this was a provider-parity bug.
+  // both (buildRawMessage, email-gmail-provider.ts:755), so this was a
+  // provider-parity bug.
   it('createDraft maps cc and bcc into the Graph payload', async () => {
     const client = createMockClient();
     const provider = new GraphEmailProvider(client);
@@ -1939,21 +1940,46 @@ describe('provider-microsoft/Outbound Recipients', () => {
     expect(msg.bccRecipients).toEqual([{ emailAddress: { address: 'dave@corp.com', name: undefined } }]);
   });
 
-  it('createDraft omits recipient keys entirely when cc/bcc are absent', async () => {
-    const client = createMockClient();
-    const provider = new GraphEmailProvider(client);
-
-    await provider.createDraft({
-      to: [{ email: 'alice@corp.com' }],
-      subject: 'No cc',
-      body: 'body',
+  // Asserted against the real wire body, not the provider-level payload: the
+  // whole reason `toGraphRecipients` returns undefined rather than [] is that
+  // JSON.stringify drops undefined keys. An absent list must never reach Graph
+  // as `null` or `[]`, because a PATCH that names the field replaces it —
+  // "Existing properties that are not included in the request body will
+  // maintain their previous values."
+  // https://learn.microsoft.com/en-us/graph/api/message-update?view=graph-rest-1.0#request-body
+  // Going through RealGraphApiClient keeps this honest if serialization changes.
+  it('an absent cc/bcc produces no key at all in the serialized request body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: 'new-id' }),
+      text: async () => '{"id":"new-id"}',
     });
+    vi.stubGlobal('fetch', fetchMock);
 
-    // JSON.stringify drops undefined keys, so an absent list must never reach
-    // Graph as an explicit null — that would clear the field server-side.
-    const payload = (client.post as MockFn).mock.calls[0]![1];
-    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('ccRecipients');
-    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('bccRecipients');
+    try {
+      const provider = new GraphEmailProvider(new RealGraphApiClient(async () => 'token'));
+      await provider.createDraft({
+        to: [{ email: 'alice@corp.com' }],
+        subject: 'No cc',
+        body: 'body',
+      });
+      await provider.updateDraft('draft-1', { subject: 'Retitled' });
+
+      const bodies = fetchMock.mock.calls.map(call => (call[1] as RequestInit).body as string);
+      expect(bodies).toHaveLength(2);
+      for (const body of bodies) {
+        expect(body).not.toContain('ccRecipients');
+        expect(body).not.toContain('bccRecipients');
+        expect(body).not.toContain('null');
+      }
+      // Sanity: the POST really did carry the recipients we did supply, so a
+      // silently-empty body can't make the assertions above pass vacuously.
+      expect(bodies[0]).toContain('"toRecipients"');
+      expect(bodies[0]).toContain('alice@corp.com');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('sendMessage maps bcc alongside cc', async () => {

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1905,6 +1905,95 @@ describe('provider-microsoft/Watcher Timestamp Boundary', () => {
   });
 });
 
+describe('provider-microsoft/Outbound Recipients', () => {
+  type MockFn = ReturnType<typeof vi.fn>;
+
+  const CC = [{ email: 'carol@corp.com', name: 'Carol' }];
+  const BCC = [{ email: 'dave@corp.com' }];
+
+  // Issue #48: createDraft built its payload with toRecipients only, so a draft
+  // created against a Graph mailbox silently lost cc/bcc. sendMessage and
+  // updateDraft mapped cc but had the same bcc gap. Gmail has always honored
+  // both (buildMimeMessage), so this was a provider-parity bug.
+  it('createDraft maps cc and bcc into the Graph payload', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createDraft({
+      to: [{ email: 'alice@corp.com' }],
+      cc: CC,
+      bcc: BCC,
+      subject: 'Draft with cc/bcc',
+      body: 'body',
+    });
+
+    const [url, payload] = (client.post as MockFn).mock.calls[0]!;
+    expect(url).toContain('/messages');
+    const msg = payload as {
+      toRecipients: Array<{ emailAddress: { address: string } }>;
+      ccRecipients?: Array<{ emailAddress: { address: string; name?: string } }>;
+      bccRecipients?: Array<{ emailAddress: { address: string } }>;
+    };
+    expect(msg.toRecipients.map(r => r.emailAddress.address)).toEqual(['alice@corp.com']);
+    expect(msg.ccRecipients).toEqual([{ emailAddress: { address: 'carol@corp.com', name: 'Carol' } }]);
+    expect(msg.bccRecipients).toEqual([{ emailAddress: { address: 'dave@corp.com', name: undefined } }]);
+  });
+
+  it('createDraft omits recipient keys entirely when cc/bcc are absent', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createDraft({
+      to: [{ email: 'alice@corp.com' }],
+      subject: 'No cc',
+      body: 'body',
+    });
+
+    // JSON.stringify drops undefined keys, so an absent list must never reach
+    // Graph as an explicit null — that would clear the field server-side.
+    const payload = (client.post as MockFn).mock.calls[0]![1];
+    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('ccRecipients');
+    expect(JSON.parse(JSON.stringify(payload))).not.toHaveProperty('bccRecipients');
+  });
+
+  it('sendMessage maps bcc alongside cc', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.sendMessage({
+      to: [{ email: 'alice@corp.com' }],
+      cc: CC,
+      bcc: BCC,
+      subject: 'Send with bcc',
+      body: 'body',
+    });
+
+    const payload = (client.post as MockFn).mock.calls[0]![1] as {
+      message: {
+        ccRecipients?: Array<{ emailAddress: { address: string } }>;
+        bccRecipients?: Array<{ emailAddress: { address: string } }>;
+      };
+    };
+    expect(payload.message.ccRecipients?.map(r => r.emailAddress.address)).toEqual(['carol@corp.com']);
+    expect(payload.message.bccRecipients?.map(r => r.emailAddress.address)).toEqual(['dave@corp.com']);
+  });
+
+  it('updateDraft patches bcc when supplied and omits it otherwise', async () => {
+    const client = createMockClient();
+    const provider = new GraphEmailProvider(client);
+
+    await provider.updateDraft('draft-bcc', { bcc: BCC });
+    const withBcc = (client.patch as MockFn).mock.calls[0]![1] as Record<string, unknown>;
+    expect(withBcc.bccRecipients).toEqual([{ emailAddress: { address: 'dave@corp.com', name: undefined } }]);
+
+    // Omitting bcc must leave the draft's existing bcc alone — Graph PATCH is a
+    // merge, so the key has to be absent rather than null/[].
+    await provider.updateDraft('draft-bcc', { subject: 'Just a subject' });
+    const withoutBcc = (client.patch as MockFn).mock.calls[1]![1] as Record<string, unknown>;
+    expect(withoutBcc).not.toHaveProperty('bccRecipients');
+  });
+});
+
 describe('provider-microsoft/Outbound Attachments', () => {
   const PDF = Buffer.from('%PDF-1.4\nbytes', 'utf-8');
   type MockFn = ReturnType<typeof vi.fn>;

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -1,5 +1,6 @@
 // GraphEmailProvider — Microsoft Graph API email provider
 import type {
+  EmailAddress,
   EmailAttachment,
   EmailMessage,
   EmailThread,
@@ -70,6 +71,18 @@ function checkGraphAttachmentLimits(
     };
   }
   return null;
+}
+
+/**
+ * Map an address list to Graph `recipient` resources. Returns `undefined` for a
+ * missing list so callers can spread it into a payload without emitting an
+ * explicit `null` — on a PATCH that would clear the field rather than leave it
+ * untouched.
+ */
+function toGraphRecipients(
+  addrs: EmailAddress[] | undefined,
+): Array<{ emailAddress: { address: string; name?: string } }> | undefined {
+  return addrs?.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
 }
 
 /** Build a Graph `fileAttachment` resource from an OutboundAttachment. */
@@ -737,8 +750,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     const graphMsg: Record<string, unknown> = {
       subject: msg.subject.slice(0, SUBJECT_MAX_LENGTH),
       body: buildGraphBody(msg.bodyHtml, msg.body),
-      toRecipients: msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } })),
-      ccRecipients: msg.cc?.map(r => ({ emailAddress: { address: r.email, name: r.name } })),
+      toRecipients: toGraphRecipients(msg.to),
+      ccRecipients: toGraphRecipients(msg.cc),
+      bccRecipients: toGraphRecipients(msg.bcc),
       singleValueExtendedProperties: [
         { id: TRACKING_PROPERTY, value: trackingId },
       ],
@@ -784,7 +798,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
     const graphMsg: Record<string, unknown> = {
       subject: msg.subject,
       body: buildGraphBody(msg.bodyHtml, msg.body),
-      toRecipients: msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } })),
+      toRecipients: toGraphRecipients(msg.to),
+      ccRecipients: toGraphRecipients(msg.cc),
+      bccRecipients: toGraphRecipients(msg.bcc),
     };
     if (msg.attachments && msg.attachments.length > 0) {
       graphMsg.attachments = msg.attachments.map(toGraphFileAttachment);
@@ -938,8 +954,11 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       }
     }
     if (msg.subject !== undefined) patch.subject = msg.subject.slice(0, SUBJECT_MAX_LENGTH);
-    if (msg.to) patch.toRecipients = msg.to.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
-    if (msg.cc) patch.ccRecipients = msg.cc.map(r => ({ emailAddress: { address: r.email, name: r.name } }));
+    // An omitted list leaves the draft's existing recipients untouched (Graph
+    // PATCH is a merge); a provided list replaces them.
+    if (msg.to) patch.toRecipients = toGraphRecipients(msg.to);
+    if (msg.cc) patch.ccRecipients = toGraphRecipients(msg.cc);
+    if (msg.bcc) patch.bccRecipients = toGraphRecipients(msg.bcc);
 
     // Attachments: an omitted field preserves the draft's existing attachments
     // (Graph attachments are child resources untouched by this PATCH). A


### PR DESCRIPTION
Closes #48.

## The bug

`GraphEmailProvider.createDraft()` built its payload with `toRecipients` only, so **any non-reply draft created against an Outlook mailbox silently lost cc and bcc** — no error, no warning. While fixing it I found the same one-line gap in two neighbours:

| site | `cc` before | `bcc` before |
|---|---|---|
| `sendMessage` | ✅ | ❌ |
| `createDraft` | ❌ | ❌ |
| `updateDraft` | ✅ | ❌ |

Gmail has always honored `ComposeMessage.bcc` (`buildRawMessage`, `email-gmail-provider.ts:755`) and `ComposeMessage` declares the field, so this is a **provider-parity bug**, not a missing feature. Issue #48 names only `createDraft`; the other two are in scope because splitting them would knowingly ship the identical defect.

`createReplyDraft` was already correct — `prepareReplyDraft` reads back and merges both cc and bcc (`:875`, `:901`). Untouched.

## Scope guard: no public API change

No compose action exposes a `bcc` input today (`SendEmailInput` `send.ts:23`, `CreateDraftInput` `draft.ts:39`, `UpdateDraftInput` `draft.ts:275` all expose `cc` only). The bcc half of this fix is therefore **dormant on the MCP surface** and becomes live the moment a public `bcc` parameter lands. The cc drop in `createDraft` is the user-facing bug being fixed today.

## Why the helper returns `undefined`, not `[]`

`toGraphRecipients` returns `undefined` for an absent list so `JSON.stringify` drops the key entirely. This matters on PATCH — per the [Graph docs](https://learn.microsoft.com/en-us/graph/api/message-update?view=graph-rest-1.0#request-body):

> Existing properties that are **not included in the request body will maintain their previous values**.

Naming the field replaces it. So an omitted list must produce *no key*, or `updateDraft` would clear a draft's recipients whenever the caller didn't restate them. (Gmail's provider needs an explicit `msg.bcc ?? current.bcc` read-back because Gmail rebuilds the whole MIME message — a full replacement. Graph doesn't, so it isn't needed here.)

## Verification

| check | result |
|---|---|
| build | ✅ exit 0 |
| tests | **881 passed**, 0 failed |
| lint | ✅ 5/5 workspaces with a lint script |
| `check:spec-coverage` | **249/249**, unchanged |
| new tests fail on unfixed source | ✅ 3 of 4 (4th is a negative control) |
| mutation check | `[]` instead of `undefined` → boundary test fails ✅ |

The negative-control test drives `createDraft`/`updateDraft` through a real `RealGraphApiClient` with a stubbed `fetch` and asserts on the **captured wire body**, so it stays honest if serialization ever changes.

**No OpenSpec proposal or spec delta**, per `openspec/AGENTS.md`: this is a bug fix restoring intended behavior. Coverage stays at 249 — no delta leaked into `openspec/specs/`.

## Peer review

Reviewed by Codex CLI (`--sandbox workspace-write`, dynamic). Verdict **APPROVE**, 0 blockers, 0 majors, 2 NITs — both applied in `4b2543f`. It independently reproduced the regression check, wrote its own fixtures confirming the serialization and reply-draft-bcc behavior, and audited all five of my stated assumptions against executed evidence.

Pre-existing and unrelated: `packages/email-agent-mcp` (the wrapper) has no `test:run` or `lint` script, so `npm run … --workspaces` exits non-zero on it. Tracked separately with the other stale-tooling items.

> ⚠️ Provider-touching — needs a live Outlook smoke after merge. Mocks don't catch Graph server-side validation.