### PR TITLE
fix(oauth-video): verify published dependency chain

### DIFF
--- a/tools/oauth-verification-video/scripts/live/public-artifact.mjs
+++ b/tools/oauth-verification-video/scripts/live/public-artifact.mjs
@@ -35,26 +35,64 @@ export function validatePublishedScopeText(text) {
   return true;
 }
 
+function readPublishedDependency(exec, packageSpec, dependencyName) {
+  const raw = exec(
+    'npm',
+    ['view', packageSpec, `dependencies.${dependencyName}`, '--json'],
+    {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']},
+  ).trim();
+  if (!raw) {
+    throw new Error(`Published ${packageSpec} does not depend on ${dependencyName}`);
+  }
+  const dependency = JSON.parse(raw);
+  if (typeof dependency !== 'string') {
+    throw new Error(`Published ${packageSpec} has an invalid ${dependencyName} dependency`);
+  }
+  return dependency;
+}
+
+function requireLockstepRange(packageSpec, dependencyName, range, packageVersion) {
+  if (![packageVersion, `^${packageVersion}`, `~${packageVersion}`].includes(range)) {
+    throw new Error(
+      `Published ${packageSpec} must use the release version of ${dependencyName}; found ${range}`,
+    );
+  }
+}
+
+export function resolvePublishedGmailProviderVersion(
+  packageVersion,
+  {exec = execFileSync} = {},
+) {
+  const cliSpec = `email-agent-mcp@${packageVersion}`;
+  const mcpRange = readPublishedDependency(
+    exec,
+    cliSpec,
+    '@usejunior/email-mcp',
+  );
+  requireLockstepRange(cliSpec, '@usejunior/email-mcp', mcpRange, packageVersion);
+
+  const mcpSpec = `@usejunior/email-mcp@${packageVersion}`;
+  const gmailRange = readPublishedDependency(
+    exec,
+    mcpSpec,
+    '@usejunior/provider-gmail',
+  );
+  requireLockstepRange(
+    mcpSpec,
+    '@usejunior/provider-gmail',
+    gmailRange,
+    packageVersion,
+  );
+  return packageVersion;
+}
+
 export function inspectPublicArtifact(
   packageVersion,
   {exec = execFileSync} = {},
 ) {
   const temporary = mkdtempSync(join(tmpdir(), 'email-agent-oauth-release-'));
   try {
-    const dependencyRaw = exec(
-      'npm',
-      [
-        'view',
-        `email-agent-mcp@${packageVersion}`,
-        'dependencies.@usejunior/provider-gmail',
-        '--json',
-      ],
-      {encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe']},
-    ).trim();
-    const dependency = JSON.parse(dependencyRaw);
-    if (typeof dependency !== 'string' || !/^\d+\.\d+\.\d+(?:-.+)?$/.test(dependency)) {
-      throw new Error('Published email-agent-mcp must pin an exact @usejunior/provider-gmail version');
-    }
+    const dependency = resolvePublishedGmailProviderVersion(packageVersion, {exec});
 
     const archiveRaw = exec(
       'npm',

--- a/tools/oauth-verification-video/test/live-recording.node-test.mjs
+++ b/tools/oauth-verification-video/test/live-recording.node-test.mjs
@@ -18,7 +18,10 @@ import {
 } from '../scripts/live/commands.mjs';
 import {validateRecordingConfig} from '../scripts/live/config.mjs';
 import {buildLiveOperatorScript} from '../scripts/live/operator-script.mjs';
-import {validatePublishedScopeText} from '../scripts/live/public-artifact.mjs';
+import {
+  resolvePublishedGmailProviderVersion,
+  validatePublishedScopeText,
+} from '../scripts/live/public-artifact.mjs';
 import {
   uniqueTakePath,
   verifyUsableDuration,
@@ -148,6 +151,50 @@ test('published artifact scope check rejects the legacy broad scope', () => {
       'https://www.googleapis.com/auth/gmail.modify https://mail.google.com/.attacker.example',
     ),
     true,
+  );
+});
+
+test('published artifact follows the CLI dependency chain for the lockstep Gmail release', () => {
+  const calls = [];
+  const exec = (_command, args) => {
+    calls.push(args);
+    if (args[0] === 'view' && args[1] === 'email-agent-mcp@0.1.10') {
+      return '"^0.1.10"\n';
+    }
+    if (args[0] === 'view' && args[1] === '@usejunior/email-mcp@0.1.10') {
+      return '"^0.1.10"\n';
+    }
+    throw new Error(`Unexpected command: ${args.join(' ')}`);
+  };
+
+  assert.equal(
+    resolvePublishedGmailProviderVersion('0.1.10', {exec}),
+    '0.1.10',
+  );
+  assert.deepEqual(calls, [
+    [
+      'view',
+      'email-agent-mcp@0.1.10',
+      'dependencies.@usejunior/email-mcp',
+      '--json',
+    ],
+    [
+      'view',
+      '@usejunior/email-mcp@0.1.10',
+      'dependencies.@usejunior/provider-gmail',
+      '--json',
+    ],
+  ]);
+
+  assert.throws(
+    () => resolvePublishedGmailProviderVersion('0.1.10', {
+      exec: (_command, args) => (
+        args[1] === 'email-agent-mcp@0.1.10'
+          ? '"latest"\n'
+          : '"^0.1.10"\n'
+      ),
+    }),
+    /must use the release version/,
   );
 });
 


### PR DESCRIPTION
## Summary
- follow the canonical CLI → email-mcp → Gmail provider dependency chain
- require every link to reference the lockstep release version
- verify the actual Gmail provider tarball used by the public release

## Verification
- `npm run test:oauth-video` (27 passing)
- live public artifact inspection for `email-agent-mcp@0.1.10` passes and resolves `@usejunior/provider-gmail@0.1.10`