### PR TITLE
feat(cli): add configure mailbox picker

### DIFF
--- a/openspec/changes/add-configure-mailbox-picker/proposal.md
+++ b/openspec/changes/add-configure-mailbox-picker/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Returning users with multiple configured mailboxes must currently remember both
+the provider and the mailbox alias when they run `email-agent-mcp configure`.
+A bare interactive configure silently defaults to Microsoft, which can send the
+user through the wrong authentication flow.
+
+## What Changes
+
+- Detect ambiguous interactive `configure` and `setup` invocations when more
+  than one mailbox is configured.
+- Present the configured mailboxes with email address, provider, exact alias,
+  and last-authenticated date, plus an option to add a new mailbox.
+- Reauthenticate a selected mailbox using its saved provider and exact alias.
+- Send the add-new choice through the existing first-run provider wizard.
+- Preserve direct flag-driven behavior whenever `--provider` or `--mailbox` is
+  supplied, for all non-TTY callers, and for the NemoClaw setup variant.
+
+## Impact
+
+- Affected spec: `cli`
+- Affected code: `packages/email-mcp/src/cli.ts`,
+  `packages/email-mcp/src/wizard.ts`, and their tests
+- User-visible behavior: ambiguous interactive configure commands gain one
+  mailbox selection step; explicit and automated invocations are unchanged.

--- a/openspec/changes/add-configure-mailbox-picker/specs/cli/spec.md
+++ b/openspec/changes/add-configure-mailbox-picker/specs/cli/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Configure Subcommand
+
+The system SHALL provide a `configure` subcommand (aliased as `setup`) with an
+interactive setup wizard: provider picker, credentials entry, connection test,
+and config persistence.
+
+When `configure` or `setup` is run in a TTY without an explicit provider or
+mailbox and more than one mailbox is already configured, the system SHALL
+present a mailbox picker before authentication. The picker SHALL identify each
+mailbox by email address, provider, saved alias, and last-authenticated date,
+and SHALL offer an add-new-mailbox choice.
+
+#### Scenario: Interactive setup
+- **WHEN** `email-agent-mcp configure` is run
+- **THEN** the system launches the interactive wizard with a provider picker for Outlook and Gmail and tests the selected connection
+
+#### Scenario: Ambiguous configure presents saved mailboxes
+- **WHEN** `email-agent-mcp configure` or `email-agent-mcp setup` is run in a TTY
+- **AND** neither `--provider` nor `--mailbox` is supplied
+- **AND** more than one mailbox is configured
+- **THEN** the system presents a picker containing each mailbox's email address, provider, exact saved alias, and last-authenticated date
+- **AND** the picker includes an option to add a new mailbox
+
+#### Scenario: Existing mailbox selection preserves routing identity
+- **WHEN** a user selects an existing mailbox from the configure picker
+- **THEN** the system starts authentication with that mailbox's saved provider
+- **AND** passes the exact saved mailbox alias rather than substituting its email address
+
+#### Scenario: Add-new selection uses the setup wizard
+- **WHEN** a user selects add new mailbox from the configure picker
+- **THEN** the system launches the existing provider setup wizard
+
+#### Scenario: Explicit configure intent bypasses the picker
+- **WHEN** `configure` or `setup` is run with `--provider` or `--mailbox`
+- **THEN** the system skips the mailbox picker
+- **AND** runs the existing flag-driven configure behavior
+
+#### Scenario: Automated and specialized configure flows bypass the picker
+- **WHEN** `configure` or `setup` is run outside a TTY
+- **OR** `configure --nemoclaw` is run
+- **THEN** the system skips the mailbox picker
+- **AND** runs the existing configure behavior
+
+#### Scenario: Configure picker cancellation
+- **WHEN** the user cancels the configure mailbox picker
+- **THEN** the system exits successfully without starting authentication
+
+#### Scenario: Direct Gmail configure (broker default)
+- **WHEN** `email-agent-mcp configure --provider gmail` is run without `--client-id`, `--client-secret`, or Gmail BYOK env vars, and the mailbox has no prior saved metadata
+- **THEN** the system contacts the OAuth broker (default `https://oauth.usejunior.com`, override via `--broker-url` or `AGENT_EMAIL_GMAIL_BROKER_URL`)
+- **AND** registers a session at `POST /api/sessions` with a locally-generated `session_id` and the SHA-256 hash of a locally-generated `pickup_secret`
+- **AND** opens the broker's authorization URL in the browser, polls `POST /api/tickets/claim` (presenting the raw `pickup_secret` for proof of ownership), and persists mailbox metadata with `source: 'broker'` once consent completes
+
+#### Scenario: Broker URL must be https (or http loopback)
+- **WHEN** `--broker-url` or `AGENT_EMAIL_GMAIL_BROKER_URL` is set to a non-https URL that is not `http://localhost`, `http://127.0.0.1`, or `http://[::1]`
+- **THEN** the system refuses to use it and surfaces a configuration error
+
+#### Scenario: Direct Gmail configure (BYOK)
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with both `--client-id` and `--client-secret` (or both `AGENT_EMAIL_GMAIL_CLIENT_ID` and `AGENT_EMAIL_GMAIL_CLIENT_SECRET`)
+- **THEN** the system runs a local-loopback OAuth flow against Google directly using those credentials
+- **AND** persists mailbox metadata with `source: 'byok'` containing the supplied client_id and client_secret
+
+#### Scenario: Partial BYOK credentials are rejected
+- **WHEN** `email-agent-mcp configure --provider gmail` is run with exactly one of `--client-id` or `--client-secret` (and the corresponding env var for the other half is unset)
+- **THEN** the system exits non-zero with a message stating that BYOK requires both halves and that omitting both selects the broker
+
+#### Scenario: Reconfigure preserves saved mode
+- **WHEN** `email-agent-mcp configure --provider gmail --mailbox <existing>` is run for a mailbox that already has saved metadata
+- **AND** no explicit `--client-id`/`--client-secret`/`--broker-url` flags or env vars are supplied
+- **THEN** the system reuses the saved mode and credentials (broker URL or BYOK client_id/client_secret) rather than switching modes
+- **AND** existing BYOK users on subsequent reconnects are not silently routed through the broker
+
+#### Scenario: Setup alias
+- **WHEN** `email-agent-mcp setup` is run
+- **THEN** the system behaves identically to `email-agent-mcp configure`

--- a/openspec/changes/add-configure-mailbox-picker/tasks.md
+++ b/openspec/changes/add-configure-mailbox-picker/tasks.md
@@ -1,0 +1,8 @@
+- [x] Route ambiguous interactive `configure` and `setup` commands to a mailbox picker
+- [x] Display email address, provider, exact alias, and last-authenticated date
+- [x] Reauthenticate an existing selection with its saved provider and alias
+- [x] Route the add-new selection through the existing setup wizard
+- [x] Preserve explicit flags, non-TTY behavior, cancellation, and NemoClaw setup
+- [x] Add focused wizard and CLI routing tests
+- [x] Run `openspec validate add-configure-mailbox-picker --strict`
+- [x] Run build, lint, tests, and OpenSpec traceability validation

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -11,6 +11,7 @@ import {
   loadConfig,
   saveConfig,
   isDirectCliRun,
+  shouldShowConfigureMailboxPicker,
 } from './cli.js';
 import { mkdtemp, rm, readFile, symlink } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -1080,6 +1081,43 @@ describe('cli/TTY-Aware Default Behavior', () => {
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining('Unknown command'),
     );
+  });
+});
+
+describe('cli/Configure Mailbox Picker Routing', () => {
+  it('Scenario: Ambiguous configure presents saved mailboxes', () => {
+    const configure = parseCliArgs(['configure']);
+    const setup = parseCliArgs(['setup']);
+
+    expect(shouldShowConfigureMailboxPicker(configure, 2, true)).toBe(true);
+    expect(shouldShowConfigureMailboxPicker(setup, 2, true)).toBe(true);
+    expect(shouldShowConfigureMailboxPicker(configure, 1, true)).toBe(false);
+  });
+
+  it('Scenario: Explicit configure intent bypasses the picker', () => {
+    expect(shouldShowConfigureMailboxPicker(
+      parseCliArgs(['configure', '--provider', 'gmail']),
+      2,
+      true,
+    )).toBe(false);
+    expect(shouldShowConfigureMailboxPicker(
+      parseCliArgs(['configure', '--mailbox', 'personal']),
+      2,
+      true,
+    )).toBe(false);
+  });
+
+  it('Scenario: Automated and specialized configure flows bypass the picker', () => {
+    expect(shouldShowConfigureMailboxPicker(
+      parseCliArgs(['configure']),
+      2,
+      false,
+    )).toBe(false);
+    expect(shouldShowConfigureMailboxPicker(
+      parseCliArgs(['configure', '--nemoclaw']),
+      2,
+      true,
+    )).toBe(false);
   });
 });
 

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -65,6 +65,20 @@ export interface ConfiguredMailboxSummary {
   lastInteractiveAuthAt?: string;
 }
 
+export function shouldShowConfigureMailboxPicker(
+  opts: CliOptions,
+  mailboxCount: number,
+  isTTY = Boolean(process.stdout.isTTY),
+): boolean {
+  return (
+    isTTY &&
+    mailboxCount > 1 &&
+    !opts.provider &&
+    !opts.mailbox &&
+    !opts.nemoclaw
+  );
+}
+
 /**
  * Get the config file path: ~/.email-agent-mcp/config.json
  */
@@ -475,8 +489,16 @@ export async function runCli(args: string[]): Promise<number> {
     case 'watch':
       return await runWatch(opts);
     case 'setup':
-    case 'configure':
+    case 'configure': {
+      if (process.stdout.isTTY && !opts.provider && !opts.mailbox && !opts.nemoclaw) {
+        const mailboxes = await listConfiguredMailboxSummaries();
+        if (shouldShowConfigureMailboxPicker(opts, mailboxes.length)) {
+          const { runWizardConfigurePicker } = await import('./wizard.js');
+          return await runWizardConfigurePicker(opts, mailboxes);
+        }
+      }
       return await runConfigure(opts);
+    }
     case 'status':
       return await runStatus();
     case 'token':

--- a/packages/email-mcp/src/wizard.test.ts
+++ b/packages/email-mcp/src/wizard.test.ts
@@ -99,7 +99,7 @@ describe('wizard/Reconnect Picker', () => {
     };
     const gmail: ConfiguredMailboxSummary = {
       provider: 'gmail',
-      mailboxName: 'user@gmail.com',
+      mailboxName: 'personal',
       emailAddress: 'user@gmail.com',
     };
 
@@ -113,7 +113,7 @@ describe('wizard/Reconnect Picker', () => {
     expect(cliMockState.runConfigureCalls).toHaveLength(1);
     expect(cliMockState.runConfigureCalls[0]).toMatchObject({
       provider: 'gmail',
-      mailbox: 'user@gmail.com',
+      mailbox: 'personal',
     });
   });
 
@@ -176,6 +176,94 @@ describe('wizard/Reconnect Picker', () => {
       provider: 'microsoft',
       mailbox: 'default',
     });
+  });
+});
+
+describe('wizard/Configure Mailbox Picker', () => {
+  beforeEach(() => {
+    promptMockState.selectResults = [];
+    promptMockState.confirmResults = [];
+    promptMockState.textResults = [];
+    promptMockState.passwordResults = [];
+    promptMockState.confirmResult = false;
+    promptMockState.textResult = '';
+    promptMockState.passwordResult = '';
+    cliMockState.runConfigureCalls = [];
+    cliMockState.runConfigureResult = 0;
+    vi.clearAllMocks();
+  });
+
+  it('Scenario: Existing mailbox selection preserves routing identity', async () => {
+    const work: ConfiguredMailboxSummary = {
+      provider: 'microsoft',
+      mailboxName: 'work',
+      emailAddress: 'user@contoso.com',
+      lastInteractiveAuthAt: '2026-01-12T10:00:00.000Z',
+    };
+    const personal: ConfiguredMailboxSummary = {
+      provider: 'gmail',
+      mailboxName: 'personal',
+      emailAddress: 'user@gmail.com',
+      lastInteractiveAuthAt: '2025-11-03T10:00:00.000Z',
+    };
+    promptMockState.selectResults = [personal];
+
+    const { runWizardConfigurePicker } = await import('./wizard.js');
+    const exit = await runWizardConfigurePicker(
+      { command: 'configure' },
+      [work, personal],
+    );
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toEqual([
+      expect.objectContaining({
+        command: 'configure',
+        provider: 'gmail',
+        mailbox: 'personal',
+      }),
+    ]);
+
+    const clackPrompts = await import('@clack/prompts');
+    const picker = vi.mocked(clackPrompts.select).mock.calls[0]?.[0];
+    const labels = picker?.options.map(option => option.label);
+    expect(labels).toEqual(expect.arrayContaining([
+      expect.stringContaining('user@contoso.com (microsoft, alias: work, last auth:'),
+      expect.stringContaining('user@gmail.com (gmail, alias: personal, last auth:'),
+      'Add a new mailbox',
+    ]));
+  });
+
+  it('Scenario: Add-new selection uses the setup wizard', async () => {
+    const mailboxes: ConfiguredMailboxSummary[] = [
+      { provider: 'microsoft', mailboxName: 'work' },
+      { provider: 'gmail', mailboxName: 'personal' },
+    ];
+    promptMockState.selectResults = ['add-new-mailbox', 'microsoft'];
+    promptMockState.confirmResults = [false];
+
+    const { runWizardConfigurePicker } = await import('./wizard.js');
+    const exit = await runWizardConfigurePicker({ command: 'setup' }, mailboxes);
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(0);
+    const clackPrompts = await import('@clack/prompts');
+    expect(vi.mocked(clackPrompts.select)).toHaveBeenCalledTimes(2);
+  });
+
+  it('Scenario: Configure picker cancellation', async () => {
+    promptMockState.selectResults = [CANCEL_TOKEN];
+
+    const { runWizardConfigurePicker } = await import('./wizard.js');
+    const exit = await runWizardConfigurePicker(
+      { command: 'configure' },
+      [
+        { provider: 'microsoft', mailboxName: 'work' },
+        { provider: 'gmail', mailboxName: 'personal' },
+      ],
+    );
+
+    expect(exit).toBe(0);
+    expect(cliMockState.runConfigureCalls).toHaveLength(0);
   });
 });
 

--- a/packages/email-mcp/src/wizard.ts
+++ b/packages/email-mcp/src/wizard.ts
@@ -5,6 +5,16 @@ import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import type { CliOptions, ConfiguredMailboxSummary } from './cli.js';
 
+const ADD_NEW_MAILBOX = 'add-new-mailbox';
+
+function formatMailboxOption(mailbox: ConfiguredMailboxSummary): string {
+  const email = mailbox.emailAddress ?? mailbox.mailboxName;
+  const lastAuth = mailbox.lastInteractiveAuthAt
+    ? new Date(mailbox.lastInteractiveAuthAt).toLocaleDateString()
+    : 'unknown';
+  return `${email} (${mailbox.provider}, alias: ${mailbox.mailboxName}, last auth: ${lastAuth})`;
+}
+
 /**
  * First-run wizard — guides user through email setup.
  */
@@ -220,6 +230,47 @@ export async function runWizardSetup(opts: CliOptions): Promise<number> {
 }
 
 /**
+ * Configure entrypoint for returning users with multiple saved mailboxes.
+ */
+export async function runWizardConfigurePicker(
+  opts: CliOptions,
+  mailboxes: ConfiguredMailboxSummary[],
+): Promise<number> {
+  const { runConfigure } = await import('./cli.js');
+
+  p.intro('🦞 email-agent-mcp — Reauthenticate a mailbox');
+
+  const picked = await p.select<ConfiguredMailboxSummary | typeof ADD_NEW_MAILBOX>({
+    message: 'Which mailbox do you want to (re)authenticate?',
+    options: [
+      ...mailboxes.map(mailbox => ({
+        value: mailbox,
+        label: formatMailboxOption(mailbox),
+      })),
+      {
+        value: ADD_NEW_MAILBOX,
+        label: 'Add a new mailbox',
+      },
+    ],
+  });
+
+  if (p.isCancel(picked)) {
+    p.outro('Configuration cancelled.');
+    return 0;
+  }
+
+  if (picked === ADD_NEW_MAILBOX) {
+    return await runWizardSetup(opts);
+  }
+
+  return await runConfigure({
+    ...opts,
+    provider: picked.provider,
+    mailbox: picked.mailboxName,
+  });
+}
+
+/**
  * Returning user menu — show status and offer actions.
  */
 export async function runWizardMenu(opts: CliOptions, mailboxes: ConfiguredMailboxSummary[]): Promise<number> {
@@ -309,13 +360,9 @@ export async function runWizardMenu(opts: CliOptions, mailboxes: ConfiguredMailb
         const picked = await p.select<ConfiguredMailboxSummary>({
           message: 'Which mailbox do you want to reconnect?',
           options: mailboxes.map(mb => {
-            const email = mb.emailAddress ?? mb.mailboxName;
-            const lastAuth = mb.lastInteractiveAuthAt
-              ? new Date(mb.lastInteractiveAuthAt).toLocaleDateString()
-              : 'unknown';
             return {
               value: mb,
-              label: `${email} (${mb.provider}, last auth: ${lastAuth})`,
+              label: formatMailboxOption(mb),
             };
           }),
         });
@@ -329,7 +376,7 @@ export async function runWizardMenu(opts: CliOptions, mailboxes: ConfiguredMailb
       return await runConfigure({
         ...opts,
         provider: target.provider,
-        mailbox: target.emailAddress ?? target.mailboxName,
+        mailbox: target.mailboxName,
       });
     }
 


### PR DESCRIPTION
## Summary
- add a TTY-only mailbox picker for ambiguous `configure` / `setup` commands with multiple saved accounts
- show email, provider, exact alias, and last-auth date, with an add-new option
- preserve explicit flags, non-TTY behavior, and NemoClaw setup; dispatch existing accounts with their exact saved alias
- reuse the improved alias-preserving label/dispatch behavior in the returning-user reconnect menu
- add and complete the `add-configure-mailbox-picker` OpenSpec change

## Validation
- `npm run build`
- `npm run test:run` (957 Vitest tests + 4 Node smoke-script tests)
- `npm run lint`
- `npm run check:spec-coverage` (262/262)
- `npx openspec validate add-configure-mailbox-picker --strict`

Closes #37