### PR TITLE
feat(mcp): expose list_mailboxes on the MCP tool surface (closes #93)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,14 @@ If your mailbox status name is not an email address, pass `--reply-sender <email
 
 ## Tool Reference
 
-Agent Email exposes 23 MCP tools:
+Agent Email exposes 24 MCP tools:
 
 | Tool | Description | Type |
 |------|-------------|------|
 | `list_emails` | List recent emails with filtering | read |
 | `read_email` | Read full email content as markdown | read |
 | `search_emails` | Full-text search across mailboxes | read |
+| `list_mailboxes` | Enumerate configured mailboxes, their status, and the default | read |
 | `get_mailbox_status` | Connection status and warnings | read |
 | `get_thread` | Full conversation context | read |
 | `list_attachments` | List attachment metadata for an email | read |

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1339,7 +1339,7 @@ describe('mcp-transport/List Mailboxes Tool', () => {
   function makeMailbox(o: MailboxOverrides): LazyMailboxState {
     const address = `${o.name}@example.com`;
     return {
-      name: o.name,
+      name: o.name, // logical config name, e.g. "work"
       emailAddress: address,
       displayName: address,
       providerType: 'microsoft',
@@ -1364,7 +1364,14 @@ describe('mcp-transport/List Mailboxes Tool', () => {
     expect(actions.find(a => a.name === 'list_mailboxes')).toBeDefined();
     const { result } = await executeTool(actions, {}, 'list_mailboxes', {});
     return result as {
-      mailboxes: Array<{ name: string; provider: string; isDefault: boolean; status: string; error?: string }>;
+      mailboxes: Array<{
+        name: string;
+        emailAddress: string | null;
+        provider: string;
+        isDefault: boolean;
+        status: string;
+        error?: string;
+      }>;
     };
   }
 
@@ -1375,9 +1382,11 @@ describe('mcp-transport/List Mailboxes Tool', () => {
     ]);
 
     expect(result.mailboxes).toHaveLength(2);
-    expect(result.mailboxes.map(m => m.name)).toEqual(['work@example.com', 'personal@example.com']);
+    // Logical name and emailAddress are DISTINCT fields (canonical contract).
+    expect(result.mailboxes.map(m => m.name)).toEqual(['work', 'personal']);
+    expect(result.mailboxes.map(m => m.emailAddress)).toEqual(['work@example.com', 'personal@example.com']);
     expect(result.mailboxes.filter(m => m.isDefault)).toHaveLength(1);
-    expect(result.mailboxes.find(m => m.name === 'work@example.com')?.isDefault).toBe(true);
+    expect(result.mailboxes.find(m => m.name === 'work')?.isDefault).toBe(true);
     // A connected mailbox carries no error key.
     expect(result.mailboxes.every(m => m.error === undefined)).toBe(true);
   });
@@ -1389,8 +1398,9 @@ describe('mcp-transport/List Mailboxes Tool', () => {
     ]);
 
     expect(result.mailboxes).toHaveLength(2);
-    const broken = result.mailboxes.find(m => m.name === 'broken@example.com');
+    const broken = result.mailboxes.find(m => m.name === 'broken');
     expect(broken?.status).toBe('error');
+    expect(broken?.emailAddress).toBe('broken@example.com');
     expect(broken?.error).toContain('AADSTS700016');
   });
 
@@ -1408,9 +1418,64 @@ describe('mcp-transport/List Mailboxes Tool', () => {
     expect(result.mailboxes.map(m => m.error)).toEqual(['token expired', 'consent required']);
   });
 
+  it('Scenario: a mailbox with no email address reports emailAddress: null rather than fabricating one', async () => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.mailboxes = [{
+      name: 'legacy',
+      emailAddress: undefined, // legacy metadata predating emailAddress capture
+      displayName: 'legacy',
+      providerType: 'microsoft',
+      provider: {} as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+    const actions = await buildLazyActions(state, noAllowlist);
+    const { result } = await executeTool(actions, {}, 'list_mailboxes', {}) as {
+      result: { mailboxes: Array<{ name: string; emailAddress: string | null }> };
+    };
+    expect(result.mailboxes[0]!.name).toBe('legacy');
+    expect(result.mailboxes[0]!.emailAddress).toBeNull();
+  });
+
   it('Scenario: returns an empty list when no mailbox is configured', async () => {
     const result = await runListMailboxes('not_configured', []);
     expect(result.mailboxes).toEqual([]);
+  });
+});
+
+// The SHIPPED list_mailboxes path (buildLazyActions → executeTool) is the
+// canonical implementation of the mailbox-config/List Mailboxes requirement —
+// the core listMailboxesAction reads an in-memory store this server never fills
+// and is dead code (tracked for follow-up removal/reconciliation). This block is
+// the spec-traceable proof that the shipped output matches the canonical shape:
+// distinct `name` + `emailAddress`, provider, isDefault, status.
+describe('mailbox-config/List Mailboxes', () => {
+  it('Scenario: List all mailboxes', async () => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.mailboxes = [{
+      name: 'work',
+      emailAddress: 'test-user@example.com',
+      displayName: 'test-user@example.com',
+      providerType: 'microsoft',
+      provider: {} as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+    const actions = await buildLazyActions(state, () => undefined);
+    const { result } = await executeTool(actions, {}, 'list_mailboxes', {}) as {
+      result: { mailboxes: Array<Record<string, unknown>> };
+    };
+    expect(result.mailboxes).toEqual([{
+      name: 'work',
+      emailAddress: 'test-user@example.com',
+      provider: 'microsoft',
+      isDefault: true,
+      status: 'connected',
+    }]);
   });
 });
 

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -14,6 +14,7 @@ import {
   coerceArgsForZod,
   type EmailActionDef,
   type LazyProviderState,
+  type LazyMailboxState,
 } from './server.js';
 
 // Create test actions that mimic the email-core action pattern
@@ -293,8 +294,8 @@ describe('mcp-transport/Lazy Provider State', () => {
     // No init has been triggered — state is still 'pending'.
     const actions = await buildLazyActions(state, noAllowlist);
 
-    // 4 custom tools + 19 email-core actions = 23 tools, no auth performed.
-    expect(actions.length).toBe(23);
+    // 5 custom tools + 19 email-core actions = 24 tools, no auth performed.
+    expect(actions.length).toBe(24);
     expect(state.status).toBe('pending');
     expect(state.initPromise).toBeNull();
     expect(state.provider).toBeNull();
@@ -1318,6 +1319,98 @@ describe('mcp-transport/Lazy Provider State', () => {
     await waitForInit(state);
     spy.mockRestore();
     expect(state.status).toBe('not_configured');
+  });
+});
+
+// Issue #93: list_mailboxes is a bespoke tool that enumerates state.mailboxes
+// directly. These tests drive the SHIPPED path (buildLazyActions → executeTool),
+// not the core listMailboxesAction, whose in-memory mailboxStore this server
+// never populates.
+describe('mcp-transport/List Mailboxes Tool', () => {
+  const noAllowlist = () => undefined;
+
+  type MailboxOverrides = {
+    name: string;
+    status: 'connected' | 'error';
+    isDefault?: boolean;
+    error?: string;
+  };
+
+  function makeMailbox(o: MailboxOverrides): LazyMailboxState {
+    const address = `${o.name}@example.com`;
+    return {
+      name: o.name,
+      emailAddress: address,
+      displayName: address,
+      providerType: 'microsoft',
+      provider: o.status === 'connected' ? ({} as never) : null,
+      auth: null,
+      isDefault: o.isDefault ?? false,
+      status: o.status,
+      error: o.error,
+    };
+  }
+
+  // Preset status to a settled value so waitForInit short-circuits without
+  // touching real auth — the tool then reads the state.mailboxes we planted.
+  async function runListMailboxes(
+    settledStatus: LazyProviderState['status'],
+    mailboxes: LazyMailboxState[],
+  ) {
+    const state = createLazyProviderState();
+    state.status = settledStatus;
+    state.mailboxes = mailboxes;
+    const actions = await buildLazyActions(state, noAllowlist);
+    expect(actions.find(a => a.name === 'list_mailboxes')).toBeDefined();
+    const { result } = await executeTool(actions, {}, 'list_mailboxes', {});
+    return result as {
+      mailboxes: Array<{ name: string; provider: string; isDefault: boolean; status: string; error?: string }>;
+    };
+  }
+
+  it('Scenario: enumerates connected mailboxes with the default marked', async () => {
+    const result = await runListMailboxes('connected', [
+      makeMailbox({ name: 'work', isDefault: true, status: 'connected' }),
+      makeMailbox({ name: 'personal', status: 'connected' }),
+    ]);
+
+    expect(result.mailboxes).toHaveLength(2);
+    expect(result.mailboxes.map(m => m.name)).toEqual(['work@example.com', 'personal@example.com']);
+    expect(result.mailboxes.filter(m => m.isDefault)).toHaveLength(1);
+    expect(result.mailboxes.find(m => m.name === 'work@example.com')?.isDefault).toBe(true);
+    // A connected mailbox carries no error key.
+    expect(result.mailboxes.every(m => m.error === undefined)).toBe(true);
+  });
+
+  it('Scenario: surfaces mailboxes that failed to authenticate alongside connected ones', async () => {
+    const result = await runListMailboxes('connected', [
+      makeMailbox({ name: 'work', isDefault: true, status: 'connected' }),
+      makeMailbox({ name: 'broken', status: 'error', error: 'AADSTS700016: app not found' }),
+    ]);
+
+    expect(result.mailboxes).toHaveLength(2);
+    const broken = result.mailboxes.find(m => m.name === 'broken@example.com');
+    expect(broken?.status).toBe('error');
+    expect(broken?.error).toContain('AADSTS700016');
+  });
+
+  it('Scenario: still enumerates when every mailbox failed — does not throw like the data actions', async () => {
+    // The whole point of reading state.mailboxes via waitForInit instead of
+    // ensureProvider: an agent calling list_mailboxes to diagnose "why is
+    // nothing working?" gets the list, not a PROVIDER_UNAVAILABLE error.
+    const result = await runListMailboxes('error', [
+      makeMailbox({ name: 'one', status: 'error', error: 'token expired' }),
+      makeMailbox({ name: 'two', status: 'error', error: 'consent required' }),
+    ]);
+
+    expect(result.mailboxes).toHaveLength(2);
+    expect(result.mailboxes.every(m => m.status === 'error')).toBe(true);
+    expect(result.mailboxes.map(m => m.error)).toEqual(['token expired', 'consent required']);
+  });
+
+  it('Scenario: returns an empty list when no mailbox is configured', async () => {
+    const result = await runListMailboxes('not_configured', []);
+    expect(result.mailboxes).toEqual([]);
   });
 });
 

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -968,6 +968,43 @@ export async function buildLazyActions(
         }
       },
     },
+    {
+      name: 'list_mailboxes',
+      description:
+        'List every configured mailbox with its connection status and which one is the default. Use this to discover available mailbox names to pass as the `mailbox` argument to other tools. Reports mailboxes that failed to authenticate too, so it stays useful for diagnosing a broken setup.',
+      input: z.object({}),
+      output: z.object({
+        mailboxes: z.array(
+          z.object({
+            name: z.string(),
+            provider: z.string(),
+            isDefault: z.boolean(),
+            status: z.enum(['connected', 'error']),
+            error: z.string().optional(),
+          }),
+        ),
+      }),
+      annotations: { readOnlyHint: true, destructiveHint: false },
+      // Enumerates state.mailboxes directly — NOT via the generic action wrapper
+      // and NOT via the core listMailboxesAction, whose in-memory mailboxStore is
+      // never populated by this server (it loads mailboxes from disk metadata into
+      // state.mailboxes). Uses waitForInit rather than ensureProvider: ensureProvider
+      // throws when zero mailboxes are connected, which is exactly the misconfigured
+      // case an agent would call this tool to diagnose. waitForInit settles init
+      // (populating both connected and error mailboxes) and never throws.
+      run: async () => {
+        await waitForInit(state);
+        return {
+          mailboxes: getKnownMailboxes(state).map(mailbox => ({
+            name: mailbox.emailAddress ?? mailbox.displayName,
+            provider: mailbox.providerType,
+            isDefault: mailbox.isDefault,
+            status: mailbox.status,
+            ...(mailbox.status === 'error' && mailbox.error ? { error: mailbox.error } : {}),
+          })),
+        };
+      },
+    },
     wrapAction(sendEmailAction),
     wrapAction(replyToEmailAction),
     wrapAction(createDraftAction),

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -971,12 +971,16 @@ export async function buildLazyActions(
     {
       name: 'list_mailboxes',
       description:
-        'List every configured mailbox with its connection status and which one is the default. Use this to discover available mailbox names to pass as the `mailbox` argument to other tools. Reports mailboxes that failed to authenticate too, so it stays useful for diagnosing a broken setup.',
+        'List every configured mailbox: its logical `name` (pass this as the `mailbox` argument to other tools), its `emailAddress`, provider, connection status, and which one is the default. Reports mailboxes that failed to authenticate too, so it stays useful for diagnosing a broken setup.',
       input: z.object({}),
+      // Shape matches the canonical mailbox-config/List Mailboxes requirement:
+      // logical `name` and a SEPARATE `emailAddress` (nullable — legacy mailbox
+      // metadata may lack an address; never fabricate one from the name).
       output: z.object({
         mailboxes: z.array(
           z.object({
             name: z.string(),
+            emailAddress: z.string().nullable(),
             provider: z.string(),
             isDefault: z.boolean(),
             status: z.enum(['connected', 'error']),
@@ -990,13 +994,17 @@ export async function buildLazyActions(
       // never populated by this server (it loads mailboxes from disk metadata into
       // state.mailboxes). Uses waitForInit rather than ensureProvider: ensureProvider
       // throws when zero mailboxes are connected, which is exactly the misconfigured
-      // case an agent would call this tool to diagnose. waitForInit settles init
-      // (populating both connected and error mailboxes) and never throws.
+      // case an agent would call this tool to diagnose. waitForInit resolves once
+      // init settles (populating both connected and error mailboxes) without
+      // throwing on an all-failed state — it is provider-optional, not a latency
+      // guarantee (a never-settling auth promise would still block, as it does for
+      // every other tool that awaits init).
       run: async () => {
         await waitForInit(state);
         return {
           mailboxes: getKnownMailboxes(state).map(mailbox => ({
-            name: mailbox.emailAddress ?? mailbox.displayName,
+            name: mailbox.name,
+            emailAddress: mailbox.emailAddress ?? null,
             provider: mailbox.providerType,
             isDefault: mailbox.isDefault,
             status: mailbox.status,


### PR DESCRIPTION
Closes #93.

## What & why

`list_mailboxes` was specified (`mailbox-config/List Mailboxes`) and implemented as a core action, but **never reachable from the MCP tool surface** — an agent inspecting the schema had no way to discover mailbox enumeration.

**The naive fix ships an always-empty tool.** The core `listMailboxesAction` reads a module-private `mailboxStore` (`configure.ts:20`) that only `configureMailboxAction` writes to — and the shipped stdio server never calls `configure_mailbox`. It loads mailboxes from disk metadata into `state.mailboxes` (`LazyMailboxState[]`). Wrapping the action would return `{mailboxes: []}` at runtime. ([Full finding on #93](https://github.com/UseJunior/email-agent-mcp/issues/93#issuecomment-5053351511).)

## Approach — a bespoke tool modeled on `get_mailbox_status`

Reads `state.mailboxes` directly. Two deliberate choices, both load-bearing:

1. **`waitForInit`, not `ensureProvider`.** `ensureProvider` throws when zero mailboxes are connected — exactly the misconfigured case an agent calls `list_mailboxes` to diagnose. `waitForInit` settles init (populating connected **and** error mailboxes) and never throws on all-failed. (It is provider-optional, *not* a latency guarantee — it awaits `initPromise` like any init-dependent tool.)
2. **`getKnownMailboxes` (all), not `getConnectedMailboxes` (connected-only).** A failed mailbox must be *visible* with its error, or the tool is useless precisely when it's needed. Mutation-tested: swapping to `getConnectedMailboxes` breaks the error-surfacing and all-failed tests.

## Output conforms to the canonical shape

`{ name, emailAddress, provider, isDefault, status: 'connected'|'error', error? }` — `name` is the logical config name, `emailAddress` a **distinct nullable** field (legacy metadata without an address reports `null`, never a fabricated one). Live output:

```json
{ "mailboxes": [ { "name": "work", "emailAddress": "test-user@example.com", "provider": "microsoft", "isDefault": true, "status": "connected" } ] }
```

## Verification

| check | result |
|---|---|
| build | ✅ |
| tests | **887 passed** (+6 new) |
| lint | ✅ |
| `check:spec-coverage` | **249/249** |
| live MCP handshake | 24 tools, `list_mailboxes` present, canonical output shape |
| mutation (`getKnownMailboxes`→`getConnectedMailboxes`) | 2 tests fail ✅ |

Tool count 23 → 24 (README + `buildLazyActions` assertion). A spec-traceable `describe('mailbox-config/List Mailboxes')` test drives the **shipped** path (`buildLazyActions → executeTool`) and asserts the exact canonical shape — so coverage credit reflects real shipped behavior, not the dead core action.

**No OpenSpec proposal** — restoring an existing specified capability.

## Peer review

Codex CLI (`--sandbox workspace-write`, dynamic). Verdict: no blockers, **one MAJOR** (output collapsed `name`/`emailAddress`, violating the canonical contract) + 2 NITs — **all addressed** in `c7c598a`, a 1:1 application of Codex's copy-ready prompt. It independently reproduced the mutation test, confirmed the tool count against an isolated `origin/main` archive (23) vs HEAD (24), and probed the live handshake.

## Follow-up (not this PR)

The core `listMailboxesAction` + `mailboxStore` are dead code (unwired, and the action omits `emailAddress`, so it's also non-conforming). Left untouched per scope; worth a separate removal/reconciliation.

> Provider-touching only at the enumeration layer (no network calls beyond init) — post-merge smoke will drive it against the live mailbox.