### PR TITLE
fix(smoke): wait for lazy provider readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "build": "npm run build -w @usejunior/email-core && npm run build -w @usejunior/provider-microsoft && npm run build -w @usejunior/provider-gmail && npm run build -w @usejunior/email-mcp",
     "test": "npm run test --workspaces --if-present",
-    "test:run": "npm run test:run --workspaces --if-present",
+    "test:run": "npm run test:run --workspaces --if-present && npm run test:scripts",
+    "test:scripts": "node --test scripts/launch-prep-smoke.test.mjs",
     "lint": "npm run lint --workspaces --if-present",
     "clean": "npm run clean --workspaces --if-present",
     "check:spec-coverage": "node scripts/check-spec-coverage.mjs",

--- a/scripts/launch-prep-smoke.mjs
+++ b/scripts/launch-prep-smoke.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 
@@ -146,7 +147,7 @@ function requireSuccess(name, result) {
   return result;
 }
 
-function requireLiveMailbox(status) {
+export function requireLiveMailbox(status) {
   if (!status || typeof status !== 'object') {
     throw new Error('get_mailbox_status returned an invalid payload');
   }
@@ -162,7 +163,51 @@ function requireLiveMailbox(status) {
   }
 
   if (String(status.status).toLowerCase() !== 'connected') {
-    throw new Error(`Mailbox is not connected: ${status.status ?? 'unknown status'}`);
+    const warnings = Array.isArray(status.warnings)
+      ? status.warnings.filter(warning => typeof warning === 'string').join('; ')
+      : '';
+    throw new Error(
+      `Mailbox is not connected: ${status.status ?? 'unknown status'}${warnings ? ` (${warnings})` : ''}`,
+    );
+  }
+}
+
+export async function waitForLiveMailbox(
+  getStatus,
+  {
+    timeoutMs = 15_000,
+    pollIntervalMs = 250,
+    now = Date.now,
+    delay = sleep,
+  } = {},
+) {
+  const deadline = now() + timeoutMs;
+  let lastStatus;
+
+  while (true) {
+    lastStatus = await getStatus();
+    const normalizedStatus = String(lastStatus?.status ?? '').toLowerCase();
+    if (normalizedStatus === 'connected') {
+      requireLiveMailbox(lastStatus);
+      return lastStatus;
+    }
+
+    if (normalizedStatus !== 'connecting' && normalizedStatus !== 'pending') {
+      requireLiveMailbox(lastStatus);
+    }
+
+    const remainingMs = deadline - now();
+    if (remainingMs <= 0) {
+      const warnings = Array.isArray(lastStatus?.warnings)
+        ? lastStatus.warnings.filter(warning => typeof warning === 'string').join('; ')
+        : '';
+      throw new Error(
+        `Mailbox did not become connected within ${timeoutMs}ms. ` +
+        `Last status: ${lastStatus?.status ?? 'unknown'}${warnings ? ` (${warnings})` : ''}`,
+      );
+    }
+
+    await delay(Math.min(pollIntervalMs, remainingMs));
   }
 }
 
@@ -258,8 +303,9 @@ async function main() {
       mutations: [],
     };
 
-    const status = await callJson(client, 'get_mailbox_status', getMailboxArg(opts.mailbox));
-    requireLiveMailbox(status);
+    const status = await waitForLiveMailbox(
+      () => callJson(client, 'get_mailbox_status', getMailboxArg(opts.mailbox)),
+    );
     summary.status = status;
     summary.replySender = await resolveReplySender(opts, status);
 
@@ -391,7 +437,13 @@ async function main() {
   }
 }
 
-main().catch(err => {
-  console.error(err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+const isDirectRun =
+  typeof process.argv[1] === 'string' &&
+  import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isDirectRun) {
+  main().catch(err => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/scripts/launch-prep-smoke.test.mjs
+++ b/scripts/launch-prep-smoke.test.mjs
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { waitForLiveMailbox } from './launch-prep-smoke.mjs';
+
+const connected = {
+  name: 'work@example.com',
+  provider: 'microsoft',
+  status: 'connected',
+  isDefault: true,
+  warnings: [],
+};
+
+test('launch smoke accepts an immediately connected mailbox', async () => {
+  let calls = 0;
+  const result = await waitForLiveMailbox(async () => {
+    calls += 1;
+    return connected;
+  });
+
+  assert.equal(result, connected);
+  assert.equal(calls, 1);
+});
+
+test('launch smoke waits for lazy initialization to connect', async () => {
+  const statuses = [
+    {
+      name: 'pending',
+      provider: 'pending',
+      status: 'connecting',
+      isDefault: false,
+      warnings: ['Authenticating — provider is warming up'],
+    },
+    connected,
+  ];
+  const delays = [];
+  let mailboxArgument = '';
+
+  const result = await waitForLiveMailbox(
+    async () => {
+      mailboxArgument = 'work';
+      return statuses.shift();
+    },
+    {
+      delay: async milliseconds => {
+        delays.push(milliseconds);
+      },
+    },
+  );
+
+  assert.equal(result, connected);
+  assert.equal(mailboxArgument, 'work');
+  assert.deepEqual(delays, [250]);
+});
+
+test('launch smoke fails immediately for a terminal mailbox state', async () => {
+  let calls = 0;
+
+  await assert.rejects(
+    waitForLiveMailbox(async () => {
+      calls += 1;
+      return {
+        name: 'none',
+        provider: 'none',
+        status: 'not configured',
+        isDefault: false,
+        warnings: ['Run email-agent-mcp configure'],
+      };
+    }),
+    /Live mailbox not configured/,
+  );
+
+  assert.equal(calls, 1);
+});
+
+test('launch smoke times out with the last status and warnings', async () => {
+  let nowMs = 0;
+  let calls = 0;
+
+  await assert.rejects(
+    waitForLiveMailbox(
+      async () => {
+        calls += 1;
+        return {
+          name: 'pending',
+          provider: 'pending',
+          status: 'connecting',
+          isDefault: false,
+          warnings: ['still warming up'],
+        };
+      },
+      {
+        timeoutMs: 500,
+        pollIntervalMs: 200,
+        now: () => nowMs,
+        delay: async milliseconds => {
+          nowMs += milliseconds;
+        },
+      },
+    ),
+    error => {
+      assert.match(error.message, /within 500ms/);
+      assert.match(error.message, /Last status: connecting/);
+      assert.match(error.message, /still warming up/);
+      return true;
+    },
+  );
+
+  assert.equal(calls, 4);
+});


### PR DESCRIPTION
## Summary
- poll `get_mailbox_status` only while lazy provider initialization is pending/connecting
- preserve immediate failures for terminal missing/error/demo states
- bound readiness to 15 seconds and include the last status/warnings on timeout
- add deterministic Node tests to the root release test gate

## Validation
- `npm run build`
- `npm run lint`
- `npm run test:run` (949 workspace tests + 4 script tests)
- `npm run check:spec-coverage` (262/262)
- `npm run check:server-json`
- `npm run check:gemini-extension-manifest`
- read-only live smoke reached the real mailbox's connected state; it no longer failed on `connecting` and stopped later only because no inbox item matched the default safe-sender fixture

Closes #134