### PR TITLE
feat(cli): add Gmail BYOK wizard flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,110 @@ passing an array (even empty) replaces them.
 | Provider | Status | Package |
 |----------|--------|---------|
 | Microsoft 365 (Graph API) | Fully supported | `@usejunior/provider-microsoft` |
-| Gmail | Supported via interactive CLI OAuth or manual refresh-token setup | `@usejunior/provider-gmail` |
+| Gmail | Supported via interactive CLI OAuth (default client or your own) or manual refresh-token setup | `@usejunior/provider-gmail` |
 
-Use `email-agent-mcp configure --provider gmail` to run the local browser OAuth flow, or add a manual mailbox token file under `~/.email-agent-mcp/tokens/`. See [packages/provider-gmail/README.md](./packages/provider-gmail/README.md).
+Use `email-agent-mcp configure --provider gmail` to run the local browser OAuth flow, or add a manual mailbox token file under `~/.email-agent-mcp/tokens/`. See [Gmail Setup](#gmail-setup) below and [packages/provider-gmail/README.md](./packages/provider-gmail/README.md).
+
+## Gmail Setup
+
+Gmail has two supported OAuth paths. Both end with the same result: a refresh
+token on your machine, and Gmail API calls going directly from your machine to
+Google.
+
+| Path | Command | Google Cloud project needed? |
+|------|---------|------------------------------|
+| Default OAuth client | `email-agent-mcp configure --provider gmail` | No |
+| Bring your own key (BYOK) | same command plus `--client-id` / `--client-secret` | Yes, yours |
+
+**Recommended for now: BYOK.** Our default OAuth client is still in Google's
+"Testing" publishing status while verification is in progress, which caps it at
+100 registered test users and shows the "Google hasn't verified this app"
+interstitial during consent. Verification for Gmail's restricted scope requires
+a CASA security assessment and takes several weeks; progress is tracked in
+[issue #112](https://github.com/UseJunior/email-agent-mcp/issues/112). BYOK
+sidesteps the shared 100-user cap and puts the app's publishing status under
+your control; your own app still has Google's Testing constraints until you
+publish it.
+
+Other reasons to pick BYOK: dedicated API quota, your own privacy policy and
+verification status, and no dependency on the hosted broker at
+`https://oauth.usejunior.com`.
+
+### Scope requested
+
+Agent Email requests exactly one Gmail scope:
+
+```text
+https://mail.google.com/
+```
+
+This is a restricted scope covering read, send, modify, and delete. It is the
+single scope you add to your own OAuth consent screen.
+
+### BYOK: create your own Google OAuth client
+
+1. **Create a project** in the [Google Cloud Console](https://console.cloud.google.com/projectcreate),
+   or select an existing one.
+2. **Enable the Gmail API** under *APIs & Services → Library → Gmail API → Enable*.
+3. **Configure the OAuth consent screen** under *APIs & Services → OAuth consent screen*:
+   - User type **External** for a personal `@gmail.com` account, or **Internal**
+     if you are on Google Workspace and only your own org needs access.
+   - Add the scope `https://mail.google.com/`.
+   - While the app is in *Testing*, add your own Gmail address under **Test users**,
+     or consent will be refused.
+4. **Create the OAuth client** under *APIs & Services → Credentials → Create
+   credentials → OAuth client ID*. Choose application type **Desktop app**.
+   Desktop is required: `configure` starts a throwaway listener on an ephemeral
+   loopback port (`http://127.0.0.1:<port>/oauth2callback`), and only Desktop
+   clients let Google accept an arbitrary loopback port without pre-registering
+   the exact redirect URI. A Web application client will fail with
+   `redirect_uri_mismatch`.
+5. **Copy the client ID and client secret.**
+
+### BYOK: hand the credentials to email-agent-mcp
+
+Pass both halves as flags:
+
+```bash
+npx email-agent-mcp configure \
+  --provider gmail \
+  --mailbox personal \
+  --client-id YOUR_GOOGLE_CLIENT_ID \
+  --client-secret YOUR_GOOGLE_CLIENT_SECRET
+```
+
+Or set the two namespaced environment variables and omit the flags:
+
+```bash
+export AGENT_EMAIL_GMAIL_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
+export AGENT_EMAIL_GMAIL_CLIENT_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+
+npx email-agent-mcp configure --provider gmail --mailbox personal
+```
+
+Both halves are required. Supplying only one exits with an error rather than
+silently falling back to the default client. Supplying neither selects the
+default OAuth client.
+
+Your browser opens Google's consent screen, the CLI catches the callback on
+loopback, exchanges the code with PKCE, and writes the mailbox to
+`~/.email-agent-mcp/tokens/<safe-key>.json` with `"source": "byok"` alongside
+your `clientId`, `clientSecret`, and the resulting `refreshToken`. Token
+refreshes then go straight to Google's token endpoint; no broker is involved.
+
+Re-running `configure` for a mailbox that is already saved reuses the saved
+credentials, so you only pass the flags once. Passing `--client-id` and
+`--client-secret` for a mailbox previously configured against the default
+client migrates it to BYOK.
+
+### BYOK: keep the grant from expiring after 7 days
+
+Google expires refresh tokens after 7 days while *your* OAuth app is in
+*Testing* publishing status, which shows up as a re-authentication prompt about
+once a week. `email-agent-mcp status` warns when a mailbox is approaching that
+window. Publishing your app (*OAuth consent screen → Publish app*) removes the
+7-day expiry. Since you own the app and are its only user, the 100-user test
+cap does not apply to you either way.
 
 ## Security Defaults
 
@@ -270,7 +371,7 @@ email-agent-mcp/
 
 ## Releasing
 
-Tag-driven release via GitHub Actions with npm OIDC trusted publishing. All 5 packages publish in dependency order with `--provenance`, then `server.json` is published to the official MCP Registry with `mcp-publisher`.
+Tag-driven release via GitHub Actions with npm OIDC trusted publishing. All 6 packages publish in dependency order with `--provenance`, then `server.json` is published to the official MCP Registry with `mcp-publisher`.
 
 ## FAQ
 

--- a/openspec/changes/add-gmail-byok-wizard/proposal.md
+++ b/openspec/changes/add-gmail-byok-wizard/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The primary onboarding command, `npx -y email-agent-mcp`, opens the interactive
+wizard, but its Gmail path always selects the hosted OAuth broker. Users who
+want the currently recommended bring-your-own-key (BYOK) path must leave the
+wizard and discover CLI flags or environment variables.
+
+The hosted OAuth app is still in Google's Testing status, so the wizard should
+make that path's user cap, unverified-app interstitial, and seven-day refresh
+token lifetime explicit while making BYOK available directly.
+
+## What Changes
+
+- Add a Gmail authentication-mode picker to the first-run wizard.
+- Keep the hosted default available, with plain language about its current
+  Testing-status limitations.
+- Let users choose BYOK, link to the repository's Gmail Setup instructions,
+  require a Desktop OAuth client, and prompt for both credential halves.
+- Collect the client secret with a masked password prompt and never render it
+  in wizard output.
+- Preserve existing explicit flag/environment behavior and the existing
+  reconnect path that reuses saved mailbox credentials.
+- Add the Gmail Setup documentation needed by the wizard link.
+
+## Impact
+
+- Affected spec: `cli`
+- Affected code: `packages/email-mcp/src/wizard.ts` and its tests
+- Affected docs: `README.md`
+- User-visible behavior: the Gmail wizard gains one explicit authentication
+  choice; Outlook and non-interactive configure flows remain unchanged.

--- a/openspec/changes/add-gmail-byok-wizard/specs/cli/spec.md
+++ b/openspec/changes/add-gmail-byok-wizard/specs/cli/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Interactive Wizard
+
+The interactive wizard SHALL guide the user through provider selection, credential entry, and connection verification. It uses a provider picker presenting available options.
+
+For Gmail, the wizard SHALL offer the hosted default OAuth client and a bring-your-own-key (BYOK) OAuth client. It SHALL state the hosted client's current Google Testing-status limitations, and the BYOK path SHALL identify the required client type as Desktop app and link to the repository's Gmail Setup instructions.
+
+The wizard SHALL collect a BYOK client secret with a masked prompt, SHALL require both the client ID and client secret, and SHALL NOT render the secret in terminal output. Explicit CLI or environment credentials SHALL continue to take precedence without being replaced by wizard input. Reconnecting an existing mailbox SHALL continue to reuse its saved authentication mode and credentials.
+
+#### Scenario: Provider picker shows available providers
+- **WHEN** the interactive wizard starts
+- **THEN** it presents a provider picker with both Outlook and Gmail as selectable providers
+
+#### Scenario: Wizard persists config on success
+- **WHEN** the wizard completes successfully (credentials validated, connection tested)
+- **THEN** it writes the configuration to `~/.email-agent-mcp/config.json`
+- **AND** the configured email address is auto-added to the send allowlist
+
+#### Scenario: Gmail wizard offers both authentication modes
+- **WHEN** a user selects Gmail in the first-run wizard without explicit BYOK credentials
+- **THEN** the wizard offers the hosted default OAuth client and a BYOK OAuth client
+- **AND** the hosted option states the current Google Testing-status limitations
+
+#### Scenario: Gmail wizard collects BYOK credentials confidentially
+- **WHEN** a user selects BYOK in the Gmail wizard
+- **THEN** the wizard identifies Desktop app as the required Google OAuth client type
+- **AND** links to the repository's Gmail Setup instructions
+- **AND** prompts for the client ID and a masked client secret
+- **AND** forwards both values to Gmail configuration without rendering the secret
+
+#### Scenario: Gmail wizard rejects incomplete BYOK credentials
+- **WHEN** the Gmail BYOK wizard receives only one non-empty credential half
+- **THEN** it exits non-zero before starting OAuth
+- **AND** explains that both the client ID and client secret are required
+
+#### Scenario: Gmail wizard preserves explicit credentials
+- **WHEN** the wizard is started with both Gmail BYOK credential halves supplied by CLI options or namespaced environment variables
+- **THEN** it forwards those credentials without replacing them or prompting for another authentication mode
+
+#### Scenario: Gmail wizard reconnect preserves saved credentials
+- **WHEN** a user reconnects an existing Gmail mailbox from the wizard menu
+- **THEN** the wizard delegates configuration for that mailbox without prompting for a new authentication mode
+- **AND** the saved authentication mode and credentials are reused by Gmail configuration

--- a/openspec/changes/add-gmail-byok-wizard/tasks.md
+++ b/openspec/changes/add-gmail-byok-wizard/tasks.md
@@ -1,0 +1,9 @@
+- [x] Add a Gmail authentication-mode picker to the first-run wizard
+- [x] Explain the hosted client's current Testing-status limitations
+- [x] Prompt for a Desktop OAuth client ID and masked client secret in BYOK mode
+- [x] Reject incomplete BYOK input before starting OAuth
+- [x] Preserve explicit flag/env credentials and saved reconnect behavior
+- [x] Add the linked Gmail Setup documentation to the root README
+- [x] Add wizard tests for default, BYOK, incomplete, confidential, explicit, and reconnect paths
+- [x] Run `openspec validate add-gmail-byok-wizard --strict`
+- [x] Run build, lint, tests, and OpenSpec traceability validation

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -756,6 +756,9 @@ describe('cli/Gmail Configure', () => {
       clientId: 'cli-client-id',
       clientSecret: 'cli-client-secret',
     });
+    expect(JSON.stringify(vi.mocked(console.error).mock.calls)).not.toContain(
+      'cli-client-secret',
+    );
   });
 
   it('Scenario: Partial BYOK credentials are rejected', async () => {

--- a/packages/email-mcp/src/wizard.test.ts
+++ b/packages/email-mcp/src/wizard.test.ts
@@ -10,8 +10,12 @@ const CANCEL_TOKEN = Symbol.for('email-agent-mcp/test-cancel');
 
 const promptMockState = vi.hoisted(() => ({
   selectResults: [] as unknown[],
+  confirmResults: [] as boolean[],
+  textResults: [] as string[],
+  passwordResults: [] as string[],
   confirmResult: false as boolean,
   textResult: '' as string,
+  passwordResult: '' as string,
 }));
 
 vi.mock('@clack/prompts', async (importOriginal) => {
@@ -36,8 +40,18 @@ vi.mock('@clack/prompts', async (importOriginal) => {
       }
       return promptMockState.selectResults.shift();
     }),
-    confirm: vi.fn(async () => promptMockState.confirmResult),
-    text: vi.fn(async () => promptMockState.textResult),
+    confirm: vi.fn(async () =>
+      promptMockState.confirmResults.length > 0
+        ? promptMockState.confirmResults.shift()!
+        : promptMockState.confirmResult),
+    text: vi.fn(async () =>
+      promptMockState.textResults.length > 0
+        ? promptMockState.textResults.shift()!
+        : promptMockState.textResult),
+    password: vi.fn(async () =>
+      promptMockState.passwordResults.length > 0
+        ? promptMockState.passwordResults.shift()!
+        : promptMockState.passwordResult),
     isCancel: vi.fn((v: unknown) => v === CANCEL),
   };
 });
@@ -66,10 +80,15 @@ vi.mock('./cli.js', async (importOriginal) => {
 describe('wizard/Reconnect Picker', () => {
   beforeEach(() => {
     promptMockState.selectResults = [];
+    promptMockState.confirmResults = [];
+    promptMockState.textResults = [];
+    promptMockState.passwordResults = [];
     promptMockState.confirmResult = false;
     promptMockState.textResult = '';
+    promptMockState.passwordResult = '';
     cliMockState.runConfigureCalls = [];
     cliMockState.runConfigureResult = 0;
+    vi.clearAllMocks();
   });
 
   it('Scenario: Multiple mailboxes — picker dispatches runConfigure with selected provider/mailbox', async () => {
@@ -98,7 +117,7 @@ describe('wizard/Reconnect Picker', () => {
     });
   });
 
-  it('Scenario: Single mailbox — picker skipped, runConfigure called directly', async () => {
+  it('Scenario: Gmail wizard reconnect preserves saved credentials', async () => {
     const gmail: ConfiguredMailboxSummary = {
       provider: 'gmail',
       mailboxName: 'user@gmail.com',
@@ -111,6 +130,8 @@ describe('wizard/Reconnect Picker', () => {
     const exit = await runWizardMenu({}, [gmail]);
 
     expect(exit).toBe(0);
+    const clackPrompts = await import('@clack/prompts');
+    expect(vi.mocked(clackPrompts.select)).toHaveBeenCalledTimes(1);
     expect(cliMockState.runConfigureCalls).toHaveLength(1);
     expect(cliMockState.runConfigureCalls[0]).toMatchObject({
       provider: 'gmail',
@@ -155,5 +176,128 @@ describe('wizard/Reconnect Picker', () => {
       provider: 'microsoft',
       mailbox: 'default',
     });
+  });
+});
+
+describe('wizard/Gmail Authentication Choice', () => {
+  beforeEach(() => {
+    promptMockState.selectResults = [];
+    promptMockState.confirmResults = [];
+    promptMockState.textResults = [];
+    promptMockState.passwordResults = [];
+    promptMockState.confirmResult = false;
+    promptMockState.textResult = '';
+    promptMockState.passwordResult = '';
+    cliMockState.runConfigureCalls = [];
+    cliMockState.runConfigureResult = 0;
+    vi.clearAllMocks();
+  });
+
+  it('Scenario: Gmail wizard offers both authentication modes', async () => {
+    promptMockState.selectResults = ['gmail', 'broker'];
+    promptMockState.confirmResults = [true, false];
+    promptMockState.textResults = [''];
+
+    const { runWizardSetup } = await import('./wizard.js');
+    const exit = await runWizardSetup({});
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(1);
+    expect(cliMockState.runConfigureCalls[0]).toMatchObject({
+      command: 'configure',
+      provider: 'gmail',
+    });
+    expect(cliMockState.runConfigureCalls[0]).not.toHaveProperty('clientId');
+    expect(cliMockState.runConfigureCalls[0]).not.toHaveProperty('clientSecret');
+
+    const clackPrompts = await import('@clack/prompts');
+    const authPrompt = vi.mocked(clackPrompts.select).mock.calls[1]?.[0];
+    expect(authPrompt?.options.map(option => option.value)).toEqual(['byok', 'broker']);
+
+    const notes = JSON.stringify(vi.mocked(clackPrompts.note).mock.calls);
+    expect(notes).toContain('Testing status');
+    expect(notes).toContain('100 test users');
+    expect(notes).toContain('unverified-app');
+    expect(notes).toContain('7 days');
+  });
+
+  it('Scenario: Gmail wizard collects BYOK credentials confidentially', async () => {
+    const clientSecret = 'wizard-client-secret';
+    promptMockState.selectResults = ['gmail', 'byok'];
+    promptMockState.confirmResults = [true, false];
+    promptMockState.textResults = ['wizard-client-id', ''];
+    promptMockState.passwordResults = [clientSecret];
+
+    const { runWizardSetup } = await import('./wizard.js');
+    const exit = await runWizardSetup({});
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(1);
+    expect(cliMockState.runConfigureCalls[0]).toMatchObject({
+      command: 'configure',
+      provider: 'gmail',
+      clientId: 'wizard-client-id',
+      clientSecret,
+    });
+
+    const clackPrompts = await import('@clack/prompts');
+    expect(vi.mocked(clackPrompts.password)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Google OAuth client secret' }),
+    );
+    const notes = JSON.stringify(vi.mocked(clackPrompts.note).mock.calls);
+    expect(notes).toContain('Desktop app');
+    expect(notes).toContain('#gmail-setup');
+
+    const renderedOutput = JSON.stringify([
+      ...vi.mocked(clackPrompts.intro).mock.calls,
+      ...vi.mocked(clackPrompts.outro).mock.calls,
+      ...vi.mocked(clackPrompts.note).mock.calls,
+      ...vi.mocked(clackPrompts.log.error).mock.calls,
+      ...vi.mocked(clackPrompts.log.success).mock.calls,
+    ]);
+    expect(renderedOutput).not.toContain(clientSecret);
+  });
+
+  it('Scenario: Gmail wizard rejects incomplete BYOK credentials', async () => {
+    promptMockState.selectResults = ['gmail', 'byok'];
+    promptMockState.textResults = ['wizard-client-id'];
+    promptMockState.passwordResults = [''];
+
+    const { runWizardSetup } = await import('./wizard.js');
+    const exit = await runWizardSetup({});
+
+    expect(exit).toBe(2);
+    expect(cliMockState.runConfigureCalls).toHaveLength(0);
+
+    const clackPrompts = await import('@clack/prompts');
+    expect(vi.mocked(clackPrompts.log.error)).toHaveBeenCalledWith(
+      'Gmail BYOK requires both the client ID and client secret.',
+    );
+  });
+
+  it('Scenario: Gmail wizard preserves explicit credentials', async () => {
+    const clientSecret = 'explicit-client-secret';
+    promptMockState.selectResults = ['gmail'];
+    promptMockState.confirmResults = [true, false];
+    promptMockState.textResults = [''];
+
+    const { runWizardSetup } = await import('./wizard.js');
+    const exit = await runWizardSetup({
+      clientId: 'explicit-client-id',
+      clientSecret,
+    });
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls[0]).toMatchObject({
+      command: 'configure',
+      provider: 'gmail',
+      clientId: 'explicit-client-id',
+      clientSecret,
+    });
+
+    const clackPrompts = await import('@clack/prompts');
+    expect(vi.mocked(clackPrompts.select)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(clackPrompts.password)).not.toHaveBeenCalled();
+    expect(JSON.stringify(vi.mocked(clackPrompts.note).mock.calls)).not.toContain(clientSecret);
   });
 });

--- a/packages/email-mcp/src/wizard.ts
+++ b/packages/email-mcp/src/wizard.ts
@@ -31,17 +31,97 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
     return 0;
   }
 
+  const configOpts: CliOptions = { ...opts, command: 'configure', provider };
+
   if (provider === 'gmail') {
+    const suppliedClientId =
+      opts.clientId ?? process.env['AGENT_EMAIL_GMAIL_CLIENT_ID'];
+    const suppliedClientSecret =
+      opts.clientSecret ?? process.env['AGENT_EMAIL_GMAIL_CLIENT_SECRET'];
+
+    if (suppliedClientId || suppliedClientSecret) {
+      p.note(
+        'Using Gmail OAuth credentials supplied by CLI options or the\n' +
+        'AGENT_EMAIL_GMAIL_CLIENT_ID / AGENT_EMAIL_GMAIL_CLIENT_SECRET\n' +
+        'environment variables.',
+        'Gmail authentication',
+      );
+    } else {
+      const authMode = await p.select({
+        message: 'Choose Gmail authentication',
+        options: [
+          {
+            value: 'byok',
+            label: 'Use my own Google OAuth client (recommended)',
+            hint: 'Requires a Desktop app client ID and secret',
+          },
+          {
+            value: 'broker',
+            label: 'Use the default OAuth client',
+            hint: 'No Google Cloud project needed',
+          },
+        ],
+      });
+
+      if (p.isCancel(authMode)) {
+        p.outro('Setup cancelled.');
+        return 0;
+      }
+
+      if (authMode === 'byok') {
+        p.note(
+          'Create a Google OAuth client with application type Desktop app.\n' +
+          'A Web application client fails because this CLI uses an ephemeral\n' +
+          'loopback redirect port.\n' +
+          '\n' +
+          'Setup guide: https://github.com/UseJunior/email-agent-mcp#gmail-setup',
+          'Bring your own Google OAuth client',
+        );
+
+        const clientIdInput = await p.text({
+          message: 'Google OAuth client ID',
+          placeholder: '123456789.apps.googleusercontent.com',
+        });
+        if (p.isCancel(clientIdInput)) {
+          p.outro('Setup cancelled.');
+          return 0;
+        }
+
+        const clientSecretInput = await p.password({
+          message: 'Google OAuth client secret',
+          mask: '•',
+        });
+        if (p.isCancel(clientSecretInput)) {
+          p.outro('Setup cancelled.');
+          return 0;
+        }
+
+        const clientId = clientIdInput.trim();
+        const clientSecret = clientSecretInput.trim();
+        if (!clientId || !clientSecret) {
+          p.log.error('Gmail BYOK requires both the client ID and client secret.');
+          p.outro('Setup failed. See: https://github.com/UseJunior/email-agent-mcp#gmail-setup');
+          return 2;
+        }
+
+        configOpts.clientId = clientId;
+        configOpts.clientSecret = clientSecret;
+      } else {
+        p.note(
+          "The default OAuth client is currently in Google's Testing status.\n" +
+          'It is capped at 100 test users, shows an unverified-app consent\n' +
+          'screen, and its refresh tokens expire after 7 days.\n' +
+          '\n' +
+          'Choose BYOK instead for a stable personal or organization-owned grant.',
+          'Default OAuth client limits',
+        );
+      }
+    }
+
     p.note(
-      'Gmail setup opens Google in your browser and consent goes to a hosted\n' +
-      'OAuth broker. The broker holds the OAuth client_secret server-side, so\n' +
-      'no Google credentials are bundled into this CLI or written to disk. After\n' +
-      'consent, your refresh token is stored locally; Gmail API calls go directly\n' +
-      'from your machine to Google.\n' +
-      '\n' +
-      'To use your own OAuth client instead, pass --client-id and --client-secret\n' +
-      '(or set AGENT_EMAIL_GMAIL_CLIENT_ID and AGENT_EMAIL_GMAIL_CLIENT_SECRET).\n' +
-      `Credentials stored at ${getAgentEmailHome()}/tokens/`,
+      'Gmail setup opens Google in your browser. After consent, your refresh\n' +
+      'token is stored locally and Gmail API calls go directly from your\n' +
+      `machine to Google.\nCredentials stored at ${getAgentEmailHome()}/tokens/`,
       'How Gmail auth works',
     );
   } else {
@@ -61,7 +141,6 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
   }
 
   // Run the actual configure — Microsoft prints a device code; Gmail prints a browser URL.
-  const configOpts: CliOptions = { ...opts, command: 'configure', provider };
   const exitCode = await runConfigure(configOpts);
   if (exitCode !== 0) {
     p.outro('Setup failed. Try again with: email-agent-mcp setup');


### PR DESCRIPTION
## Summary
- add a first-run Gmail authentication picker with BYOK recommended and the hosted client's current Testing-status limits stated plainly
- collect BYOK client ID plus a masked client secret, reject incomplete credentials before OAuth, and preserve explicit/saved credential paths
- add the linked Gmail Setup guide with Desktop-app instructions and current verification context
- specify the behavior through a strict OpenSpec CLI delta and traceable wizard tests

## Validation
- `npm run build`
- `npm run lint`
- `npm run test:run` (949 tests)
- `npm run check:spec-coverage` (262/262 current-spec scenarios)
- `npm run check:server-json`
- `npm run check:gemini-extension-manifest`
- `openspec validate add-gmail-byok-wizard --strict`
- real PTY smoke: Gmail → BYOK, Desktop-app guidance visible, secret rendered only as mask bullets, cancellation before OAuth/persistence

Closes #122