### PR TITLE
fix(oauth-video): match published scopes as exact tokens

### DIFF
--- a/tools/oauth-verification-video/scripts/live/public-artifact.mjs
+++ b/tools/oauth-verification-video/scripts/live/public-artifact.mjs
@@ -11,6 +11,7 @@ import {join} from 'node:path';
 
 const EXPECTED_SCOPE = 'https://www.googleapis.com/auth/gmail.modify';
 const LEGACY_SCOPE = 'https://mail.google.com/';
+const URL_TOKEN = /https:\/\/[A-Za-z0-9./_-]+/g;
 
 function filesBelow(root) {
   const files = [];
@@ -24,10 +25,11 @@ function filesBelow(root) {
 }
 
 export function validatePublishedScopeText(text) {
-  if (!text.includes(EXPECTED_SCOPE)) {
+  const urls = new Set(text.match(URL_TOKEN) ?? []);
+  if (!urls.has(EXPECTED_SCOPE)) {
     throw new Error(`Published Gmail provider does not contain ${EXPECTED_SCOPE}`);
   }
-  if (text.includes(LEGACY_SCOPE)) {
+  if (urls.has(LEGACY_SCOPE)) {
     throw new Error(`Published Gmail provider still contains legacy scope ${LEGACY_SCOPE}`);
   }
   return true;

--- a/tools/oauth-verification-video/test/live-recording.node-test.mjs
+++ b/tools/oauth-verification-video/test/live-recording.node-test.mjs
@@ -137,6 +137,18 @@ test('published artifact scope check rejects the legacy broad scope', () => {
     ),
     /legacy scope/,
   );
+  assert.equal(
+    validatePublishedScopeText(
+      'https://www.googleapis.com/auth/gmail.modify https://attacker.example/https://mail.google.com/',
+    ),
+    true,
+  );
+  assert.equal(
+    validatePublishedScopeText(
+      'https://www.googleapis.com/auth/gmail.modify https://mail.google.com/.attacker.example',
+    ),
+    true,
+  );
 });
 
 test('take paths never overwrite and usable duration includes inMs', () => {


### PR DESCRIPTION
## Summary
- replace URL substring checks in the public Gmail artifact scanner with exact extracted-URL token matching
- add adversarial host-prefix and host-suffix cases for the legacy Gmail scope

## Validation
- focused OAuth video suite: 26 tests passed

Follow-up to #148. Resolves the external CodeQL alert reported on that merge. Supersedes #149, which retained conflicting pre-squash history.