### PR TITLE
feat(email): authored-only preview for Microsoft reply drafts (closes #124)

### DIFF
--- a/openspec/changes/update-reply-draft-preview-quoted-history/tasks.md
+++ b/openspec/changes/update-reply-draft-preview-quoted-history/tasks.md
@@ -1,33 +1,33 @@
 ### Phase 1 — verify Graph `uniqueBody` (hard gate: no Phase 2 code before this is done)
 
-- [ ] Against a real Outlook mailbox, create both a `createReply` and a `createReplyAll` draft and record whether `uniqueBody` is populated while `isDraft: true`
-- [ ] Verify `uniqueBody.content` contains the persisted authored HTML including the `force_black` wrapper, and excludes the assembled thread history
-- [ ] Verify `uniqueBody` updates correctly after PATCHing the reply draft via `update_draft`
-- [ ] Write the findings up on issue #87. If `uniqueBody` fails verification, decide between provider-side structural extraction and deferring this change entirely — do not proceed on an assumption
+- [x] Against a real Outlook mailbox, create both a `createReply` and a `createReplyAll` draft and record whether `uniqueBody` is populated while `isDraft: true`
+- [x] Verify `uniqueBody.content` contains the persisted authored HTML including the `force_black` wrapper, and excludes the assembled thread history
+- [x] Verify `uniqueBody` updates correctly after PATCHing the reply draft via `update_draft`
+- [x] Write the findings up on issue #87. If `uniqueBody` fails verification, decide between provider-side structural extraction and deferring this change entirely — do not proceed on an assumption
 
 ### Phase 2 — provider-neutral plumbing
 
-- [ ] Add `authoredBodyHtml?: string` to `EmailMessage` in `packages/email-core/src/types.ts`
-- [ ] Map Graph's `uniqueBody` `{contentType, content}` shape onto `authoredBodyHtml` in the **generic** `GraphEmailProvider.getMessage()` (`email-graph-provider.ts:332`). There is no dedicated draft read-back path — `buildDraftPreview` calls `EmailReader.getMessage`, so `$select` must be widened there. Accept the consequence explicitly: every Graph message read gains the optional field
-- [ ] Add a negative control to the Phase 1 verification: confirm that for a **fresh** (non-reply) Graph draft, `uniqueBody` equals the full body — or that the mapping leaves `authoredBodyHtml` unset — so `update_draft` can never misclassify a fresh draft as authored-only
-- [ ] Implement the provider-side structural fallback behind an unambiguous reply boundary, leaving `authoredBodyHtml` undefined when none is found. Keep it in `provider-microsoft` — `email-core` must not gain a dependency on it
-- [ ] Add `quotedHistoryOmitted: z.boolean().optional()` to `DraftPreviewSchema` in `packages/email-core/src/actions/compose-helpers.ts`
-- [ ] Teach `buildDraftPreview` to accept an explicit authored-only request and use `authoredBodyHtml` only when it is present AND differs from the persisted `bodyHtml`; set `quotedHistoryOmitted` only in that case
+- [x] Add `authoredBodyHtml?: string` to `EmailMessage` in `packages/email-core/src/types.ts`
+- [x] Map Graph's `uniqueBody` `{contentType, content}` shape onto `authoredBodyHtml` in the **generic** `GraphEmailProvider.getMessage()` (`email-graph-provider.ts:332`). There is no dedicated draft read-back path — `buildDraftPreview` calls `EmailReader.getMessage`, so `$select` must be widened there. Accept the consequence explicitly: every Graph message read gains the optional field
+- [x] Add a negative control to the Phase 1 verification: confirm that for a **fresh** (non-reply) Graph draft, `uniqueBody` equals the full body — or that the mapping leaves `authoredBodyHtml` unset — so `update_draft` can never misclassify a fresh draft as authored-only
+- [x] Implement the provider-side structural fallback behind an unambiguous reply boundary, leaving `authoredBodyHtml` undefined when none is found. Keep it in `provider-microsoft` — `email-core` must not gain a dependency on it
+- [x] Add `quotedHistoryOmitted: z.boolean().optional()` to `DraftPreviewSchema` in `packages/email-core/src/actions/compose-helpers.ts`
+- [x] Teach `buildDraftPreview` to accept an explicit authored-only request and use `authoredBodyHtml` only when it is present AND differs from the persisted `bodyHtml`; set `quotedHistoryOmitted` only in that case
 
 ### Phase 3 — action surfaces
 
-- [ ] Add `include_quoted: z.boolean().optional().default(false)` to `create_draft`, `update_draft`, and `reply_to_email`, with a `.describe()` stating it affects only the preview, never the stored or sent body
-- [ ] Pass the flag explicitly to `buildDraftPreview` from `create_draft`, `update_draft`, and **only the draft branch** of `reply_to_email`
-- [ ] Leave `send_email(draft: true)` unchanged — verify it still receives the full persisted preview
-- [ ] Verify the 32 KiB `PREVIEW_BODY_LIMIT` cap and `bodyHtmlTruncated` still apply to whichever body is returned
+- [x] Add `include_quoted: z.boolean().optional().default(false)` to `create_draft`, `update_draft`, and `reply_to_email`, with a `.describe()` stating it affects only the preview, never the stored or sent body
+- [x] Pass the flag explicitly to `buildDraftPreview` from `create_draft`, `update_draft`, and **only the draft branch** of `reply_to_email`
+- [x] Leave `send_email(draft: true)` unchanged — verify it still receives the full persisted preview
+- [x] Verify the 32 KiB `PREVIEW_BODY_LIMIT` cap and `bodyHtmlTruncated` still apply to whichever body is returned
 
 ### Phase 4 — tests and gate
 
-- [ ] Add tests under `describe('email-write/Authored-Only Reply Draft Preview')` covering: authored and full HTML differing, being equal (flag must stay unset), the provider signal absent (fail open), `include_quoted: true`, no provider write during preview construction, and Gmail/fresh drafts unaffected
-- [ ] Every `create_draft` test call MUST supply `to` and `subject` — `validateRequiredFields` runs at `draft.ts:88`, before the `replyTo` branch, so a `{reply_to, body}`-only call returns `MISSING_FIELD` and never reaches the provider
-- [ ] Assert semantically, not just by scenario name: the coverage checker does not bind an `it()` to its enclosing `describe()`
-- [ ] Live smoke against a real Outlook reply draft — mocks cannot catch Graph read-back behavior
-- [ ] Confirm the MODIFIED `Draft Workflow` block still matches the post-`add-create-draft-reply-all` baseline; rebase the delta if #58 archived with different wording
-- [ ] Run `openspec validate update-reply-draft-preview-quoted-history --strict`
-- [ ] Run `npm run test:run --workspaces`, `npm run lint --workspaces`, and `npm run check:spec-coverage`
-- [ ] Draft the release note for the `preview.bodyHtml` default change
+- [x] Add tests under `describe('email-write/Authored-Only Reply Draft Preview')` covering: authored and full HTML differing, being equal (flag must stay unset), the provider signal absent (fail open), `include_quoted: true`, no provider write during preview construction, and Gmail/fresh drafts unaffected
+- [x] Every `create_draft` test call MUST supply `to` and `subject` — `validateRequiredFields` runs at `draft.ts:88`, before the `replyTo` branch, so a `{reply_to, body}`-only call returns `MISSING_FIELD` and never reaches the provider
+- [x] Assert semantically, not just by scenario name: the coverage checker does not bind an `it()` to its enclosing `describe()`
+- [x] Live smoke against a real Outlook reply draft — mocks cannot catch Graph read-back behavior
+- [x] Confirm the MODIFIED `Draft Workflow` block still matches the post-`add-create-draft-reply-all` baseline; rebase the delta if #58 archived with different wording
+- [x] Run `openspec validate update-reply-draft-preview-quoted-history --strict`
+- [x] Run `npm run test:run --workspaces`, `npm run lint --workspaces`, and `npm run check:spec-coverage`
+- [x] Draft the release note for the `preview.bodyHtml` default change

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -325,6 +325,8 @@ export const DraftPreviewSchema = z.object({
     .describe('True if preview.body was truncated to fit the MCP response budget. The persisted draft body is unchanged.'),
   bodyHtmlTruncated: z.boolean().optional()
     .describe('True if preview.bodyHtml was truncated to fit the MCP response budget. The persisted draft body is unchanged.'),
+  quotedHistoryOmitted: z.boolean().optional()
+    .describe('True only when preview.bodyHtml omits provider-assembled quoted history. The persisted draft body is unchanged.'),
 });
 
 export const PreviewErrorSchema = z.object({
@@ -390,7 +392,7 @@ function toPreviewError(err: unknown): PreviewError {
 export async function buildDraftPreview(
   provider: Pick<EmailReader, 'getMessage'>,
   draftId: string,
-  opts?: { retryDelayMs?: number },
+  opts?: { retryDelayMs?: number; authoredOnly?: boolean },
 ): Promise<BuildDraftPreviewResult> {
   const retryDelay = opts?.retryDelayMs ?? PREVIEW_RETRY_DELAY_MS;
 
@@ -423,10 +425,17 @@ export async function buildDraftPreview(
     preview.body = text;
     if (truncated) preview.bodyTruncated = true;
   }
-  if (persisted.bodyHtml !== undefined) {
-    const { text, truncated } = truncateForPreview(persisted.bodyHtml, PREVIEW_BODY_LIMIT);
+  const useAuthoredBody = opts?.authoredOnly === true
+    && persisted.authoredBodyHtml !== undefined
+    && persisted.authoredBodyHtml !== persisted.bodyHtml;
+  const previewBodyHtml = useAuthoredBody
+    ? persisted.authoredBodyHtml
+    : persisted.bodyHtml;
+  if (previewBodyHtml !== undefined) {
+    const { text, truncated } = truncateForPreview(previewBodyHtml, PREVIEW_BODY_LIMIT);
     preview.bodyHtml = text;
     if (truncated) preview.bodyHtmlTruncated = true;
+    if (useAuthoredBody) preview.quotedHistoryOmitted = true;
   }
   return { preview };
 }

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -6,6 +6,7 @@ import { MockEmailProvider } from '../testing/mock-provider.js';
 import { createDraftAction, sendDraftAction, updateDraftAction } from './draft.js';
 import { sendEmailAction } from './send.js';
 import { replyToEmailAction } from './reply.js';
+import { buildDraftPreview, PREVIEW_BODY_LIMIT } from './compose-helpers.js';
 import { ProviderError } from '../providers/provider.js';
 import type { ActionContext } from './registry.js';
 import type { EmailMessage } from '../types.js';
@@ -460,6 +461,204 @@ function persistedDraft(overrides: Partial<EmailMessage>): EmailMessage {
     ...overrides,
   };
 }
+
+describe('email-write/Authored-Only Reply Draft Preview', () => {
+  const fullReplyHtml = '<html><body><div>Persisted authored reply</div><hr><div id="divRplyFwdMsg">Quoted thread</div></body></html>';
+  const authoredReplyHtml = '<div style="color:black;">Persisted authored reply</div>';
+
+  beforeEach(() => {
+    provider.addMessage({
+      id: 'msg123',
+      subject: 'Topic',
+      from: { email: 'sender@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2026-07-23T12:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+  });
+
+  it('Scenario: Microsoft reply draft preview omits quoted history by default', async () => {
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Re: Topic',
+      to: [{ email: 'sender@allowed.com' }],
+      bodyHtml: fullReplyHtml,
+      authoredBodyHtml: authoredReplyHtml,
+    }));
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'msg123',
+      to: 'sender@allowed.com',
+      subject: 'Re: Topic',
+      body: 'Quick note.',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.preview!.bodyHtml).toBe(authoredReplyHtml);
+    expect(result.preview!.bodyHtml).not.toContain('Quoted thread');
+    expect(result.preview!.quotedHistoryOmitted).toBe(true);
+  });
+
+  it('Scenario: include_quoted returns the full persisted preview', async () => {
+    const hugeQuotedBody = authoredReplyHtml
+      + '<div id="divRplyFwdMsg">'
+      + 'q'.repeat(PREVIEW_BODY_LIMIT * 2)
+      + '</div>';
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Re: Topic',
+      to: [{ email: 'sender@allowed.com' }],
+      bodyHtml: hugeQuotedBody,
+      authoredBodyHtml: authoredReplyHtml,
+    }));
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'msg123',
+      to: 'sender@allowed.com',
+      subject: 'Re: Topic',
+      body: 'Quick note.',
+      include_quoted: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.preview!.bodyHtml).toContain('divRplyFwdMsg');
+    expect(Buffer.byteLength(result.preview!.bodyHtml!, 'utf-8')).toBe(PREVIEW_BODY_LIMIT);
+    expect(result.preview!.bodyHtmlTruncated).toBe(true);
+    expect(result.preview!.quotedHistoryOmitted).toBeUndefined();
+  });
+
+  it('Scenario: equal authored and persisted bodies do not claim quoted history was omitted', async () => {
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Re: Topic',
+      to: [{ email: 'sender@allowed.com' }],
+      bodyHtml: authoredReplyHtml,
+      authoredBodyHtml: authoredReplyHtml,
+    }));
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'msg123',
+      to: 'sender@allowed.com',
+      subject: 'Re: Topic',
+      body: 'Quick note.',
+    });
+
+    expect(result.preview!.bodyHtml).toBe(authoredReplyHtml);
+    expect(result.preview!.quotedHistoryOmitted).toBeUndefined();
+  });
+
+  it('Scenario: Ambiguous body anatomy fails open to the full preview', async () => {
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Re: Topic',
+      to: [{ email: 'sender@allowed.com' }],
+      bodyHtml: fullReplyHtml,
+      authoredBodyHtml: undefined,
+    }));
+
+    const result = await createDraftAction.run(ctx, {
+      reply_to: 'msg123',
+      to: 'sender@allowed.com',
+      subject: 'Re: Topic',
+      body: 'Quick note.',
+    });
+
+    expect(result.preview!.bodyHtml).toBe(fullReplyHtml);
+    expect(result.preview!.bodyHtml).toContain('Quoted thread');
+    expect(result.preview!.quotedHistoryOmitted).toBeUndefined();
+  });
+
+  it('Scenario: Preview omission does not mutate the persisted draft', async () => {
+    const getMessage = vi.fn().mockResolvedValue(persistedDraft({
+      bodyHtml: fullReplyHtml,
+      authoredBodyHtml: authoredReplyHtml,
+    }));
+    const providerWrite = vi.fn();
+
+    const result = await buildDraftPreview(
+      { getMessage, updateDraft: providerWrite } as Pick<typeof provider, 'getMessage'>,
+      'draft-1',
+      { authoredOnly: true, retryDelayMs: 0 },
+    );
+
+    expect(result.preview!.bodyHtml).toBe(authoredReplyHtml);
+    expect(result.preview!.quotedHistoryOmitted).toBe(true);
+    await expect(getMessage.mock.results[0]!.value).resolves.toMatchObject({
+      bodyHtml: fullReplyHtml,
+    });
+    expect(providerWrite).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: Gmail and fresh drafts are unaffected', async () => {
+    const freshHtml = '<html><body><p>Fresh draft</p><hr><p>Authored horizontal rule tail</p></body></html>';
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Fresh',
+      to: [{ email: 'alice@allowed.com' }],
+      bodyHtml: freshHtml,
+    }));
+    ctx.allMailboxes = [{
+      name: 'gmail',
+      emailAddress: 'me@gmail.com',
+      provider,
+      providerType: 'gmail',
+      isDefault: true,
+      status: 'connected',
+    }];
+    ctx.mailboxName = 'gmail';
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Fresh',
+      body: 'Fresh draft',
+      mailbox: 'gmail',
+    });
+
+    expect(result.preview!.bodyHtml).toBe(freshHtml);
+    expect(result.preview!.bodyHtml).toContain('Authored horizontal rule tail');
+    expect(result.preview!.quotedHistoryOmitted).toBeUndefined();
+  });
+
+  it('update_draft requests authored-only preview without changing the persisted body', async () => {
+    const created = await provider.createDraft({
+      to: [{ email: 'sender@allowed.com' }],
+      subject: 'Re: Topic',
+      body: 'Old reply',
+    });
+    const updateSpy = vi.spyOn(provider, 'updateDraft');
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      id: created.draftId!,
+      subject: 'Re: Topic',
+      to: [{ email: 'sender@allowed.com' }],
+      bodyHtml: fullReplyHtml,
+      authoredBodyHtml: authoredReplyHtml,
+    }));
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      body: 'Updated reply',
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(result.preview!.bodyHtml).toBe(authoredReplyHtml);
+    expect(result.preview!.quotedHistoryOmitted).toBe(true);
+  });
+
+  it('send_email draft mode retains the full persisted preview', async () => {
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Fresh send draft',
+      to: [{ email: 'alice@allowed.com' }],
+      bodyHtml: fullReplyHtml,
+      authoredBodyHtml: authoredReplyHtml,
+    }));
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Fresh send draft',
+      body: 'Body',
+      draft: true,
+    });
+
+    expect(result.preview!.bodyHtml).toBe(fullReplyHtml);
+    expect(result.preview!.quotedHistoryOmitted).toBeUndefined();
+  });
+});
 
 describe('email-write/Draft Preview (issue #75)', () => {
   it('Scenario: Draft-creating tools return a persisted preview', async () => {

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -45,6 +45,8 @@ const CreateDraftInput = z.object({
   body: z.string().optional(),
   body_file: z.string().optional(),
   reply_to: z.string().optional(),
+  include_quoted: z.boolean().optional().default(false)
+    .describe('Include provider-assembled quoted history in preview.bodyHtml. This affects only the preview, never the stored or sent body.'),
   mailbox: z.string().optional(),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
@@ -136,7 +138,9 @@ export const createDraftAction: EmailAction<
           attachments: attachments.length > 0 ? attachments : undefined,
         });
         const previewResult = result.success && result.draftId
-          ? await buildDraftPreview(ctx.provider, result.draftId)
+          ? await buildDraftPreview(ctx.provider, result.draftId, {
+            authoredOnly: !input.include_quoted,
+          })
           : {};
         return {
           success: result.success,
@@ -160,7 +164,9 @@ export const createDraftAction: EmailAction<
         attachments: attachments.length > 0 ? attachments : undefined,
       });
       const previewResult = result.success && result.draftId
-        ? await buildDraftPreview(ctx.provider, result.draftId)
+        ? await buildDraftPreview(ctx.provider, result.draftId, {
+          authoredOnly: !input.include_quoted,
+        })
         : {};
       return {
         success: result.success,
@@ -283,6 +289,8 @@ const UpdateDraftInput = z.object({
   subject: z.string().optional(),
   body: z.string().optional(),
   body_file: z.string().optional(),
+  include_quoted: z.boolean().optional().default(false)
+    .describe('Include provider-assembled quoted history in preview.bodyHtml. This affects only the preview, never the stored or sent body.'),
   mailbox: z.string().optional(),
   format: z.enum(['markdown', 'html', 'text']).optional()
     .describe("Body format. 'markdown' (default) renders via GFM with line-break preservation; 'html' is passthrough; 'text' sends as plain text."),
@@ -382,7 +390,9 @@ export const updateDraftAction: EmailAction<
       // Acceptable for v1 — see buildDraftPreview docs for the optimization
       // path (provider returning the persisted draft directly).
       const previewResult = result.success && result.draftId
-        ? await buildDraftPreview(ctx.provider, result.draftId)
+        ? await buildDraftPreview(ctx.provider, result.draftId, {
+          authoredOnly: !input.include_quoted,
+        })
         : {};
       return {
         success: result.success,

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -463,6 +463,50 @@ describe('email-write/Reply Draft Preview (issue #75)', () => {
     ]);
   });
 
+  it('reply_to_email draft defaults to an authored-only persisted preview', async () => {
+    const fullHtml = '<div>Authored reply</div><div id="divRplyFwdMsg">Quoted thread</div>';
+    const authoredHtml = '<div style="color:black;">Authored reply</div>';
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Re: Hello',
+      to: [{ email: 'partner@lawfirm.com' }],
+      bodyHtml: fullHtml,
+      authoredBodyHtml: authoredHtml,
+    }));
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Authored reply',
+      draft: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.preview!.bodyHtml).toBe(authoredHtml);
+    expect(result.preview!.bodyHtml).not.toContain('Quoted thread');
+    expect(result.preview!.quotedHistoryOmitted).toBe(true);
+  });
+
+  it('reply_to_email draft include_quoted returns the full persisted preview', async () => {
+    const fullHtml = '<div>Authored reply</div><div id="divRplyFwdMsg">Quoted thread</div>';
+    vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({
+      subject: 'Re: Hello',
+      to: [{ email: 'partner@lawfirm.com' }],
+      bodyHtml: fullHtml,
+      authoredBodyHtml: '<div style="color:#000000;">Authored reply</div>',
+    }));
+
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Authored reply',
+      draft: true,
+      include_quoted: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.preview!.bodyHtml).toBe(fullHtml);
+    expect(result.preview!.bodyHtml).toContain('Quoted thread');
+    expect(result.preview!.quotedHistoryOmitted).toBeUndefined();
+  });
+
   it('reply_to_email draft persistent read-back failure: previewError surfaces, success unchanged', async () => {
     vi.spyOn(provider, 'getMessage').mockRejectedValue(new Error('read-back persistent'));
 

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -24,6 +24,8 @@ const ReplyToEmailInput = z.object({
   mailbox: z.string().optional(),
   cc: z.array(z.string()).optional(),
   draft: z.boolean().optional(),
+  include_quoted: z.boolean().optional().default(false)
+    .describe('Include provider-assembled quoted history in preview.bodyHtml for draft replies. This affects only the preview, never the stored or sent body.'),
   reply_all: z.boolean().optional().default(true)
     .describe('When false, reply only to the original sender. Default true preserves reply-all behavior (cc the original thread).'),
   format: z.enum(['markdown', 'html', 'text']).optional()
@@ -176,7 +178,9 @@ export const replyToEmailAction: EmailAction<
           attachments,
         });
         const previewResult = draftResult.success && draftResult.draftId
-          ? await buildDraftPreview(ctx.provider, draftResult.draftId)
+          ? await buildDraftPreview(ctx.provider, draftResult.draftId, {
+            authoredOnly: !input.include_quoted,
+          })
           : {};
         return {
           success: draftResult.success,

--- a/packages/email-core/src/types.ts
+++ b/packages/email-core/src/types.ts
@@ -26,6 +26,12 @@ export interface EmailMessage {
   hasAttachments: boolean;
   body?: string;
   bodyHtml?: string;
+  /**
+   * Provider-identified authored region of an HTML reply body, excluding the
+   * provider-assembled quoted thread. Providers leave this unset unless they
+   * can identify the reply boundary unambiguously.
+   */
+  authoredBodyHtml?: string;
   snippet?: string;
   folder?: string;
   labels?: string[];

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -36,6 +36,24 @@ const ALLOWED_ATTACHMENT_CASTS = new Set([
   'microsoft.graph.fileAttachment/contentId',
   'microsoft.graph.fileAttachment/contentBytes',
 ]);
+const MESSAGE_SELECT = [
+  'id',
+  'subject',
+  'from',
+  'toRecipients',
+  'ccRecipients',
+  'bccRecipients',
+  'receivedDateTime',
+  'isRead',
+  'hasAttachments',
+  'body',
+  'categories',
+  'conversationId',
+  'flag',
+  'internetMessageId',
+  'internetMessageHeaders',
+  'uniqueBody',
+].join(',');
 
 function assertAttachmentSelectValid(select: string): void {
   for (const raw of select.split(',')) {
@@ -165,7 +183,7 @@ describe('provider-microsoft/Message Mapping', () => {
       },
     ]);
     expect(client.get).toHaveBeenCalledWith(
-      '/me/messages/msg-attachments?$expand=attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)',
+      `/me/messages/msg-attachments?$select=${MESSAGE_SELECT}&$expand=attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)`,
     );
   });
 
@@ -224,9 +242,12 @@ describe('provider-microsoft/Message Mapping', () => {
     ]);
     expect(client.get).toHaveBeenNthCalledWith(
       1,
-      '/me/messages/msg-attachments?$expand=attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)',
+      `/me/messages/msg-attachments?$select=${MESSAGE_SELECT}&$expand=attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)`,
     );
-    expect(client.get).toHaveBeenNthCalledWith(2, '/me/messages/msg-attachments');
+    expect(client.get).toHaveBeenNthCalledWith(
+      2,
+      `/me/messages/msg-attachments?$select=${MESSAGE_SELECT}`,
+    );
     expect(client.get).toHaveBeenNthCalledWith(
       3,
       '/me/messages/msg-attachments/attachments?$select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId',
@@ -277,6 +298,64 @@ describe('provider-microsoft/Message Mapping', () => {
 
     expect(msg.cc).toEqual([]);
     expect(msg.bcc).toEqual([]);
+  });
+
+  it('Scenario: getMessage maps uniqueBody for an unambiguous Graph reply draft', async () => {
+    const authored = '<html><body><div style="color:black;"><p>Authored reply</p><hr><p>Tail</p></div></body></html>';
+    const bodyOpen = QUOTED_REPLY_BODY.match(/<body[^>]*>/i)!;
+    const insertAt = bodyOpen.index! + bodyOpen[0].length;
+    const fullBody = QUOTED_REPLY_BODY.slice(0, insertAt)
+      + '<div style="color:#000000;"><p>Authored reply</p><hr><p>Tail</p></div>'
+      + QUOTED_REPLY_BODY.slice(insertAt);
+    const client = createSchemaValidatingClient([{
+      ...quotedReplyResponse(),
+      body: { contentType: 'html', content: fullBody },
+      uniqueBody: { contentType: 'html', content: authored },
+    }]);
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('draft-123');
+
+    expect(msg.bodyHtml).toBe(fullBody);
+    expect(msg.authoredBodyHtml).toBe(authored);
+    expect(msg.authoredBodyHtml).toContain('color:black');
+    expect(msg.authoredBodyHtml).not.toContain('divRplyFwdMsg');
+  });
+
+  it('Scenario: getMessage structurally extracts only the authored region when uniqueBody is absent', async () => {
+    const authored = '<div><p>Authored start</p><hr><p>Authored after horizontal rule</p></div>';
+    const bodyOpen = QUOTED_REPLY_BODY.match(/<body[^>]*>/i)!;
+    const insertAt = bodyOpen.index! + bodyOpen[0].length;
+    const fullBody = QUOTED_REPLY_BODY.slice(0, insertAt)
+      + authored
+      + QUOTED_REPLY_BODY.slice(insertAt);
+    const client = createSchemaValidatingClient([{
+      ...quotedReplyResponse(),
+      body: { contentType: 'html', content: fullBody },
+    }]);
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('draft-123');
+
+    expect(msg.authoredBodyHtml).toBe(authored);
+    expect(msg.authoredBodyHtml).toContain('Authored after horizontal rule');
+    expect(msg.authoredBodyHtml).not.toContain('divRplyFwdMsg');
+    expect(msg.bodyHtml).toContain('Original message content');
+  });
+
+  it('Scenario: getMessage leaves authoredBodyHtml unset for fresh or ambiguous drafts', async () => {
+    const freshBody = '<html><body><div>Fresh draft</div><hr><div>Authored horizontal rule tail</div></body></html>';
+    const client = createSchemaValidatingClient([{
+      id: 'fresh-draft',
+      body: { contentType: 'html', content: freshBody },
+      uniqueBody: { contentType: 'html', content: '<div>Fresh draft</div>' },
+    }]);
+    const provider = new GraphEmailProvider(client);
+
+    const msg = await provider.getMessage('fresh-draft');
+
+    expect(msg.bodyHtml).toBe(freshBody);
+    expect(msg.authoredBodyHtml).toBeUndefined();
   });
 });
 
@@ -878,6 +957,33 @@ describe('provider-microsoft/update_draft Quote Preservation', () => {
     expect(patchBody.content).toContain('Original message content');
   });
 
+  it('Scenario: update_draft does not mistake an authored horizontal rule for the Graph boundary', async () => {
+    const replyDraftBody = replyDraftWith(
+      '<div>Old authored start<hr><p>Old authored tail</p></div>',
+    );
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'draft-update-authored-hr',
+        body: { contentType: 'html', content: replyDraftBody },
+      }),
+      patch: vi.fn().mockResolvedValueOnce({}),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.updateDraft('draft-update-authored-hr', {
+      bodyHtml: '<div>Replacement authored body<hr><p>Replacement tail</p></div>',
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patchBody = (patchArgs[1] as { body: { content: string } }).body;
+    expect(patchBody.content).toContain('Replacement authored body');
+    expect(patchBody.content).toContain('Replacement tail');
+    expect(patchBody.content).not.toContain('Old authored start');
+    expect(patchBody.content).not.toContain('Old authored tail');
+    expect(patchBody.content).toContain('divRplyFwdMsg');
+    expect(patchBody.content).toContain('Original message content');
+  });
+
   it('Scenario: update_draft on a fresh draft replaces body wholesale', async () => {
     // No <hr> after <body> → no recognizable Graph reply anatomy → fall through to buildGraphBody
     const FRESH_DRAFT_BODY = '<html><body><div>Old fresh content</div></body></html>';
@@ -1165,7 +1271,7 @@ describe('provider-microsoft/Thread Lookup', () => {
     expect(thread.messageCount).toBe(2);
     expect(client.get).toHaveBeenNthCalledWith(
       1,
-      '/me/messages/msg-1?$expand=attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)',
+      `/me/messages/msg-1?$select=${MESSAGE_SELECT}&$expand=attachments($select=id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId)`,
     );
     const url = (client.get as ReturnType<typeof vi.fn>).mock.calls[1]![0] as string;
     const decodedUrl = decodeURIComponent(url).replaceAll('+', ' ');

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -205,6 +205,27 @@ const DELTA_SELECT = '$select=subject,from,toRecipients,ccRecipients,receivedDat
 //   base attachment: https://learn.microsoft.com/en-us/graph/api/resources/attachment?view=graph-rest-1.0
 //   fileAttachment:  https://learn.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-1.0
 const ATTACHMENT_SELECT = 'id,name,contentType,size,isInline,microsoft.graph.fileAttachment/contentId';
+// `uniqueBody` is returned only when explicitly selected. Because adding
+// `$select=uniqueBody` would narrow Graph's response, list every message field
+// consumed by mapGraphMessage and widen the existing getMessage projection.
+const MESSAGE_SELECT = [
+  'id',
+  'subject',
+  'from',
+  'toRecipients',
+  'ccRecipients',
+  'bccRecipients',
+  'receivedDateTime',
+  'isRead',
+  'hasAttachments',
+  'body',
+  'categories',
+  'conversationId',
+  'flag',
+  'internetMessageId',
+  'internetMessageHeaders',
+  'uniqueBody',
+].join(',');
 
 // Graph message and attachment IDs are base64url-flavored and routinely contain
 // `=`, `+`, `/`, `_`, `-`. Path segments must encode `+`, `/`, and `=` or Graph
@@ -344,7 +365,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
 
   async getMessage(id: string): Promise<EmailMessage> {
     const encodedId = encodeGraphPathId(id);
-    const expandedUrl = `${this.basePath}/messages/${encodedId}?$expand=attachments($select=${ATTACHMENT_SELECT})`;
+    const expandedUrl = `${this.basePath}/messages/${encodedId}?$select=${MESSAGE_SELECT}&$expand=attachments($select=${ATTACHMENT_SELECT})`;
 
     try {
       const response = await this.client.get(expandedUrl) as unknown as GraphMessage;
@@ -355,7 +376,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailCatego
       if (!(err instanceof GraphApiError) || err.status !== 400) throw err;
     }
 
-    const message = await this.client.get(`${this.basePath}/messages/${encodedId}`) as unknown as GraphMessage;
+    const message = await this.client.get(
+      `${this.basePath}/messages/${encodedId}?$select=${MESSAGE_SELECT}`,
+    ) as unknown as GraphMessage;
     const attachments = await this.client.get(
       `${this.basePath}/messages/${encodedId}/attachments?$select=${ATTACHMENT_SELECT}`,
     );
@@ -1351,6 +1374,7 @@ interface GraphMessage {
   isRead?: boolean;
   hasAttachments?: boolean;
   body?: { contentType: string; content: string };
+  uniqueBody?: { contentType: string; content: string };
   categories?: string[];
   conversationId?: string;
   flag?: { flagStatus?: string };
@@ -1418,6 +1442,20 @@ function mapGraphMessage(msg: GraphMessage): EmailMessage {
     contentId: attachment.contentId,
   }));
 
+  const bodyHtml = msg.body?.contentType?.toLowerCase() === 'html'
+    ? msg.body.content
+    : undefined;
+  let authoredBodyHtml: string | undefined;
+  if (bodyHtml !== undefined) {
+    const replyRegion = findGraphQuotedReplyRegion(bodyHtml);
+    if (replyRegion) {
+      authoredBodyHtml = msg.uniqueBody?.contentType?.toLowerCase() === 'html'
+        && typeof msg.uniqueBody.content === 'string'
+        ? msg.uniqueBody.content
+        : bodyHtml.slice(replyRegion.bodyOpenEnd, replyRegion.dividerStart);
+    }
+  }
+
   return {
     id: msg.id,
     subject: msg.subject ?? '',
@@ -1445,7 +1483,8 @@ function mapGraphMessage(msg: GraphMessage): EmailMessage {
     isFlagged: msg.flag?.flagStatus === 'flagged',
     hasAttachments: msg.hasAttachments ?? false,
     body: msg.body?.contentType?.toLowerCase() === 'text' ? msg.body.content : undefined,
-    bodyHtml: msg.body?.contentType?.toLowerCase() === 'html' ? msg.body.content : undefined,
+    bodyHtml,
+    authoredBodyHtml,
     attachments,
     labels: msg.categories,
     conversationId: msg.conversationId,
@@ -1632,10 +1671,11 @@ function wrapPlainTextAsHtml(text: string): string {
 /**
  * Locate the splice region in a Graph reply draft body.
  *
- * Returns null when the content is not a recognizable Graph reply (no `<body>` tag,
- * or `<body>` without a following `<hr>` divider). Returns the anchors otherwise:
+ * Returns null unless the content has Graph's unambiguous reply anatomy: a
+ * `<body>`, the `divRplyFwdMsg` boundary, and the `<hr>` divider immediately
+ * before that boundary. Returns the anchors otherwise:
  * - `bodyOpenEnd`: index of the first character after the `<body ...>` opening tag
- * - `dividerStart`: index of the first `<hr ...>` that follows
+ * - `dividerStart`: index of Graph's `<hr ...>` divider
  *
  * Both create-path (`mergeQuotedReplyHtml`, inserts at `bodyOpenEnd`) and update-path
  * (`updateDraft`, replaces `bodyOpenEnd..dividerStart`) share this anatomy parser so
@@ -1647,7 +1687,17 @@ function findGraphQuotedReplyRegion(
   const bodyMatch = content.match(/<body[^>]*>/i);
   if (!bodyMatch || bodyMatch.index === undefined) return null;
   const bodyOpenEnd = bodyMatch.index + bodyMatch[0].length;
-  const dividerMatch = content.slice(bodyOpenEnd).match(/<hr\b[^>]*>/i);
+
+  const boundaryMatch = content.slice(bodyOpenEnd).match(
+    /<div\b[^>]*\bid\s*=\s*(["'])divRplyFwdMsg\1[^>]*>/i,
+  );
+  if (!boundaryMatch || boundaryMatch.index === undefined) return null;
+  const boundaryStart = bodyOpenEnd + boundaryMatch.index;
+
+  // Match the divider adjacent to Graph's boundary, not the first <hr> in the
+  // authored region. Markdown `---` legitimately renders to an authored <hr>.
+  const beforeBoundary = content.slice(bodyOpenEnd, boundaryStart);
+  const dividerMatch = beforeBoundary.match(/<hr\b[^>]*>\s*$/i);
   if (!dividerMatch || dividerMatch.index === undefined) return null;
   return { bodyOpenEnd, dividerStart: bodyOpenEnd + dividerMatch.index };
 }


### PR DESCRIPTION
## Summary

- add provider-neutral `EmailMessage.authoredBodyHtml` and map Microsoft Graph `uniqueBody` only for structurally recognized reply drafts
- default `create_draft`, `update_draft`, and draft-mode `reply_to_email` previews to authored-only HTML, with `include_quoted: true` restoring the full persisted preview
- preserve `send_email(draft: true)`, stored/sent bodies, the 32 KiB preview cap, and fail-open behavior
- harden Graph reply-boundary detection so authored `<hr>` elements are not mistaken for quoted-history dividers

Closes #124. Refs #87.

## Why

Graph reply-draft read-back includes the entire provider-assembled quote chain, which can add thousands of redundant tokens to every draft write response. The persisted read-back remains authoritative; this change only narrows `preview.bodyHtml` when Graph supplies a safe authored region and signals that with `quotedHistoryOmitted: true`.

## Live Graph verification

The prior `createReply` probe had already verified that `uniqueBody` is populated on drafts, contains the persisted `force_black` authored HTML, excludes `divRplyFwdMsg`, refreshes after PATCH, and leaves the stored full body intact.

This implementation run closed the two residual items and posted the evidence to #87:

- `createReplyAll`: `isDraft:true`; authored marker and normalized black wrapper present; authored content after an authored `<hr>` preserved; `divRplyFwdMsg` excluded; 430-character `uniqueBody` versus 46,724-character full body
- fresh non-reply draft: Graph returned different byte shapes for `uniqueBody` (131 chars) and `body` (184 chars), with no reply boundary. The mapper therefore requires the unambiguous `divRplyFwdMsg` boundary and leaves `authoredBodyHtml` unset for fresh drafts
- all four throwaway probe drafts were deleted and none were sent

## Implementation notes / traps handled

- Graph normalizes `color:#000000` to `color:black`; code treats provider HTML opaquely and fixtures cover both forms
- adding a bare `$select=uniqueBody` would narrow the response, so `getMessage()` now explicitly selects every mapped message field plus `uniqueBody` while retaining the attachment expansion and its 400 fallback
- the structural fallback locates the `<hr>` adjacent to `divRplyFwdMsg`, never the first `<hr>` in authored content

## Validation

- `npm run build`
- `npm run test:run --workspaces --if-present` — 901 passed
- `npm run lint --workspaces --if-present`
- CI-equivalent `npx vitest run --coverage ...` — 901 passed
- `npm run check:spec-coverage` — 249/249
- `npx openspec validate update-reply-draft-preview-quoted-history --strict`
- live Outlook action smoke: default preview 327 chars with omission flag; full preview capped at 32 KiB with truncation flag; stored read-back retained 62,698 chars and the quote boundary; both drafts deleted

## Release note

Microsoft reply-draft tools now return only the authored portion of `preview.bodyHtml` by default and set `preview.quotedHistoryOmitted: true` when quoted history was removed. Pass `include_quoted: true` to `create_draft`, `update_draft`, or draft-mode `reply_to_email` to receive the previous full persisted preview. This changes preview output only; stored and sent message bodies are unchanged.