### PR TITLE
Expose strip_signatures on read_email

### DIFF
--- a/openspec/changes/update-read-email-strip-signatures/tasks.md
+++ b/openspec/changes/update-read-email-strip-signatures/tasks.md
@@ -1,9 +1,9 @@
-- [ ] Add `strip_signatures: z.boolean().optional().default(false)` to the inline `read_email` input schema in `packages/email-mcp/src/server.ts`
-- [ ] Forward the caller's value to `readEmailAction.run()` in place of the hardcoded `strip_signatures: false` at `server.ts:832`, and delete the "wiring it through is tracked separately" comment
-- [ ] Update the `read_email` tool description to mention the flag alongside `strip_quoted_history`, and note that it defaults to `false` here while the core action defaults to `true`
-- [ ] Add MCP-level tests in `packages/email-mcp/src/server.test.ts` under `describe('email-read/Optional Signature Stripping on the MCP Read Surface')` covering the flag omitted, `true`, and `true` combined with `strip_quoted_history: true`
-- [ ] For the composition test, build the fixture so the signature sits immediately before the terminal quoted-history block — a signature cannot trail the whole body while the quoted block is still terminal
-- [ ] Confirm the core signature-heuristic paths stay covered: RFC-3676 `-- ` delimiter, "Sent from my iPhone", confidentiality disclaimer
-- [ ] Assert semantically, not just by scenario name: the coverage checker does not bind an `it()` to its enclosing `describe()`, so a correctly-named test in the wrong block still passes the gate
-- [ ] Run `openspec validate update-read-email-strip-signatures --strict`
-- [ ] Run `npm run test:run --workspaces`, `npm run lint --workspaces`, and `npm run check:spec-coverage`
+- [x] Add `strip_signatures: z.boolean().optional().default(false)` to the inline `read_email` input schema in `packages/email-mcp/src/server.ts`
+- [x] Forward the caller's value to `readEmailAction.run()` in place of the hardcoded `strip_signatures: false` at `server.ts:832`, and delete the "wiring it through is tracked separately" comment
+- [x] Update the `read_email` tool description to mention the flag alongside `strip_quoted_history`, and note that it defaults to `false` here while the core action defaults to `true`
+- [x] Add MCP-level tests in `packages/email-mcp/src/server.test.ts` under `describe('email-read/Optional Signature Stripping on the MCP Read Surface')` covering the flag omitted, `true`, and `true` combined with `strip_quoted_history: true`
+- [x] For the composition test, build the fixture so the signature sits immediately before the terminal quoted-history block — a signature cannot trail the whole body while the quoted block is still terminal
+- [x] Confirm the core signature-heuristic paths stay covered: RFC-3676 `-- ` delimiter, "Sent from my iPhone", confidentiality disclaimer
+- [x] Assert semantically, not just by scenario name: the coverage checker does not bind an `it()` to its enclosing `describe()`, so a correctly-named test in the wrong block still passes the gate
+- [x] Run `openspec validate update-read-email-strip-signatures --strict`
+- [x] Run `npm run test:run --workspaces`, `npm run lint --workspaces`, and `npm run check:spec-coverage`

--- a/packages/email-core/src/content/signatures.test.ts
+++ b/packages/email-core/src/content/signatures.test.ts
@@ -11,4 +11,20 @@ describe('content-engine/Signature Stripping', () => {
     expect(result).not.toContain('John Doe');
     expect(result).not.toContain('Senior Partner');
   });
+
+  it('strips a mobile client footer in the latter half of the message', () => {
+    const body = 'The revised agreement looks good to me.\n\nSent from my iPhone';
+
+    expect(stripSignature(body)).toBe('The revised agreement looks good to me.');
+  });
+
+  it('strips a confidentiality disclaimer in the latter half of the message', () => {
+    const body = [
+      'The revised agreement looks good to me.',
+      '',
+      'CONFIDENTIALITY: This email is intended only for the named recipient.',
+    ].join('\n');
+
+    expect(stripSignature(body)).toBe('The revised agreement looks good to me.');
+  });
 });

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -891,10 +891,8 @@ describe('mcp-transport/Lazy Provider State', () => {
     expect(result.body).not.toContain('Want to push standup to 10am?');
   });
 
-  it('Scenario: read_email does NOT strip signatures even with sig delimiter present', async () => {
-    // Wiring strip_signatures through the MCP tool is out of scope for issue #76 and
-    // tracked separately. The MCP adapter must keep the previous behavior of returning
-    // signatures intact regardless of the action default.
+  describe('email-read/Optional Signature Stripping on the MCP Read Surface', () => {
+  it('Scenario: Signatures preserved by default over MCP', async () => {
     const getMessage = vi.fn().mockResolvedValue({
       id: 'msg-sig',
       subject: 'Signed reply',
@@ -930,10 +928,111 @@ describe('mcp-transport/Lazy Provider State', () => {
 
     const actions = await buildLazyActions(state, noAllowlist);
     const readEmail = actions.find(a => a.name === 'read_email')!;
+    const parsed = (readEmail.input as { parse: (v: unknown) => {
+      strip_signatures: boolean;
+    } }).parse({ id: 'msg-sig' });
     const result = await readEmail.run({}, { id: 'msg-sig' }) as { body: string };
 
+    expect(parsed.strip_signatures).toBe(false);
+    expect(readEmail.description).toContain('strip_signatures');
+    expect(readEmail.description).toContain('defaults to false');
     expect(result.body).toContain('Alice Smith');
     expect(result.body).toContain('Senior Partner');
+  });
+
+  it('Scenario: Signatures stripped when the flag is requested', async () => {
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-sig',
+      subject: 'Signed reply',
+      from: { email: 'alice@corp.com', name: 'Alice' },
+      to: [{ email: 'bob@corp.com', name: 'Bob' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      body: [
+        'Sounds good.',
+        '',
+        '-- ',
+        'Alice Smith',
+        'Senior Partner',
+      ].join('\n'),
+    });
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'alice@corp.com';
+    state.mailboxes = [{
+      name: 'alice',
+      emailAddress: 'alice@corp.com',
+      displayName: 'alice@corp.com',
+      providerType: 'gmail',
+      provider: { getMessage } as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, {
+      id: 'msg-sig',
+      strip_signatures: true,
+    }) as { body: string };
+
+    expect(result.body).toContain('Sounds good.');
+    expect(result.body).not.toContain('Alice Smith');
+    expect(result.body).not.toContain('Senior Partner');
+  });
+
+  it('Scenario: Both stripping flags compose', async () => {
+    const quotedTail = Array.from(
+      { length: 40 },
+      (_, index) => `> historical line ${index + 1}`,
+    ).join('\n');
+    const getMessage = vi.fn().mockResolvedValue({
+      id: 'msg-both',
+      subject: 'Signed reply with history',
+      from: { email: 'alice@corp.com', name: 'Alice' },
+      to: [{ email: 'bob@corp.com', name: 'Bob' }],
+      receivedAt: '2026-04-09T12:00:00.000Z',
+      body: [
+        'Approved.',
+        '',
+        '-- ',
+        'Alice Smith',
+        'Senior Partner',
+        '',
+        'On Wed, Mar 13, 2024 at 9:30 AM Bob <bob@corp.com> wrote:',
+        quotedTail,
+      ].join('\n'),
+    });
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.provider = { getMessage } as never;
+    state.connectedMailbox = 'alice@corp.com';
+    state.mailboxes = [{
+      name: 'alice',
+      emailAddress: 'alice@corp.com',
+      displayName: 'alice@corp.com',
+      providerType: 'gmail',
+      provider: { getMessage } as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const readEmail = actions.find(a => a.name === 'read_email')!;
+    const result = await readEmail.run({}, {
+      id: 'msg-both',
+      strip_signatures: true,
+      strip_quoted_history: true,
+    }) as { body: string };
+
+    expect(result.body).toContain('Approved.');
+    expect(result.body).not.toContain('Alice Smith');
+    expect(result.body).not.toContain('historical line 1');
+  });
   });
 
   it('Scenario: read_email demo path is unchanged when no mailbox is configured', async () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -797,11 +797,12 @@ export async function buildLazyActions(
     },
     {
       name: 'read_email',
-      description: 'Read the full content of an email by ID, transformed to token-efficient markdown. Set strip_quoted_history to true to drop the terminal "On … wrote:" / Outlook-header / `>`-prefix reply chain and replace it with a short marker.',
+      description: 'Read the full content of an email by ID, transformed to token-efficient markdown. Set strip_quoted_history to true to drop the terminal "On … wrote:" / Outlook-header / `>`-prefix reply chain and replace it with a short marker. Set strip_signatures to true to remove detected signatures and legal disclaimers; it defaults to false here for MCP compatibility even though the core action defaults to true.',
       input: z.object({
         id: z.string(),
         mailbox: z.string().optional(),
         strip_quoted_history: z.boolean().optional().default(false),
+        strip_signatures: z.boolean().optional().default(false),
       }),
       output: z.object({
         id: z.string(),
@@ -826,20 +827,24 @@ export async function buildLazyActions(
       annotations: { readOnlyHint: true, destructiveHint: false },
       run: async (_ctx, input) => {
         await waitForInit(state);
-        const inp = input as { id: string; mailbox?: string; strip_quoted_history?: boolean };
+        const inp = input as {
+          id: string;
+          mailbox?: string;
+          strip_quoted_history?: boolean;
+          strip_signatures?: boolean;
+        };
         if (!getDefaultMailbox(state)) return demoReadEmail(inp.id);
         const { mailbox } = resolveMailboxContext(state, inp.mailbox);
         // Delegate to the canonical readEmailAction so MCP stays a thin adapter
         // (per AGENTS.md: actions are the single source of truth, transport layers
-        // must not re-implement business logic). strip_signatures stays false for
-        // backwards compatibility — wiring it through is tracked separately.
+        // must not re-implement business logic).
         const { readEmailAction } = await import('@usejunior/email-core');
         const actionResult = await readEmailAction.run(
           { provider: mailbox.provider },
           {
             id: inp.id,
             mailbox: inp.mailbox,
-            strip_signatures: false,
+            strip_signatures: inp.strip_signatures ?? false,
             strip_quoted_history: inp.strip_quoted_history ?? false,
           },
         );


### PR DESCRIPTION
Closes #87.

## What changed
- adds optional `strip_signatures` to the MCP `read_email` input
- preserves existing MCP behavior with a `false` default while documenting the core action's different default
- forwards the caller's value to the canonical email-core read action
- verifies opt-in stripping, default preservation, and composition with `strip_quoted_history`
- strengthens signature heuristic coverage for RFC 3676, mobile footers, and confidentiality disclaimers
- completes the approved OpenSpec task list

## Compatibility
This is additive and opt-in. MCP callers that omit `strip_signatures` continue receiving signatures exactly as before.

## Validation
- `npm run build`
- full workspace suite: 919 tests passed
- `npm run lint --workspaces --if-present`
- `npm run check:spec-coverage` (249/249 against the active proposal set)
- `openspec validate update-read-email-strip-signatures --strict`
- `git diff --check`