### PR TITLE
fix(distribution): publish scoped compatibility package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
           TAG_REF="${RELEASE_TAG:-$GITHUB_REF_NAME}"
           TAG_VERSION="${TAG_REF#v}"
 
-          for pkg in packages/email-core/package.json packages/email-mcp/package.json packages/provider-microsoft/package.json packages/provider-gmail/package.json packages/email-agent-mcp/package.json; do
+          for pkg in packages/email-core/package.json packages/email-mcp/package.json packages/provider-microsoft/package.json packages/provider-gmail/package.json packages/email-agent-mcp/package.json packages/email-agent-mcp-scoped/package.json; do
             PKG_VERSION="$(node -p "require('./${pkg}').version")"
             if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
               echo "Tag version ($TAG_VERSION) must match ${pkg} version ($PKG_VERSION)."
@@ -111,7 +111,7 @@ jobs:
 
       - name: Verify package contents (dry-run)
         run: |
-          for pkg in email-core provider-microsoft provider-gmail email-mcp email-agent-mcp; do
+          for pkg in email-core provider-microsoft provider-gmail email-mcp email-agent-mcp email-agent-mcp-scoped; do
             echo "=== packages/$pkg ==="
             (cd "packages/$pkg" && npm pack --dry-run)
           done
@@ -122,7 +122,7 @@ jobs:
           VERSION="${TAG_REF#v}"
           ALREADY=0
           TOTAL=0
-          for pkg in @usejunior/email-core @usejunior/provider-microsoft @usejunior/provider-gmail @usejunior/email-mcp email-agent-mcp; do
+          for pkg in @usejunior/email-core @usejunior/provider-microsoft @usejunior/provider-gmail @usejunior/email-mcp email-agent-mcp @usejunior/email-agent-mcp; do
             TOTAL=$((TOTAL + 1))
             if npm view "$pkg@$VERSION" version >/dev/null 2>&1; then
               echo "$pkg@$VERSION already published."
@@ -219,6 +219,11 @@ jobs:
 
           # Tier 4: depends on email-mcp
           publish_pkg "email-agent-mcp" "packages/email-agent-mcp"
+
+          sleep 10
+
+          # Tier 5: compatibility name depends on the canonical distribution
+          publish_pkg "@usejunior/email-agent-mcp" "packages/email-agent-mcp-scoped"
 
   publish-mcp-registry:
     name: Publish MCP Registry metadata

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Agent Email ships with restrictive defaults that you loosen as needed:
 | `@usejunior/provider-microsoft` | Microsoft Graph API email provider |
 | `@usejunior/provider-gmail` | Gmail API email provider |
 | `email-agent-mcp` | Distribution wrapper (`npx email-agent-mcp`) |
+| `@usejunior/email-agent-mcp` | Compatibility wrapper, published in lockstep; use `email-agent-mcp` for new installs |
 
 ## Quality and Trust Signals
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1550,6 +1550,10 @@
         "uncrypto": "^0.1.3"
       }
     },
+    "node_modules/@usejunior/email-agent-mcp": {
+      "resolved": "packages/email-agent-mcp-scoped",
+      "link": true
+    },
     "node_modules/@usejunior/email-core": {
       "resolved": "packages/email-core",
       "link": true
@@ -5927,6 +5931,20 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@usejunior/email-mcp": "^0.1.9"
+      },
+      "bin": {
+        "email-agent-mcp": "bin/email-agent-mcp.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "packages/email-agent-mcp-scoped": {
+      "name": "@usejunior/email-agent-mcp",
+      "version": "0.1.9",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "email-agent-mcp": "0.1.9"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"

--- a/packages/email-agent-mcp-scoped/README.md
+++ b/packages/email-agent-mcp-scoped/README.md
@@ -1,0 +1,13 @@
+# @usejunior/email-agent-mcp
+
+Compatibility package for existing scoped-package users.
+
+The canonical distribution is [`email-agent-mcp`](https://www.npmjs.com/package/email-agent-mcp):
+
+```bash
+npx -y email-agent-mcp
+```
+
+Both package names are published from the same release and resolve to the same
+CLI and MCP server implementation. New installations should use the unscoped
+package.

--- a/packages/email-agent-mcp-scoped/bin/email-agent-mcp.js
+++ b/packages/email-agent-mcp-scoped/bin/email-agent-mcp.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { runCliDirect } from 'email-agent-mcp';
+
+void runCliDirect(process.argv.slice(2));

--- a/packages/email-agent-mcp-scoped/index.d.ts
+++ b/packages/email-agent-mcp-scoped/index.d.ts
@@ -1,0 +1,2 @@
+// Compatibility package. The unscoped package is canonical.
+export * from 'email-agent-mcp';

--- a/packages/email-agent-mcp-scoped/index.js
+++ b/packages/email-agent-mcp-scoped/index.js
@@ -1,0 +1,2 @@
+// Compatibility package. The unscoped package is canonical.
+export * from 'email-agent-mcp';

--- a/packages/email-agent-mcp-scoped/package.json
+++ b/packages/email-agent-mcp-scoped/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@usejunior/email-agent-mcp",
+  "version": "0.1.9",
+  "description": "Compatibility package for email-agent-mcp — use the unscoped package for new installations",
+  "type": "module",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "bin": {
+    "email-agent-mcp": "./bin/email-agent-mcp.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js"
+    }
+  },
+  "dependencies": {
+    "email-agent-mcp": "0.1.9"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "files": [
+    "bin",
+    "index.js",
+    "index.d.ts"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/UseJunior/email-agent-mcp.git",
+    "directory": "packages/email-agent-mcp-scoped"
+  },
+  "homepage": "https://github.com/UseJunior/email-agent-mcp#readme",
+  "bugs": {
+    "url": "https://github.com/UseJunior/email-agent-mcp/issues"
+  },
+  "keywords": [
+    "email",
+    "mcp",
+    "ai-agent",
+    "microsoft-graph",
+    "gmail"
+  ],
+  "license": "Apache-2.0"
+}

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -23,6 +23,11 @@ npx -y email-agent-mcp
 
 The interactive setup wizard walks you through OAuth configuration and mailbox selection.
 
+`email-agent-mcp` is the canonical package name. The legacy
+`@usejunior/email-agent-mcp` compatibility package is published in lockstep for
+existing users, but new installations should use the unscoped package shown
+above.
+
 ## What Works Today
 
 - Microsoft 365 / Outlook mailbox access through MCP stdio

--- a/scripts/bump_version.mjs
+++ b/scripts/bump_version.mjs
@@ -25,6 +25,7 @@ const PACKAGE_JSONS = [
   'packages/provider-microsoft/package.json',
   'packages/provider-gmail/package.json',
   'packages/email-agent-mcp/package.json',
+  'packages/email-agent-mcp-scoped/package.json',
 ];
 
 const SERVER_JSON = 'packages/email-agent-mcp/server.json';
@@ -36,6 +37,7 @@ const WORKSPACE_DEPS = [
   '@usejunior/email-mcp',
   '@usejunior/provider-microsoft',
   '@usejunior/provider-gmail',
+  'email-agent-mcp',
 ];
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -95,7 +97,9 @@ function checkVersionSync() {
       if (!deps) continue;
       for (const name of WORKSPACE_DEPS) {
         if (deps[name]) {
-          const expected = `^${[...uniqueVersions][0]}`;
+          const expected = name === 'email-agent-mcp'
+            ? [...uniqueVersions][0]
+            : `^${[...uniqueVersions][0]}`;
           if (deps[name] !== expected && uniqueVersions.size === 1) {
             console.error(`  ${rel}: ${name} is "${deps[name]}", expected "${expected}"`);
             ok = false;
@@ -129,7 +133,9 @@ function bumpVersion(newVersion) {
       if (!deps) continue;
       for (const name of WORKSPACE_DEPS) {
         if (deps[name]) {
-          deps[name] = `^${newVersion}`;
+          deps[name] = name === 'email-agent-mcp'
+            ? newVersion
+            : `^${newVersion}`;
         }
       }
     }

--- a/scripts/check-isolated-runtime.mjs
+++ b/scripts/check-isolated-runtime.mjs
@@ -15,6 +15,7 @@ const PACKAGES = [
   'provider-gmail',
   'email-mcp',
   'email-agent-mcp',
+  'email-agent-mcp-scoped',
 ];
 
 async function main() {
@@ -44,15 +45,29 @@ async function main() {
       timeout: 120000,
     });
 
-    // Spawn the MCP server and send JSON-RPC requests
-    console.error('[smoke] Starting MCP server...');
-    const result = await testMcpServer(tmpDir);
-
-    if (result.success) {
-      console.error(`[smoke] PASS: MCP server responded with ${result.toolCount} tools`);
-    } else {
-      console.error(`[smoke] FAIL: ${result.error}`);
-      process.exit(1);
+    // Exercise both distribution package entry points directly. Invoking the
+    // package-local bins avoids npm's single .bin symlink collision when both
+    // compatibility names are intentionally installed together.
+    const distributions = [
+      {
+        label: 'email-agent-mcp',
+        serverBin: join(tmpDir, 'node_modules', 'email-agent-mcp', 'bin', 'email-agent-mcp.js'),
+      },
+      {
+        label: '@usejunior/email-agent-mcp',
+        serverBin: join(tmpDir, 'node_modules', '@usejunior', 'email-agent-mcp', 'bin', 'email-agent-mcp.js'),
+      },
+    ];
+    for (const distribution of distributions) {
+      console.error(`[smoke] Starting ${distribution.label} MCP server...`);
+      const result = await testMcpServer(tmpDir, distribution.serverBin);
+      if (!result.success) {
+        console.error(`[smoke] FAIL (${distribution.label}): ${result.error}`);
+        process.exit(1);
+      }
+      console.error(
+        `[smoke] PASS (${distribution.label}): MCP server responded with ${result.toolCount} tools`,
+      );
     }
 
     // Clean up tarballs
@@ -71,9 +86,8 @@ async function main() {
   }
 }
 
-function testMcpServer(installDir) {
+function testMcpServer(installDir, serverBin) {
   return new Promise((resolve) => {
-    const serverBin = join(installDir, 'node_modules', '.bin', 'email-agent-mcp');
     const proc = spawn(serverBin, ['serve'], {
       cwd: installDir,
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/scripts/check-server-json.mjs
+++ b/scripts/check-server-json.mjs
@@ -18,6 +18,9 @@ const serverJson = JSON.parse(
 const packageJson = JSON.parse(
   readFileSync(resolve(root, 'packages/email-agent-mcp/package.json'), 'utf-8'),
 );
+const scopedPackageJson = JSON.parse(
+  readFileSync(resolve(root, 'packages/email-agent-mcp-scoped/package.json'), 'utf-8'),
+);
 
 let ok = true;
 
@@ -50,9 +53,23 @@ if (pkgEntry && pkgEntry.identifier !== packageJson.name) {
   ok = false;
 }
 
+if (scopedPackageJson.version !== packageJson.version) {
+  console.error(
+    `FAIL: scoped package version "${scopedPackageJson.version}" !== canonical package version "${packageJson.version}"`,
+  );
+  ok = false;
+}
+
+if (scopedPackageJson.dependencies?.[packageJson.name] !== packageJson.version) {
+  console.error(
+    `FAIL: scoped package must depend on ${packageJson.name} at exact version "${packageJson.version}"`,
+  );
+  ok = false;
+}
+
 if (ok) {
   console.log(
-    `PASS: server.json matches package.json (${packageJson.version})`,
+    `PASS: server.json and scoped compatibility package match canonical package.json (${packageJson.version})`,
   );
 } else {
   process.exit(1);


### PR DESCRIPTION
## Summary
- add `@usejunior/email-agent-mcp` as a thin compatibility workspace over the canonical `email-agent-mcp` distribution
- publish both names in lockstep with exact-version dependency and version-bump validation
- exercise both package-local CLIs from freshly packed tarballs in the isolated runtime smoke test
- document that new users should install the canonical unscoped package

## Validation
- `npm run build`
- `npm run lint`
- `npm run test:run` (945 tests)
- `npm run check:spec-coverage` (262/262)
- `npm run check:server-json`
- `npm run check:gemini-extension-manifest`
- `node scripts/bump_version.mjs --check`
- package dry runs for both distributions
- `npm run check:isolated-runtime` (both names expose 26 MCP tools)

Closes #111