### PR TITLE
docs(readme): document body_file frontmatter and unsanitised html passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,17 +199,20 @@ accept an optional `format`:
 | `html` | Passthrough — your HTML is sent as-is. |
 | `text` | No rendering; sent as plain text. |
 
-`html` is unsanitised passthrough: no sanitiser, no allowlist, no rewriting.
-Your markup and inline CSS reach the wire byte-for-byte — that is what makes
-styled mail possible, and it means you own whatever you send.
+`html` is unsanitised passthrough: no sanitiser, no allowlist, no rewriting of
+your markup. Inline CSS and arbitrary tags survive to the wire — that is what
+makes styled mail possible, and it means you own whatever you send. The one
+default modification is the force-black wrapper below; with `force_black:
+false` the body passes through byte-for-byte.
 
 For `markdown` and `html` the rendered HTML is wrapped in a
 `<div style="color: #000000;">` so Outlook's dark mode does not turn the text
 white-on-white.
 
 **Body files** — `send_email`, `create_draft`, and `update_draft` also accept
-`body_file`: a path to a `.md`, `.html`, or `.txt` file — sandboxed to the
-working directory — used as the body instead of `body`. A `.md` body file may
+`body_file`: a path to a `.md`, `.html`, or `.txt` file (read relative to
+`EMAIL_MCP_SAFE_DIR`, default the process working directory) used as the body
+instead of `body`. A `.md` body file may
 open with a YAML frontmatter block:
 
 ```md
@@ -225,9 +228,9 @@ force_black: false
 Recognized keys are `to`, `cc`, `subject`, `reply_to`, `draft`, `format`, and
 `force_black` (`draft: true` turns a `send_email` call into a draft save). A
 frontmatter value overrides the same-named tool parameter. Frontmatter is
-parsed only from `.md` files, and the file extension never sets the format —
-a `.html` body file is still rendered as markdown unless `format: "html"`
-accompanies it as a tool parameter.
+parsed only from `.md` files, and the file extension never selects the format —
+without an explicit `format` tool parameter, even a `.html` body file gets the
+default markdown rendering; pass `format: "html"` for passthrough.
 
 **Reading** — `read_email` accepts an optional `format` of `markdown` (default)
 or `html`:

--- a/README.md
+++ b/README.md
@@ -199,9 +199,35 @@ accept an optional `format`:
 | `html` | Passthrough — your HTML is sent as-is. |
 | `text` | No rendering; sent as plain text. |
 
+`html` is unsanitised passthrough: no sanitiser, no allowlist, no rewriting.
+Your markup and inline CSS reach the wire byte-for-byte — that is what makes
+styled mail possible, and it means you own whatever you send.
+
 For `markdown` and `html` the rendered HTML is wrapped in a
 `<div style="color: #000000;">` so Outlook's dark mode does not turn the text
 white-on-white.
+
+**Body files** — `send_email`, `create_draft`, and `update_draft` also accept
+`body_file`: a path to a `.md`, `.html`, or `.txt` file — sandboxed to the
+working directory — used as the body instead of `body`. A `.md` body file may
+open with a YAML frontmatter block:
+
+```md
+---
+to: alex@example.com
+subject: Quarterly summary
+format: html
+force_black: false
+---
+<p>The body starts after the closing delimiter.</p>
+```
+
+Recognized keys are `to`, `cc`, `subject`, `reply_to`, `draft`, `format`, and
+`force_black` (`draft: true` turns a `send_email` call into a draft save). A
+frontmatter value overrides the same-named tool parameter. Frontmatter is
+parsed only from `.md` files, and the file extension never sets the format —
+a `.html` body file is still rendered as markdown unless `format: "html"`
+accompanies it as a tool parameter.
 
 **Reading** — `read_email` accepts an optional `format` of `markdown` (default)
 or `html`:

--- a/packages/email-agent-mcp-scoped/README.md
+++ b/packages/email-agent-mcp-scoped/README.md
@@ -16,8 +16,8 @@ package.
 
 The compose tools (`send_email`, `reply_to_email`, `create_draft`,
 `update_draft`) accept an optional `format`: `markdown` (default, rendered as
-GFM), `html` (unsanitised passthrough — your markup and inline CSS go to the
-wire as-is), or `text` — plus `force_black` (default true), which wraps
+GFM), `html` (unsanitised passthrough — your markup and inline CSS are not
+sanitised or rewritten), or `text` — plus `force_black` (default true), which wraps
 rendered HTML in a `<div style="color: #000000;">` so Outlook dark mode does
 not hide the text. `read_email` accepts `format: "html"` to return the
 message's raw body HTML instead of the markdown default. When writing raw HTML

--- a/packages/email-agent-mcp-scoped/README.md
+++ b/packages/email-agent-mcp-scoped/README.md
@@ -11,3 +11,18 @@ npx -y email-agent-mcp
 Both package names are published from the same release and resolve to the same
 CLI and MCP server implementation. New installations should use the unscoped
 package.
+
+## Body formats
+
+The compose tools (`send_email`, `reply_to_email`, `create_draft`,
+`update_draft`) accept an optional `format`: `markdown` (default, rendered as
+GFM), `html` (unsanitised passthrough — your markup and inline CSS go to the
+wire as-is), or `text` — plus `force_black` (default true), which wraps
+rendered HTML in a `<div style="color: #000000;">` so Outlook dark mode does
+not hide the text. `read_email` accepts `format: "html"` to return the
+message's raw body HTML instead of the markdown default. When writing raw HTML
+back, pass `format: "html"` **and** `force_black: false` — otherwise each
+round trip nests another force-black wrapper.
+
+See the [`email-agent-mcp` package README](https://www.npmjs.com/package/email-agent-mcp)
+for the full tool reference.

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -120,9 +120,10 @@ optional `attachments` array — each entry is a sandboxed file `path` or inline
 
 Bodies cross the wire as markdown by default in both directions, because markdown
 is token-efficient. Both directions can opt out. The four compose tools above take
-a `format` of `markdown` (default, rendered as GFM), `html` (passthrough), or
-`text`, plus `force_black` (default true) which wraps rendered HTML in a
-force-black div so Outlook dark mode does not hide the text.
+a `format` of `markdown` (default, rendered as GFM), `html` (unsanitised
+passthrough — your markup goes to the wire as-is), or `text`, plus
+`force_black` (default true) which wraps rendered HTML in a force-black div so
+Outlook dark mode does not hide the text.
 
 `read_email` takes a `format` of `markdown` (default) or `html`. `html` returns
 the message's raw body HTML verbatim — reach for it when you need styling that

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -121,7 +121,7 @@ optional `attachments` array — each entry is a sandboxed file `path` or inline
 Bodies cross the wire as markdown by default in both directions, because markdown
 is token-efficient. Both directions can opt out. The four compose tools above take
 a `format` of `markdown` (default, rendered as GFM), `html` (unsanitised
-passthrough — your markup goes to the wire as-is), or `text`, plus
+passthrough — your markup is not sanitised or rewritten), or `text`, plus
 `force_black` (default true) which wraps rendered HTML in a force-black div so
 Outlook dark mode does not hide the text.
 


### PR DESCRIPTION
## Summary

Closes the residual documentation gaps from #155. PR #157 already documented `format` / `force_black` and the read-side `format: "html"` in the root and unscoped-package READMEs; this PR ships the three pieces that remained:

1. **`body_file` YAML frontmatter** (root `README.md`, Body formats section): `send_email`, `create_draft`, and `update_draft` accept `body_file`; a `.md` body file may carry a frontmatter block with keys `to`, `cc`, `subject`, `reply_to`, `draft`, `format`, `force_black`; frontmatter overrides same-named tool parameters; frontmatter is parsed from `.md` files only; the file extension never sets the format. All claims verified against `packages/email-core/src/content/frontmatter.ts`, `content/body-loader.ts`, and `actions/compose-helpers.ts`, and the parser was exercised directly with every documented key.
2. **Unsanitised-passthrough caution** (root + unscoped-package READMEs): `format: "html"` applies no sanitiser, allowlist, or rewriting — one sentence, capability note and caution in one, per the issue.
3. **Scoped compatibility package README** (`packages/email-agent-mcp-scoped/README.md`): previously a pointer stub with zero mention of `format` / `force_black`. Added a condensed Body formats section matching the unscoped README's depth, plus a link to the full tool reference. npm ships README.md in the tarball regardless of the `files` allowlist, so this is user-visible on npmjs.com.

Deliberately NOT done (already shipped in #157): the root README's `### Body formats` section structure, write-side `format` table, read-side `bodyFormat` / `bodyTruncated`, and the nested force-black round-trip guidance.

Note: `reply_to_email` does **not** accept `body_file` (no `resolveComposeFields` call in `actions/reply.ts`), so the frontmatter docs list only the three tools that do — this intentionally narrows the issue's claim that `format` is settable via frontmatter from every composition tool.

## Gate

`npm run build && npm run lint && npm run test:run` — pass. `check:spec-coverage`, `check:server-json` — pass.

Refs: #155

https://claude.ai/code/session_01QYEsR9B16hbcyDWkr4VPzp