### PR TITLE
Expose thread IDs on list_emails results

### DIFF
--- a/openspec/changes/update-list-emails-thread-ids/tasks.md
+++ b/openspec/changes/update-list-emails-thread-ids/tasks.md
@@ -1,11 +1,11 @@
-- [ ] Rename `SearchEmailThreadFieldsSchema` → `EmailThreadFieldsSchema` and `getSearchEmailThreadFields` → `getEmailThreadFields` in `packages/email-core/src/actions/search.ts`, keeping the old names as deprecated aliases. Put the `@deprecated` JSDoc on the actual exported alias *declarations*, not merely on an entry in the export list, so generated `.d.ts` output and editor tooling surface the warning
-- [ ] Extend `ListEmailsOutput` in `packages/email-core/src/actions/list.ts` with `.extend(EmailThreadFieldsSchema.shape)` on the row object
-- [ ] Spread `getEmailThreadFields(m)` in the single mapping in `packages/email-core/src/actions/list.ts` and the custom resolved-mailbox mapping in `packages/email-mcp/src/server.ts` (~`:777`). There is exactly one mapping on each side — `list_emails` has **no** multi-mailbox fan-out branch (its MCP input is `mailbox?: string`, never `null`); fan-out exists only for `search_emails`
-- [ ] Extend the inline `list_emails` output schema in `packages/email-mcp/src/server.ts` to match
-- [ ] Add core tests in `packages/email-core/src/actions/list.test.ts` under `describe('email-read/List Emails')` covering a Graph row, a Gmail row, and a provider that populates neither
-- [ ] Add MCP tests proving the handle survives calls using the default mailbox and an explicitly requested mailbox; do not claim or test list fan-out
-- [ ] Add a scenario test for the existing `search_emails` behavior under `describe('email-threading/Thread Handles on Message Listings')` — it ships today but was never spec-traced
-- [ ] Assert semantically, not just by name: the coverage checker associates every scenario in a file with every spec id appearing in any `describe()` in that file and does not bind an `it()` to its enclosing describe, so a correctly-named but misplaced test still passes the gate
-- [ ] Confirm no provider call count changes (the mapping reads fields already present on `EmailMessage`)
-- [ ] Run `openspec validate update-list-emails-thread-ids --strict`
-- [ ] Run `npm run test:run --workspaces`, `npm run lint --workspaces`, and `npm run check:spec-coverage`
+- [x] Rename `SearchEmailThreadFieldsSchema` → `EmailThreadFieldsSchema` and `getSearchEmailThreadFields` → `getEmailThreadFields` in `packages/email-core/src/actions/search.ts`, keeping the old names as deprecated aliases. Put the `@deprecated` JSDoc on the actual exported alias *declarations*, not merely on an entry in the export list, so generated `.d.ts` output and editor tooling surface the warning
+- [x] Extend `ListEmailsOutput` in `packages/email-core/src/actions/list.ts` with `.extend(EmailThreadFieldsSchema.shape)` on the row object
+- [x] Spread `getEmailThreadFields(m)` in the single mapping in `packages/email-core/src/actions/list.ts` and the custom resolved-mailbox mapping in `packages/email-mcp/src/server.ts` (~`:777`). There is exactly one mapping on each side — `list_emails` has **no** multi-mailbox fan-out branch (its MCP input is `mailbox?: string`, never `null`); fan-out exists only for `search_emails`
+- [x] Extend the inline `list_emails` output schema in `packages/email-mcp/src/server.ts` to match
+- [x] Add core tests in `packages/email-core/src/actions/list.test.ts` under `describe('email-read/List Emails')` covering a Graph row, a Gmail row, and a provider that populates neither
+- [x] Add MCP tests proving the handle survives calls using the default mailbox and an explicitly requested mailbox; do not claim or test list fan-out
+- [x] Add a scenario test for the existing `search_emails` behavior under `describe('email-threading/Thread Handles on Message Listings')` — it ships today but was never spec-traced
+- [x] Assert semantically, not just by name: the coverage checker associates every scenario in a file with every spec id appearing in any `describe()` in that file and does not bind an `it()` to its enclosing describe, so a correctly-named but misplaced test still passes the gate
+- [x] Confirm no provider call count changes (the mapping reads fields already present on `EmailMessage`)
+- [x] Run `openspec validate update-list-emails-thread-ids --strict`
+- [x] Run `npm run test:run --workspaces`, `npm run lint --workspaces`, and `npm run check:spec-coverage`

--- a/packages/email-core/src/actions/list.test.ts
+++ b/packages/email-core/src/actions/list.test.ts
@@ -55,6 +55,38 @@ describe('email-read/List Emails', () => {
     const result = await listEmailsAction.run(ctx, { folder: 'inbox' });
     expect(result.emails).toHaveLength(25);
   });
+
+  it('Scenario: Listed rows carry the provider conversation handle', async () => {
+    provider.addMessage({
+      id: 'graph-1',
+      subject: 'Graph conversation',
+      folder: 'inbox',
+      conversationId: 'graph-conversation-abc',
+    });
+    provider.addMessage({
+      id: 'gmail-1',
+      subject: 'Gmail thread',
+      folder: 'inbox',
+      threadId: 'gmail-thread-xyz',
+    });
+    provider.addMessage({
+      id: 'plain-1',
+      subject: 'No provider handle',
+      folder: 'inbox',
+    });
+
+    const result = await listEmailsAction.run(ctx, { folder: 'inbox' });
+    const graph = result.emails.find(email => email.id === 'graph-1');
+    const gmail = result.emails.find(email => email.id === 'gmail-1');
+    const plain = result.emails.find(email => email.id === 'plain-1');
+
+    expect(graph).toMatchObject({ conversationId: 'graph-conversation-abc' });
+    expect(graph).not.toHaveProperty('threadId');
+    expect(gmail).toMatchObject({ threadId: 'gmail-thread-xyz' });
+    expect(gmail).not.toHaveProperty('conversationId');
+    expect(plain).not.toHaveProperty('conversationId');
+    expect(plain).not.toHaveProperty('threadId');
+  });
 });
 
 describe('email-read/Folder Routing', () => {

--- a/packages/email-core/src/actions/list.ts
+++ b/packages/email-core/src/actions/list.ts
@@ -1,6 +1,7 @@
 // list_emails action — list recent emails with filtering
 import { z } from 'zod';
 import type { EmailAction } from './registry.js';
+import { EmailThreadFieldsSchema, getEmailThreadFields } from './search.js';
 
 const ListEmailsInput = z.object({
   mailbox: z.string().optional(),
@@ -19,7 +20,7 @@ const ListEmailsOutput = z.object({
     receivedAt: z.string(),
     isRead: z.boolean(),
     hasAttachments: z.boolean(),
-  })),
+  }).extend(EmailThreadFieldsSchema.shape)),
 });
 
 export const listEmailsAction: EmailAction<
@@ -49,6 +50,7 @@ export const listEmailsAction: EmailAction<
         receivedAt: m.receivedAt,
         isRead: m.isRead,
         hasAttachments: m.hasAttachments,
+        ...getEmailThreadFields(m),
       })),
     };
   },

--- a/packages/email-core/src/actions/search.test.ts
+++ b/packages/email-core/src/actions/search.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockEmailProvider } from '../testing/mock-provider.js';
+import { listEmailsAction } from './list.js';
 import { searchEmailsAction } from './search.js';
 import type { ActionContext, MailboxEntry } from './registry.js';
 
@@ -105,5 +106,52 @@ describe('email-read/Search Emails', () => {
     expect(result.emails).toHaveLength(1);
     expect(result.emails[0]?.conversationId).toBe('graph-conversation-abc');
     expect(result.emails[0]?.threadId).toBeUndefined();
+  });
+});
+
+describe('email-threading/Thread Handles on Message Listings', () => {
+  it('Scenario: Search and list rows expose the same handle shape', async () => {
+    const provider = new MockEmailProvider();
+    provider.addMessage({
+      id: 'work-1',
+      subject: 'Contract review needed',
+      from: { email: 'alice@corp.com' },
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: false,
+      hasAttachments: false,
+      conversationId: 'graph-conversation-abc',
+    });
+
+    const searchResult = await searchEmailsAction.run({ provider }, { query: 'contract review' });
+    const listResult = await listEmailsAction.run({ provider }, { folder: 'inbox' });
+
+    expect(searchResult.emails[0]?.conversationId).toBe('graph-conversation-abc');
+    expect(listResult.emails[0]?.conversationId).toBe(searchResult.emails[0]?.conversationId);
+    expect(searchResult.emails[0]).not.toHaveProperty('threadId');
+    expect(listResult.emails[0]).not.toHaveProperty('threadId');
+  });
+
+  it('Scenario: Handle omitted when the provider does not supply one', async () => {
+    const provider = new MockEmailProvider();
+    provider.addMessage({
+      id: 'plain-1',
+      subject: 'Contract review needed',
+      from: { email: 'alice@corp.com' },
+      receivedAt: '2024-03-15T10:00:00Z',
+      isRead: false,
+      hasAttachments: false,
+    });
+    const searchSpy = vi.spyOn(provider, 'searchMessages');
+    const listSpy = vi.spyOn(provider, 'listMessages');
+
+    const searchResult = await searchEmailsAction.run({ provider }, { query: 'contract review' });
+    const listResult = await listEmailsAction.run({ provider }, { folder: 'inbox' });
+
+    expect(searchResult.emails[0]).not.toHaveProperty('conversationId');
+    expect(searchResult.emails[0]).not.toHaveProperty('threadId');
+    expect(listResult.emails[0]).not.toHaveProperty('conversationId');
+    expect(listResult.emails[0]).not.toHaveProperty('threadId');
+    expect(searchSpy).toHaveBeenCalledTimes(1);
+    expect(listSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/email-core/src/actions/search.ts
+++ b/packages/email-core/src/actions/search.ts
@@ -9,19 +9,25 @@ import type { EmailMessage } from '../types.js';
  * populates `conversationId`; Gmail populates `threadId`. Both are optional
  * because providers may legitimately produce neither (e.g. drafts).
  */
-export const SearchEmailThreadFieldsSchema = z.object({
+export const EmailThreadFieldsSchema = z.object({
   conversationId: z.string().optional(),
   threadId: z.string().optional(),
 });
 
-export function getSearchEmailThreadFields(
+export function getEmailThreadFields(
   message: Pick<EmailMessage, 'conversationId' | 'threadId'>,
-): z.infer<typeof SearchEmailThreadFieldsSchema> {
+): z.infer<typeof EmailThreadFieldsSchema> {
   return {
     ...(message.conversationId !== undefined ? { conversationId: message.conversationId } : {}),
     ...(message.threadId !== undefined ? { threadId: message.threadId } : {}),
   };
 }
+
+/** @deprecated Use EmailThreadFieldsSchema. */
+export const SearchEmailThreadFieldsSchema = EmailThreadFieldsSchema;
+
+/** @deprecated Use getEmailThreadFields. */
+export const getSearchEmailThreadFields = getEmailThreadFields;
 
 const SearchEmailsInput = z.object({
   query: z.string(),
@@ -41,7 +47,7 @@ const SearchEmailsOutput = z.object({
     hasAttachments: z.boolean(),
     mailbox: z.string().optional(),
     snippet: z.string().optional(),
-  }).extend(SearchEmailThreadFieldsSchema.shape)),
+  }).extend(EmailThreadFieldsSchema.shape)),
 });
 
 export const searchEmailsAction: EmailAction<
@@ -77,7 +83,7 @@ export const searchEmailsAction: EmailAction<
           hasAttachments: m.hasAttachments,
           mailbox: m.mailbox,
           snippet: m.snippet,
-          ...getSearchEmailThreadFields(m),
+          ...getEmailThreadFields(m),
         })),
       };
     }
@@ -93,7 +99,7 @@ export const searchEmailsAction: EmailAction<
         hasAttachments: m.hasAttachments,
         mailbox: ctx.mailboxName,
         snippet: m.snippet,
-        ...getSearchEmailThreadFields(m),
+        ...getEmailThreadFields(m),
       })),
     };
   },

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -50,6 +50,8 @@ export { htmlToMarkdown, transformEmailContent } from './content/sanitize.js';
 export { readEmailAction } from './actions/read.js';
 export { sendEmailAction } from './actions/send.js';
 export {
+  EmailThreadFieldsSchema,
+  getEmailThreadFields,
   SearchEmailThreadFieldsSchema,
   getSearchEmailThreadFields,
 } from './actions/search.js';

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1047,6 +1047,7 @@ describe('mcp-transport/Lazy Provider State', () => {
         receivedAt: '2026-04-09T11:00:00.000Z',
         isRead: true,
         hasAttachments: true,
+        threadId: 'gmail-thread-xyz',
       },
     ]);
 
@@ -1100,8 +1101,52 @@ describe('mcp-transport/Lazy Provider State', () => {
         receivedAt: '2026-04-09T11:00:00.000Z',
         isRead: true,
         hasAttachments: true,
+        threadId: 'gmail-thread-xyz',
       },
     ]);
+  });
+
+  it('Scenario: custom list_emails preserves the default mailbox conversation handle', async () => {
+    const workList = vi.fn().mockResolvedValue([
+      {
+        id: 'work-1',
+        subject: 'Work result',
+        from: { email: 'boss@example.com' },
+        receivedAt: '2026-04-09T10:00:00.000Z',
+        isRead: false,
+        hasAttachments: false,
+        conversationId: 'graph-conversation-abc',
+      },
+    ]);
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { listMessages: workList } as never;
+    state.connectedMailbox = 'work@example.com';
+    state.connectedProvider = 'microsoft';
+    state.mailboxes = [{
+      name: 'work',
+      emailAddress: 'work@example.com',
+      displayName: 'work@example.com',
+      providerType: 'microsoft',
+      provider: { listMessages: workList } as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const listEmails = actions.find(a => a.name === 'list_emails')!;
+    const result = await listEmails.run({}, { limit: 10 }) as {
+      emails: Array<{ id: string; conversationId?: string; threadId?: string }>;
+    };
+
+    expect(workList).toHaveBeenCalledTimes(1);
+    expect(result.emails[0]).toMatchObject({
+      id: 'work-1',
+      conversationId: 'graph-conversation-abc',
+    });
+    expect(result.emails[0]).not.toHaveProperty('threadId');
   });
 
   // Plain `it` (no `Scenario:` prefix) so this does NOT create a phantom

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -2,8 +2,8 @@
 import { createRequire } from 'node:module';
 import type { DeletePolicy, EmailAction, EmailMessage, EmailProvider } from '@usejunior/email-core';
 import {
-  SearchEmailThreadFieldsSchema,
-  getSearchEmailThreadFields,
+  EmailThreadFieldsSchema,
+  getEmailThreadFields,
 } from '@usejunior/email-core';
 import { z } from 'zod';
 
@@ -760,7 +760,16 @@ export async function buildLazyActions(
       name: 'list_emails',
       description: 'List recent emails with filtering by unread status, folder, sender, and limit. Use offset for pagination.',
       input: z.object({ mailbox: z.string().optional(), unread: z.boolean().optional(), limit: z.number().optional(), offset: z.number().optional(), folder: z.string().optional() }),
-      output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string(), from: z.string(), receivedAt: z.string(), isRead: z.boolean(), hasAttachments: z.boolean() })) }),
+      output: z.object({
+        emails: z.array(z.object({
+          id: z.string(),
+          subject: z.string(),
+          from: z.string(),
+          receivedAt: z.string(),
+          isRead: z.boolean(),
+          hasAttachments: z.boolean(),
+        }).extend(EmailThreadFieldsSchema.shape)),
+      }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
@@ -774,13 +783,14 @@ export async function buildLazyActions(
           folder: inp.folder ?? 'inbox',
         });
         return {
-          emails: (messages as Array<{ id: string; subject: string; from: { email: string; name?: string }; receivedAt: string; isRead: boolean; hasAttachments: boolean }>).map(m => ({
+          emails: (messages as EmailMessage[]).map(m => ({
             id: m.id,
             subject: m.subject,
             from: m.from.name ? `${m.from.name} <${m.from.email}>` : m.from.email,
             receivedAt: m.receivedAt,
             isRead: m.isRead,
             hasAttachments: m.hasAttachments,
+            ...getEmailThreadFields(m),
           })),
         };
       },
@@ -853,7 +863,7 @@ export async function buildLazyActions(
           isRead: z.boolean(),
           hasAttachments: z.boolean(),
           mailbox: z.string().optional(),
-        }).extend(SearchEmailThreadFieldsSchema.shape)),
+        }).extend(EmailThreadFieldsSchema.shape)),
       }),
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
@@ -886,7 +896,7 @@ export async function buildLazyActions(
             isRead: m.isRead,
             hasAttachments: m.hasAttachments,
             mailbox: m.mailbox,
-            ...getSearchEmailThreadFields(m),
+            ...getEmailThreadFields(m),
           })),
         };
       },


### PR DESCRIPTION
Closes #84.

## What changed
- surfaces Microsoft Graph `conversationId` and Gmail `threadId` on `list_emails` rows in both email-core and MCP
- renames the shared thread-field schema/helper while preserving deprecated aliases for compatibility
- adds coverage for Graph, Gmail, omitted handles, default mailbox, explicit mailbox, and unchanged provider call counts
- completes the approved OpenSpec task list

## Compatibility
This is additive at the tool response level: both fields are optional and omitted when the provider does not supply them. Existing consumers that tolerate additive object fields are unaffected. The old exported helper/schema names remain available as deprecated aliases.

## Validation
- `npm run build`
- full workspace suite: 915 tests passed
- `npm run lint --workspaces --if-present`
- `npm run check:spec-coverage` (249/249)
- `openspec validate update-list-emails-thread-ids --strict`
- `git diff --check`