### PR TITLE
fix(gmail): request narrow modify scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,11 +252,13 @@ verification status, and no dependency on the hosted broker at
 Agent Email requests exactly one Gmail scope:
 
 ```text
-https://mail.google.com/
+https://www.googleapis.com/auth/gmail.modify
 ```
 
-This is a restricted scope covering read, send, modify, and delete. It is the
-single scope you add to your own OAuth consent screen.
+This is the narrowest Gmail scope that covers Agent Email's read, compose,
+send, label, and soft-delete-to-trash behavior. It does not permit immediate,
+permanent deletion. It is the single scope you add to your own OAuth consent
+screen.
 
 ### BYOK: create your own Google OAuth client
 
@@ -266,7 +268,7 @@ single scope you add to your own OAuth consent screen.
 3. **Configure the OAuth consent screen** under *APIs & Services → OAuth consent screen*:
    - User type **External** for a personal `@gmail.com` account, or **Internal**
      if you are on Google Workspace and only your own org needs access.
-   - Add the scope `https://mail.google.com/`.
+   - Add the scope `https://www.googleapis.com/auth/gmail.modify`.
    - While the app is in *Testing*, add your own Gmail address under **Test users**,
      or consent will be refused.
 4. **Create the OAuth client** under *APIs & Services → Credentials → Create

--- a/apps/oauth-broker/README.md
+++ b/apps/oauth-broker/README.md
@@ -60,7 +60,7 @@ by `Map.delete` between awaits is effectively atomic.
 4. Optional:
 
    ```
-   GMAIL_OAUTH_SCOPES=https://mail.google.com/    # default
+   GMAIL_OAUTH_SCOPES=https://www.googleapis.com/auth/gmail.modify    # default
    BROKER_TICKET_TTL_MS=300000                    # 5 min, default
    BROKER_REQUIRE_KV=true                         # force-fail without Redis even outside prod
    ```
@@ -77,10 +77,15 @@ by `Map.delete` between awaits is effectively atomic.
 ## Verification
 
 `https://<your-broker-domain>` must complete Google's OAuth verification
-flow including **CASA Tier 2** for the restricted `https://mail.google.com/`
-scope. Per Google's restricted-scope policy, running a server in the
-auth path (relay or otherwise) does not reduce the assessment scope —
-plan accordingly.
+flow for the restricted
+`https://www.googleapis.com/auth/gmail.modify` scope. Per Google's
+restricted-scope policy, transmitting restricted-scope data through a server
+requires a security assessment; running a server in the auth path does not
+remove that requirement.
+
+If an existing deployment explicitly sets `GMAIL_OAUTH_SCOPES`, update the
+environment value to `https://www.googleapis.com/auth/gmail.modify` before
+submitting the OAuth app for verification.
 
 ## Operational notes (deferred to follow-up PRs)
 

--- a/apps/oauth-broker/api/routes.test.ts
+++ b/apps/oauth-broker/api/routes.test.ts
@@ -107,6 +107,9 @@ describe('provider-gmail/OAuth2 Authentication (broker routes)', () => {
       expect(captured.redirect).toBeDefined();
       expect(captured.redirect).toContain('accounts.google.com');
       expect(captured.redirect).toContain(`state=${sessionId}`);
+      expect(new URL(captured.redirect!).searchParams.get('scope')).toBe(
+        'https://www.googleapis.com/auth/gmail.modify',
+      );
     }
 
     // 3. GET /api/callback exchanges code for tokens. Stub Google's response.
@@ -117,7 +120,7 @@ describe('provider-gmail/OAuth2 Authentication (broker routes)', () => {
           access_token: 'broker-access',
           refresh_token: 'broker-refresh',
           expires_in: 3600,
-          scope: 'https://mail.google.com/',
+          scope: 'https://www.googleapis.com/auth/gmail.modify',
           token_type: 'Bearer',
         }),
         { status: 200, headers: { 'content-type': 'application/json' } },

--- a/apps/oauth-broker/lib/config.test.ts
+++ b/apps/oauth-broker/lib/config.test.ts
@@ -29,6 +29,12 @@ afterEach(() => {
 });
 
 describe('provider-gmail/OAuth2 Authentication (broker config)', () => {
+  it('defaults to the narrow Gmail modify scope', () => {
+    expect(getConfig().scopes).toEqual([
+      'https://www.googleapis.com/auth/gmail.modify',
+    ]);
+  });
+
   it('Scenario: Broker requires Redis in production', () => {
     // VERCEL_ENV=production with no KV_REST_API_URL must fail fast rather
     // than silently falling back to in-memory state that is not shared

--- a/apps/oauth-broker/lib/config.ts
+++ b/apps/oauth-broker/lib/config.ts
@@ -42,7 +42,10 @@ export function getConfig(): BrokerConfig {
     clientId,
     clientSecret,
     redirectUri,
-    scopes: (process.env['GMAIL_OAUTH_SCOPES'] ?? 'https://mail.google.com/').split(/\s+/).filter(Boolean),
+    scopes: (
+      process.env['GMAIL_OAUTH_SCOPES'] ??
+      'https://www.googleapis.com/auth/gmail.modify'
+    ).split(/\s+/).filter(Boolean),
     ticketTtlMs: Number(process.env['BROKER_TICKET_TTL_MS'] ?? 5 * 60 * 1000),
     useKv,
     brokerOrigin,

--- a/openspec/changes/narrow-gmail-oauth-scope/proposal.md
+++ b/openspec/changes/narrow-gmail-oauth-scope/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The Gmail provider requests `https://mail.google.com/`, even though its delete
+operation only moves messages to trash and it never performs immediate,
+permanent deletion. Google reserves that broad scope for apps that require
+permanent deletion and requires verification submissions to request the
+narrowest scope that satisfies implemented functionality.
+
+`https://www.googleapis.com/auth/gmail.modify` covers the provider's actual
+read, compose, send, label, and trash behavior without granting permanent
+deletion. Narrowing the scope removes an avoidable OAuth verification blocker.
+
+## What Changes
+
+- Change the Gmail provider's default OAuth scope to `gmail.modify`.
+- Change the hosted OAuth broker's default scope to the same value.
+- Test both direct/BYOK and broker authorization requests.
+- Update Gmail setup and broker deployment documentation.
+- Preserve existing refresh-token metadata; new and repeated authorizations
+  request the narrower grant.
+
+## Impact
+
+- Affected spec: `provider-gmail`
+- Affected code: `packages/provider-gmail` and `apps/oauth-broker`
+- Affected docs: root Gmail setup and provider/broker READMEs
+- Operational note: deployments that explicitly set `GMAIL_OAUTH_SCOPES` must
+  update that environment value before verification submission.

--- a/openspec/changes/narrow-gmail-oauth-scope/specs/provider-gmail/spec.md
+++ b/openspec/changes/narrow-gmail-oauth-scope/specs/provider-gmail/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: OAuth2 Authentication
+
+The system SHALL authenticate to Gmail via OAuth2 using `@googleapis/gmail`
+(NOT the full `googleapis` package at 200MB). It SHALL request
+`https://www.googleapis.com/auth/gmail.modify` as its sole default Gmail scope
+because the provider reads, composes, sends, labels, and moves messages to
+trash, but does not permanently delete messages.
+
+#### Scenario: Gmail OAuth
+- **WHEN** `configure_mailbox` is called with `{provider: "gmail"}`
+- **THEN** the system initiates OAuth2 flow and persists refresh tokens
+
+#### Scenario: Gmail OAuth requests the narrowest implemented scope
+- **WHEN** the direct/BYOK flow or hosted broker builds a Google authorization URL
+- **THEN** it requests `https://www.googleapis.com/auth/gmail.modify`
+- **AND** it does not request `https://mail.google.com/`
+
+#### Scenario: Gmail OAuth via hosted broker
+- **WHEN** Gmail configure is started without explicit client credentials and no broker override
+- **THEN** the CLI generates a fresh `session_id` and a private `pickup_secret`, registers the session at `POST /api/sessions` with the SHA-256 hash of the secret, opens the browser at `GET /api/start?session=<id>`, and waits for tokens at `POST /api/tickets/claim` (presenting the raw `pickup_secret` as proof of ownership)
+- **AND** the broker exchanges Google's authorization code for tokens server-side using its held `client_secret`
+- **AND** the CLI never possesses, persists, or sees the broker's `client_secret`
+- **AND** subsequent Gmail API calls go directly from the user's machine to Google with the locally-held access token
+
+#### Scenario: Public session_id is not a bearer credential
+- **WHEN** anyone other than the originating CLI possesses a `session_id` (e.g. via browser history or server logs)
+- **THEN** they cannot exchange that `session_id` for tokens
+- **AND** the broker requires the matching `pickup_secret` (compared in constant time against the registered SHA-256 hash) before releasing tokens
+
+#### Scenario: Atomic one-shot ticket claim
+- **WHEN** two `POST /api/tickets/claim` calls present a valid `session_id` + `pickup_secret` pair concurrently
+- **THEN** at most one returns the tokens; the other returns 410 (`consumed` or `not_found`)
+- **AND** on KV-backed deployments this atomicity is implemented with a single Redis `GETDEL` command after constant-time secret verification
+
+#### Scenario: Distinguishable terminal states
+- **WHEN** the CLI polls `/api/tickets/claim` while the user has not yet completed consent
+- **THEN** the broker returns 202 `{status: "pending"}`
+- **WHEN** the user denies consent on Google's screen
+- **THEN** the broker advances the session to `denied` and subsequent claim returns 410 `{status: "denied", error_description: ...}`
+- **WHEN** Google's token exchange fails server-side
+- **THEN** the broker advances the session to `exchange_failed` and subsequent claim returns 410 `{status: "exchange_failed", error_description: ...}`
+- **WHEN** the session has expired
+- **THEN** subsequent claim returns 410 `{status: "expired"}`
+
+#### Scenario: Gmail OAuth via BYOK
+- **WHEN** Gmail configure is started with explicit `client_id` and `client_secret`
+- **THEN** the system runs a local-loopback OAuth flow against Google directly without involving the broker
+- **AND** persists the BYOK credentials in the mailbox metadata for future refreshes
+
+#### Scenario: Broker-mode refresh routes through the broker
+- **WHEN** an access token needs to be refreshed for a broker-mode Gmail mailbox
+- **THEN** the CLI POSTs the refresh token to the broker's `/api/refresh` endpoint
+- **AND** the underlying `OAuth2Client` is configured so its built-in `refreshAccessTokenAsync()` path is NOT reachable: the `refresh_token` is not stored on `oauth2Client.credentials`, an `expiry_date` is always set on `oauth2Client.credentials` whenever an access token is present, and `refreshHandler` proxies to the broker
+- **AND** byok-mode mailboxes refresh directly via Google's token endpoint using the stored `client_id` and `client_secret`
+
+#### Scenario: Broker requires Redis in production
+- **WHEN** the broker starts with `VERCEL_ENV=production` (or `BROKER_REQUIRE_KV=true`) and `KV_REST_API_URL` is unset
+- **THEN** the broker fails fast with a configuration error rather than silently falling back to in-memory state that is not shared across function invocations

--- a/openspec/changes/narrow-gmail-oauth-scope/tasks.md
+++ b/openspec/changes/narrow-gmail-oauth-scope/tasks.md
@@ -1,0 +1,6 @@
+- [x] Change the Gmail provider default to `gmail.modify`
+- [x] Change and test the OAuth broker default
+- [x] Verify direct and broker authorization URLs request the narrow scope
+- [x] Update root, provider, and broker documentation
+- [x] Run `openspec validate narrow-gmail-oauth-scope --strict`
+- [x] Run build, lint, tests, and OpenSpec traceability validation

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -722,7 +722,7 @@ describe('cli/Gmail Configure', () => {
       redirectUri: 'http://127.0.0.1:62018/oauth2callback',
       codeChallenge: 'mock-code-challenge',
       loginHint: 'steven.obiajulu@gmail.com',
-      scopes: ['https://mail.google.com/'],
+      scopes: ['https://www.googleapis.com/auth/gmail.modify'],
     });
 
     const allowlistPath = await getEffectiveSendAllowlistPath();

--- a/packages/provider-gmail/README.md
+++ b/packages/provider-gmail/README.md
@@ -64,7 +64,8 @@ The simplest path is Google's OAuth 2.0 Playground using your own client credent
 1. Open `https://developers.google.com/oauthplayground/`.
 2. Click the gear icon and enable "Use your own OAuth credentials".
 3. Paste your Google `client_id` and `client_secret`.
-4. Authorize the Gmail scope `https://mail.google.com/`.
+4. Authorize the Gmail scope
+   `https://www.googleapis.com/auth/gmail.modify`.
 5. Exchange the authorization code for tokens.
 6. Copy the returned `refresh_token`.
 

--- a/packages/provider-gmail/src/auth.test.ts
+++ b/packages/provider-gmail/src/auth.test.ts
@@ -74,7 +74,7 @@ describe('provider-gmail/OAuth2 Authentication', () => {
     await expect(auth.connect({})).rejects.toThrow('access_token or refresh_token');
   });
 
-  it('Scenario: generateAuthUrl returns OAuth2 URL with Gmail scope and PKCE', async () => {
+  it('Scenario: Gmail OAuth requests the narrowest implemented scope', async () => {
     const auth = new GmailAuthManager({
       clientId: 'test-client',
       clientSecret: 'test-secret',
@@ -89,6 +89,10 @@ describe('provider-gmail/OAuth2 Authentication', () => {
     });
 
     expect(url).toContain('accounts.google.com');
+    expect(GMAIL_OAUTH_SCOPES).toEqual([
+      'https://www.googleapis.com/auth/gmail.modify',
+    ]);
+    expect(url).not.toContain(encodeURIComponent('https://mail.google.com/'));
     expect(auth.getOAuth2Client().generateAuthUrl).toHaveBeenCalledWith({
       access_type: 'offline',
       include_granted_scopes: true,

--- a/packages/provider-gmail/src/auth.ts
+++ b/packages/provider-gmail/src/auth.ts
@@ -68,7 +68,9 @@ export interface GmailProfile {
   threadsTotal?: number;
 }
 
-export const GMAIL_OAUTH_SCOPES = ['https://mail.google.com/'];
+export const GMAIL_OAUTH_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.modify',
+];
 
 function collectAuthErrorStrings(err: unknown): string[] {
   const values = new Set<string>();


### PR DESCRIPTION
## Summary
- replace the permanent-delete `https://mail.google.com/` default with `https://www.googleapis.com/auth/gmail.modify`
- align direct/BYOK and hosted-broker authorization requests and tests
- document the narrower read/compose/send/modify scope and the broker environment update required before verification
- add and complete the `narrow-gmail-oauth-scope` OpenSpec change

## Why
The provider only moves messages to trash; it never calls Gmail's immediate permanent-delete APIs. Google's verification guidance requires the narrowest implemented scope and reserves `mail.google.com` for permanent deletion.

## Validation
- `npm run build`
- `npm run test:run` (958 Vitest tests + 4 Node smoke-script tests)
- `npm run lint`
- `npm run check:spec-coverage` (262/262)
- `npx openspec validate narrow-gmail-oauth-scope --strict`

Closes #139
Prerequisite for #112