### PR TITLE
fix(draft): refuse body edits on reply drafts instead of splicing the quoted-history boundary (closes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ white-on-white.
 instead of `body`. A `.md` body file may
 open with a YAML frontmatter block:
 
+For `update_draft`, `body` and `body_file` are permitted only on a non-reply
+draft and require `replace_body: true`; the stored body is then replaced
+wholesale. Reply draft bodies cannot be edited safely because they include
+provider-assembled quoted history, so create a new draft instead. Subject,
+recipient, and attachment updates remain available on reply drafts.
+
 ```md
 ---
 to: alex@example.com

--- a/openspec/changes/update-draft-body-safety/design.md
+++ b/openspec/changes/update-draft-body-safety/design.md
@@ -1,0 +1,28 @@
+## Context
+
+`update_draft` currently decides how to PATCH a body by inspecting the body HTML for a quoted-history boundary. Every shipped variant of that inspection has been wrong in a way that silently damages the draft. The question this design answers is not "which marker should we match" but "how do we stop matching markers at all".
+
+## Decision: reply-draft detection is provider-level, not body-level
+
+The system SHALL determine whether a draft is a reply from provider metadata, not by searching the body for a divider.
+
+Microsoft Graph knows how a draft was created. A draft made by `createReply` / `createReplyAll` carries conversation linkage (`conversationId` together with an in-reply-to relationship on the underlying message) that a fresh `createDraft` does not. That signal is authoritative, stable across correspondent clients, and unaffected by Gmail's `m_<digits>` prefixing, Exchange's `x_` prefixing, or Outlook mobile using a different container element entirely.
+
+### Alternatives considered
+
+**Tolerate prefixed markers (`x_`, `m_<digits>`).** Rejected. It narrows the failure window without closing it: the prefix set is open-ended, and it does not address Outlook-mobile drafts, where the first `divRplyFwdMsg` in the document can be nested *inside* the quoted history. Splitting there deletes the outer quoted layers — a worse outcome than the bug being fixed.
+
+**Cache the original body at draft creation and diff on update.** Rejected. It makes the tool stateful across calls, and it is unsound for drafts the tool did not create — one edited by hand in Outlook web or mobile has no cached baseline.
+
+**Keep splitting but validate the result.** Rejected. There is no reliable post-condition to check: a split that silently drops one quoted layer produces a body that still looks well-formed.
+
+## Decision: warn on reply-subject changes rather than refusing
+
+Renaming a reply draft is legitimate and needed. The threading risk is real but conditional — clients that group by subject may split the thread — and it is the caller's call to make. The system therefore permits the change and reports the risk through the `warnings` channel.
+
+This is deliberately asymmetric with the body rule. A subject change is visible to the caller in the returned preview and is trivially reversible. A destroyed quoted thread is neither.
+
+## Risks
+
+- **Detection false-negatives.** If a reply draft is not recognised as one, `replace_body: true` would permit a wholesale replace that destroys quoted history. Detection must fail *closed*: when the reply status cannot be determined, treat the draft as a reply and refuse the body edit.
+- **Breaking existing callers.** Any caller currently passing `body` to `update_draft` on a reply draft will now get an error. This is intended; both previous outcomes were silent corruption.

--- a/openspec/changes/update-draft-body-safety/design.md
+++ b/openspec/changes/update-draft-body-safety/design.md
@@ -26,3 +26,13 @@ This is deliberately asymmetric with the body rule. A subject change is visible 
 
 - **Detection false-negatives.** If a reply draft is not recognised as one, `replace_body: true` would permit a wholesale replace that destroys quoted history. Detection must fail *closed*: when the reply status cannot be determined, treat the draft as a reply and refuse the body edit.
 - **Breaking existing callers.** Any caller currently passing `body` to `update_draft` on a reply draft will now get an error. This is intended; both previous outcomes were silent corruption.
+
+## Accepted risk: the origin stamp proves a value, not authorship
+
+Peer review observed that neither stamp is cryptographically bound to this application. Any client with draft-write access to the mailbox can set the Gmail `X-Agent-Draft-Origin` header or the Graph extended property, so a forged `non_reply` on a genuine reply draft would permit a destructive replacement.
+
+This is accepted rather than mitigated. An actor able to write that stamp already holds write access to the draft and can replace or delete its body directly; routing the same damage through this tool grants no additional capability, so there is no privilege escalation to defend against. The alternative — an authenticated, draft-bound stamp — introduces secret management, rotation, and cross-installation key distribution to defend against an adversary who already has the power in question.
+
+The realistic failure is collision rather than attack: another benign tool using the same marker name. A namespaced property identifier and a vendor-prefixed header make that unlikely, and a conflicting or duplicated stamp resolves to `indeterminate` rather than to whichever value happens to be read first.
+
+Revisit if the threat model changes — specifically if drafts ever become writable by a principal that is not already trusted with the mailbox.

--- a/openspec/changes/update-draft-body-safety/proposal.md
+++ b/openspec/changes/update-draft-body-safety/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`update_draft` cannot safely edit the body of a reply draft, and both shipped behaviours fail silently in opposite directions.
+
+The current provider spec says the PATCH "replaces only the caller content above the divider". Detecting that divider from the body HTML is unsound, and the two implementations of it fail differently:
+
+- The build in wide use splices at the **first `<hr>` after `<body>`** with no marker check. Any authored horizontal rule — a markdown `---` in the composed body — becomes a false boundary, so everything below it is preserved as "quoted history" and the next update stacks a second copy of the message on top of the first.
+- The current build requires an exact `id="divRplyFwdMsg"`. When that does not match it falls through to a wholesale replace, which **silently deletes the entire quoted thread**.
+
+The marker is not stable enough to carry this weight. Gmail rewrites the id to `m_<digits>divRplyFwdMsg`, nesting on each round trip; Exchange rewrites it to `x_divRplyFwdMsg`; the two combine. A correspondent on Gmail is sufficient to break the match, and the outermost boundary is not reliably clean either. Drafts composed in Outlook mobile do not use that marker at all — they use `mail-editor-reference-message-container` — so the only `divRplyFwdMsg` present may be a Gmail-prefixed one sitting *inside* the quoted history, where splitting would delete the outer quoted layers.
+
+Graph itself is not the constraint: `PATCH /me/messages/{id}` with a full `body` is a clean replace. The concatenation is ours.
+
+See issue #159.
+
+## What Changes
+
+- **Reply drafts reject body edits.** `update_draft` with `body` or `body_file` on a reply draft SHALL return a recoverable error directing the caller to create a new draft, instead of attempting a boundary split.
+- **Non-reply drafts allow an explicit replace.** Where there is no quoted history to protect, `body` is permitted behind an explicit `replace_body: true`, and performs a wholesale replace.
+- **Subject stays editable on reply drafts, with a warning.** Renaming a reply is a legitimate operation — it is how a superseded draft is marked so the wrong one is not sent. It SHALL be permitted and SHALL return a non-blocking warning that altering a reply's subject may break threading in clients that group on subject.
+- **A `warnings` channel is added** to draft-write responses so non-blocking advisories are machine-readable rather than prose.
+- The `<hr>`/marker boundary-splice heuristic is retired.
+
+## Scope note
+
+Reply-draft *detection* is a provider-level determination, not a body heuristic — see `design.md`. Body sniffing is the thing this change exists to remove; reintroducing it to answer "is this a reply?" would preserve the defect under a new name.
+
+Deploying a current build is a separate, unblocked action and is not part of this change.
+
+## Impact
+
+- Affected specs: `email-write`, `provider-microsoft`
+- Affected code: the Microsoft provider's draft-update path (boundary detection and body merge) and the MCP `update_draft` tool schema/description
+- User-visible behavior: **breaking for one case** — callers passing `body` to `update_draft` on a reply draft now receive a recoverable error where they previously received a silently-wrong draft. Both prior outcomes were defects (stale content retained, or quoted history destroyed), so no correct caller loses a working path. `subject`, `attachments`, `to` and `cc` are unaffected.

--- a/openspec/changes/update-draft-body-safety/specs/email-write/spec.md
+++ b/openspec/changes/update-draft-body-safety/specs/email-write/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Draft Workflow
+
+The system SHALL support a draft-then-send pattern: create a draft, allow review/modification, then send. For Microsoft Graph reply drafts, this uses `createReply` or `createReplyAll` according to `reply_all`, preserving embedded images and CID references on either path.
+
+Body edits on an existing draft are constrained by whether that draft carries quoted history. When `update_draft` is called with `body` or `body_file` on a **reply** draft, the system SHALL return a recoverable structured error and SHALL NOT modify the body, because the authored content cannot be separated from the provider's auto-quoted thread without a body heuristic that is not sound across mail clients. The error SHALL name the remedy: create a new draft. When `update_draft` is called with `body` on a **non-reply** draft — where there is no quoted history to protect — the system SHALL replace the body wholesale, and SHALL require the caller to pass `replace_body: true` so the replacement is explicit.
+
+Fields other than the body remain editable on any draft. `subject`, `attachments`, `to` and `cc` SHALL be accepted on reply and non-reply drafts alike. Changing `subject` on a reply draft SHALL be permitted and SHALL emit a non-blocking warning that altering a reply's subject may break threading in clients that group by subject; it SHALL NOT be refused.
+
+#### Scenario: Create and send draft
+- **WHEN** `send_email` is called with draft mode
+- **THEN** the system creates a draft, returns the draft ID for review, and sends on confirmation
+
+#### Scenario: Draft-creating tools return a persisted preview
+- **WHEN** `create_draft`, `update_draft`, `reply_to_email` (with `draft: true`), or `send_email` (with `draft: true`) successfully creates or updates a draft
+- **THEN** the response includes a `preview` block (`{ to, cc, bcc, subject, body, bodyHtml, bodyTruncated, bodyHtmlTruncated, quotedHistoryOmitted }`) sourced by reading the persisted draft back from the provider, so persistence-layer drops are visible to the caller without a separate `read_email` round trip
+- **AND** if the read-back fails after one short retry, the response includes `previewError: { code, message }` instead of `preview`; the underlying create/update success flag is unchanged
+
+#### Scenario: Body edit on a reply draft is refused
+- **WHEN** `update_draft` is called with a `body` on a draft created as a reply
+- **THEN** the response is `{ success: false, error: { code: "REPLY_DRAFT_BODY_IMMUTABLE", recoverable: true } }`
+- **AND** the stored draft body is unchanged
+- **AND** the message directs the caller to create a new draft instead
+
+#### Scenario: Body edit on a non-reply draft requires explicit opt-in
+- **WHEN** `update_draft` is called with a `body` on a draft that is not a reply, and `replace_body` is not set
+- **THEN** the response is a recoverable error identifying `replace_body: true` as the required opt-in
+- **AND** when the same call is repeated with `replace_body: true`, the body is replaced wholesale and the call succeeds
+
+#### Scenario: Subject rename on a reply draft is permitted with a warning
+- **WHEN** `update_draft` is called on a reply draft with only a `subject` change
+- **THEN** the call succeeds and the stored subject is updated
+- **AND** the response includes a non-blocking warning that changing a reply's subject may break threading
+- **AND** the body and quoted history are unchanged
+
+#### Scenario: Non-body fields remain editable on a reply draft
+- **WHEN** `update_draft` is called on a reply draft with `attachments`, `to`, or `cc` and no `body`
+- **THEN** the call succeeds and the quoted history is preserved byte-for-byte
+
+## ADDED Requirements
+
+### Requirement: Non-Blocking Warnings on Draft Writes
+
+Draft-write actions SHALL be able to report advisories that do not prevent the operation from succeeding. When such an advisory applies, the response SHALL include a `warnings` array alongside the success flag, each entry carrying a stable `code` and a human-readable `message`.
+
+Warnings SHALL NOT change the success flag and SHALL NOT be used for conditions that prevent the write — those remain structured errors. The array SHALL be omitted or empty when no advisory applies, so callers can treat its presence as meaningful.
+
+#### Scenario: Warning accompanies a successful write
+- **WHEN** a draft-write action succeeds but an advisory applies
+- **THEN** the response has `success: true` and a `warnings` array containing at least one `{ code, message }` entry
+
+#### Scenario: No warnings key on an unremarkable write
+- **WHEN** a draft-write action succeeds with no advisory
+- **THEN** the response contains no `warnings` entries

--- a/openspec/changes/update-draft-body-safety/specs/provider-microsoft/spec.md
+++ b/openspec/changes/update-draft-body-safety/specs/provider-microsoft/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: Draft-Then-Send via createReplyAll
+
+The system SHALL use `createReplyAll` for replies. `createReplyAll` preserves embedded images, CID references, and thread metadata. The system merges Graph's auto-quoted body with caller content rather than overwriting it. When `createReplyAll`, the body merge PATCH, or the final `/send` POST fails, `replyToMessage` SHALL return a structured `{ success: false, error: { code: 'REPLY_FAILED', recoverable: false } }` rather than silently falling back to `sendMail` — a `sendMail`-based message would lack `In-Reply-To` / `References` headers and so would not thread on the recipient side.
+
+Updating the body of an existing draft SHALL NOT be performed by locating a quoted-history boundary within the body HTML. That approach is retired: the boundary marker is rewritten by intermediate systems — Gmail prefixes the id as `m_<digits>divRplyFwdMsg` and nests it on each round trip, Exchange prefixes it as `x_`, and drafts composed in Outlook mobile use a different container element entirely — so no marker match reliably identifies the authored region.
+
+The system SHALL instead determine whether a draft is a reply from Graph metadata describing how the draft was created. This determination SHALL fail closed: when reply status cannot be established, the draft SHALL be treated as a reply and a body edit refused, so an indeterminate case cannot destroy quoted history.
+
+#### Scenario: Reply preserves Graph auto-quoted thread (plain text)
+- **WHEN** the original email has prior thread history
+- **AND** the system replies via `createReplyAll` with plain-text content
+- **THEN** the resulting draft preserves Graph's auto-generated quoted thread divider and prior-message header block alongside the caller content
+
+#### Scenario: cid: references survive the merge unchanged
+- **WHEN** the original email contains embedded images referenced via `cid:` URLs in Graph's quoted body
+- **AND** the system replies via `createReplyAll`
+- **THEN** the merged draft body retains every `cid:` reference intact
+
+#### Scenario: createReplyAll failure returns structured REPLY_FAILED
+- **WHEN** `createReplyAll`, the body-merge PATCH, or the final `/send` POST throws
+- **THEN** `replyToMessage` returns `{ success: false, error: { code: 'REPLY_FAILED', recoverable: false } }`
+- **AND** does not call `sendMail`
+
+#### Scenario: Reply status is determined from provider metadata
+- **WHEN** the system needs to know whether a draft is a reply in order to service `update_draft`
+- **THEN** the determination is made from Graph metadata about the draft's origin
+- **AND** the body HTML is not searched for a divider or boundary id
+
+#### Scenario: An authored horizontal rule does not corrupt a draft
+- **WHEN** `update_draft` is called on a draft whose authored body contains a horizontal rule (for example a markdown `---`)
+- **THEN** no part of the authored body is mistaken for a quoted-history boundary
+- **AND** the draft does not accumulate a second copy of previously authored content
+
+#### Scenario: A prefixed or absent boundary marker does not destroy quoted history
+- **WHEN** `update_draft` is called on a reply draft whose boundary id is prefixed by an intermediate system, or which uses a different container element entirely
+- **THEN** the quoted history is preserved
+- **AND** the body edit is refused rather than performed against an unrecognised structure
+
+#### Scenario: Indeterminate reply status fails closed
+- **WHEN** the system cannot establish from Graph metadata whether a draft is a reply
+- **THEN** the draft is treated as a reply
+- **AND** a body edit is refused

--- a/openspec/changes/update-draft-body-safety/tasks.md
+++ b/openspec/changes/update-draft-body-safety/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Provider-level reply detection
 
-- [ ] 1.1 Add a reply-draft determination on the Microsoft provider sourced from Graph metadata, not from body content
-- [ ] 1.2 Fail closed: when reply status cannot be determined, treat the draft as a reply
-- [ ] 1.3 Unit tests covering reply draft, fresh draft, and indeterminate cases
+- [x] 1.1 Add a reply-draft determination on the Microsoft provider sourced from Graph metadata, not from body content
+- [x] 1.2 Fail closed: when reply status cannot be determined, treat the draft as a reply
+- [x] 1.3 Unit tests covering reply draft, fresh draft, and indeterminate cases
 
 ## 2. Body-edit safety in update_draft
 
-- [ ] 2.1 Reject `body`/`body_file` on a reply draft with a recoverable structured error naming the remedy (create a new draft)
-- [ ] 2.2 Accept `body` on a non-reply draft only when `replace_body: true` is passed; wholesale replace
-- [ ] 2.3 Remove the `<hr>` / `divRplyFwdMsg` boundary-splice path
-- [ ] 2.4 Regression test: a draft whose body contains a markdown `---` no longer accumulates stacked copies
-- [ ] 2.5 Regression test: a reply draft with a Gmail-prefixed or Outlook-mobile boundary does not lose quoted history
+- [x] 2.1 Reject `body`/`body_file` on a reply draft with a recoverable structured error naming the remedy (create a new draft)
+- [x] 2.2 Accept `body` on a non-reply draft only when `replace_body: true` is passed; wholesale replace
+- [x] 2.3 Remove the `<hr>` / `divRplyFwdMsg` boundary-splice path
+- [x] 2.4 Regression test: a draft whose body contains a markdown `---` no longer accumulates stacked copies
+- [x] 2.5 Regression test: a reply draft with a Gmail-prefixed or Outlook-mobile boundary does not lose quoted history
 
 ## 3. Warnings channel
 
-- [ ] 3.1 Add non-blocking `warnings` to draft-write responses
-- [ ] 3.2 Emit a threading warning when `subject` is changed on a reply draft; do not block the change
-- [ ] 3.3 Test that `subject`, `attachments`, `to`, `cc` remain editable on reply drafts
+- [x] 3.1 Add non-blocking `warnings` to draft-write responses
+- [x] 3.2 Emit a threading warning when `subject` is changed on a reply draft; do not block the change
+- [x] 3.3 Test that `subject`, `attachments`, `to`, `cc` remain editable on reply drafts
 
 ## 4. Surface and docs
 
-- [ ] 4.1 Update the MCP `update_draft` tool schema and description for `replace_body`
-- [ ] 4.2 Update any repo guidance that tells callers to create a new draft for every body edit
+- [x] 4.1 Update the MCP `update_draft` tool schema and description for `replace_body`
+- [x] 4.2 Update any repo guidance that tells callers to create a new draft for every body edit

--- a/openspec/changes/update-draft-body-safety/tasks.md
+++ b/openspec/changes/update-draft-body-safety/tasks.md
@@ -1,0 +1,24 @@
+## 1. Provider-level reply detection
+
+- [ ] 1.1 Add a reply-draft determination on the Microsoft provider sourced from Graph metadata, not from body content
+- [ ] 1.2 Fail closed: when reply status cannot be determined, treat the draft as a reply
+- [ ] 1.3 Unit tests covering reply draft, fresh draft, and indeterminate cases
+
+## 2. Body-edit safety in update_draft
+
+- [ ] 2.1 Reject `body`/`body_file` on a reply draft with a recoverable structured error naming the remedy (create a new draft)
+- [ ] 2.2 Accept `body` on a non-reply draft only when `replace_body: true` is passed; wholesale replace
+- [ ] 2.3 Remove the `<hr>` / `divRplyFwdMsg` boundary-splice path
+- [ ] 2.4 Regression test: a draft whose body contains a markdown `---` no longer accumulates stacked copies
+- [ ] 2.5 Regression test: a reply draft with a Gmail-prefixed or Outlook-mobile boundary does not lose quoted history
+
+## 3. Warnings channel
+
+- [ ] 3.1 Add non-blocking `warnings` to draft-write responses
+- [ ] 3.2 Emit a threading warning when `subject` is changed on a reply draft; do not block the change
+- [ ] 3.3 Test that `subject`, `attachments`, `to`, `cc` remain editable on reply drafts
+
+## 4. Surface and docs
+
+- [ ] 4.1 Update the MCP `update_draft` tool schema and description for `replace_body`
+- [ ] 4.2 Update any repo guidance that tells callers to create a new draft for every body edit

--- a/packages/email-agent-mcp/README.md
+++ b/packages/email-agent-mcp/README.md
@@ -125,6 +125,12 @@ passthrough — your markup is not sanitised or rewritten), or `text`, plus
 `force_black` (default true) which wraps rendered HTML in a force-black div so
 Outlook dark mode does not hide the text.
 
+For `update_draft`, changing `body` or `body_file` requires
+`replace_body: true` and is allowed only for non-reply drafts. Reply draft
+bodies retain provider-assembled quoted history and cannot be edited safely;
+create a new draft instead. Subject, recipient, and attachment updates remain
+available on reply drafts.
+
 `read_email` takes a `format` of `markdown` (default) or `html`. `html` returns
 the message's raw body HTML verbatim — reach for it when you need styling that
 markdown cannot carry (`color`, `background-color`, `text-decoration`, `<u>`),

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -9,7 +9,7 @@ import { resolveAttachmentFile } from '../content/attachment-loader.js';
 import type { BodyFormat } from '../content/body-renderer.js';
 import { parseAddressList } from '../utils/address.js';
 import { validateAttachment, sanitizeFilename } from './attachments.js';
-import type { EmailAddress, OutboundAttachment } from '../types.js';
+import type { EmailAddress, EmailMessage, OutboundAttachment } from '../types.js';
 
 // --- Error shape used by all actions ---
 
@@ -387,22 +387,21 @@ function toPreviewError(err: unknown): PreviewError {
  * successful by the caller. A single short retry handles transient
  * read-after-write windows; non-recoverable ProviderErrors skip the retry.
  *
- * Note on cost: Gmail's updateDraft already does an internal getMessage to
- * merge partial updates (see GmailEmailProvider.updateDraft), so wiring this
- * helper after updateDraft on Gmail incurs a second redundant GET. Provider
- * interface changes to surface the persisted draft directly are out of scope
- * for v1; documented here so future optimizations have a starting point.
+ * Providers may expose a draft-specific read path when their API uses distinct
+ * identifiers for draft resources and their backing messages (as Gmail does).
  */
 export async function buildDraftPreview(
-  provider: Pick<EmailReader, 'getMessage'>,
+  provider: Pick<EmailReader, 'getMessage' | 'getDraft'>,
   draftId: string,
   opts?: { retryDelayMs?: number; authoredOnly?: boolean },
 ): Promise<BuildDraftPreviewResult> {
   const retryDelay = opts?.retryDelayMs ?? PREVIEW_RETRY_DELAY_MS;
+  const readDraft = (): Promise<EmailMessage> => provider.getDraft?.(draftId)
+    ?? provider.getMessage(draftId);
 
   let persisted;
   try {
-    persisted = await provider.getMessage(draftId);
+    persisted = await readDraft();
   } catch (firstErr) {
     // Skip retry on definitively-permanent failures (e.g. invalid draft id).
     if (firstErr instanceof ProviderError && !firstErr.recoverable) {
@@ -412,7 +411,7 @@ export async function buildDraftPreview(
       await new Promise(resolve => setTimeout(resolve, retryDelay));
     }
     try {
-      persisted = await provider.getMessage(draftId);
+      persisted = await readDraft();
     } catch (secondErr) {
       return { previewError: toPreviewError(secondErr) };
     }

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -742,6 +742,24 @@ describe('email-write/Authored-Only Reply Draft Preview', () => {
     expect(providerWrite).not.toHaveBeenCalled();
   });
 
+  it('Scenario: Draft preview prefers a provider draft-resource read', async () => {
+    const getMessage = vi.fn();
+    const getDraft = vi.fn().mockResolvedValue(persistedDraft({
+      id: 'backing-message-1',
+      subject: 'Persisted Gmail draft',
+    }));
+
+    const result = await buildDraftPreview(
+      { getMessage, getDraft },
+      'draft-resource-1',
+      { retryDelayMs: 0 },
+    );
+
+    expect(result.preview?.subject).toBe('Persisted Gmail draft');
+    expect(getDraft).toHaveBeenCalledWith('draft-resource-1');
+    expect(getMessage).not.toHaveBeenCalled();
+  });
+
   it('Scenario: Gmail and fresh drafts are unaffected', async () => {
     const freshHtml = '<html><body><p>Fresh draft</p><hr><p>Authored horizontal rule tail</p></body></html>';
     vi.spyOn(provider, 'getMessage').mockResolvedValueOnce(persistedDraft({

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -246,22 +246,160 @@ describe('email-write/Send Draft', () => {
 });
 
 describe('email-write/Update Draft', () => {
-  it('Scenario: Update draft body', async () => {
+  it('Scenario: Body edit on a non-reply draft requires explicit opt-in', async () => {
     const draftResult = await createDraftAction.run(ctx, {
       to: 'alice@allowed.com',
       subject: 'Original Subject',
       body: 'Original body',
     });
 
-    const result = await updateDraftAction.run(ctx, {
+    const refused = await updateDraftAction.run(ctx, {
       draft_id: draftResult.draftId!,
       body: 'Updated body',
     });
 
+    expect(refused.success).toBe(false);
+    expect(refused.error).toMatchObject({
+      code: 'DRAFT_BODY_REPLACE_CONFIRMATION_REQUIRED',
+      recoverable: true,
+    });
+    expect(refused.error!.message).toContain('replace_body: true');
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: draftResult.draftId!,
+      body: 'Updated body',
+      replace_body: true,
+    });
+
     expect(result.success).toBe(true);
+    expect(result).not.toHaveProperty('warnings');
     const drafts = provider.getDrafts();
     const draft = drafts.get(draftResult.draftId!)!;
     expect(draft.body).toBe('Updated body');
+  });
+
+  it('Scenario: An authored horizontal rule does not accumulate stacked copies', async () => {
+    const created = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Horizontal rule',
+      body: 'Old start\n\n---\n\nOld tail',
+    });
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      body: 'Replacement start\n\n---\n\nReplacement tail',
+      replace_body: true,
+    });
+
+    expect(result.success).toBe(true);
+    const draft = provider.getDrafts().get(created.draftId!)!;
+    expect(draft.body).toBe('Replacement start\n\n---\n\nReplacement tail');
+    expect(draft.body).not.toContain('Old start');
+    expect(draft.body).not.toContain('Old tail');
+    expect(draft.bodyHtml).toContain('<hr>');
+  });
+
+  it.each([
+    '<html><body><div>Reply</div><hr><div id="m_123divRplyFwdMsg">Quoted Gmail history</div></body></html>',
+    '<html><body><div>Reply</div><div id="mail-editor-reference-message-container"><div class="ms-outlook-mobile-reference-message">Quoted mobile history</div></div></body></html>',
+  ])('Scenario: A prefixed or absent boundary marker does not destroy quoted history', async (replyBody) => {
+    provider.addMessage({
+      id: 'original-for-boundary',
+      subject: 'Original',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+    const created = await createDraftAction.run(ctx, {
+      to: 'partner@allowed.com',
+      subject: 'Re: Original',
+      body: replyBody,
+      format: 'html',
+      force_black: false,
+      reply_to: 'original-for-boundary',
+    });
+    const before = provider.getDrafts().get(created.draftId!)!;
+    const updateSpy = vi.spyOn(provider, 'updateDraft');
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      body: '<div>Replacement</div>',
+      format: 'html',
+      force_black: false,
+      replace_body: true,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: {
+        code: 'REPLY_DRAFT_BODY_IMMUTABLE',
+        recoverable: true,
+      },
+    });
+    expect(result.error!.message).toContain('Create a new draft');
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(provider.getDrafts().get(created.draftId!)!.bodyHtml).toBe(before.bodyHtml);
+  });
+
+  it('Scenario: Indeterminate reply status fails closed', async () => {
+    const created = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Unknown origin',
+      body: 'Original',
+    });
+    vi.spyOn(provider, 'getDraftReplyStatus').mockResolvedValueOnce('indeterminate');
+    const updateSpy = vi.spyOn(provider, 'updateDraft');
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      body: 'Replacement',
+      replace_body: true,
+    });
+
+    expect(result.error?.code).toBe('REPLY_DRAFT_BODY_IMMUTABLE');
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(provider.getDrafts().get(created.draftId!)!.body).toBe('Original');
+  });
+
+  it('Scenario: Non-body fields remain editable on a reply draft', async () => {
+    await writeFile(join(testDir, 'reply-attachment.txt'), 'attachment');
+    provider.addMessage({
+      id: 'original-for-fields',
+      subject: 'Original',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+    const created = await createDraftAction.run(ctx, {
+      to: 'partner@allowed.com',
+      subject: 'Re: Original',
+      body: 'Reply body with quoted history',
+      reply_to: 'original-for-fields',
+    });
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      subject: 'Superseded reply',
+      to: 'new-to@allowed.com',
+      cc: ['new-cc@allowed.com'],
+      attachments: [{ path: 'reply-attachment.txt' }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual([{
+      code: 'REPLY_SUBJECT_THREADING_WARNING',
+      message: expect.stringContaining('may break threading'),
+    }]);
+    const draft = provider.getDrafts().get(created.draftId!)!;
+    expect(draft.subject).toBe('Superseded reply');
+    expect(draft.to).toEqual([{ email: 'new-to@allowed.com', name: undefined }]);
+    expect(draft.cc).toEqual([{ email: 'new-cc@allowed.com', name: undefined }]);
+    expect(draft.attachments?.[0]?.filename).toBe('reply-attachment.txt');
+    expect(draft.body).toBe('Reply body with quoted history');
   });
 
   it('Scenario: Update draft recipients to blocked address succeeds (drafts bypass allowlist)', async () => {
@@ -280,6 +418,23 @@ describe('email-write/Update Draft', () => {
     const drafts = provider.getDrafts();
     const draft = drafts.get(draftResult.draftId!)!;
     expect(draft.to[0]!.email).toBe('hacker@evil.com');
+  });
+
+  it('update_draft permits subject changes on a non-reply draft without a warning', async () => {
+    const created = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Original',
+      body: 'Body',
+    });
+
+    const result = await updateDraftAction.run(ctx, {
+      draft_id: created.draftId!,
+      subject: 'Re: Retitled draft',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result).not.toHaveProperty('warnings');
+    expect(provider.getDrafts().get(created.draftId!)!.subject).toBe('Re: Retitled draft');
   });
 
   it('Scenario: Provider lacks updateDraft', async () => {
@@ -314,6 +469,7 @@ describe('email-write/Body Rendering', () => {
     const updated = await updateDraftAction.run(ctx, {
       draft_id: created.draftId!,
       body: '## Updated',
+      replace_body: true,
     });
 
     expect(updated.success).toBe(true);
@@ -633,6 +789,7 @@ describe('email-write/Authored-Only Reply Draft Preview', () => {
     const result = await updateDraftAction.run(ctx, {
       draft_id: created.draftId!,
       body: 'Updated reply',
+      replace_body: true,
     });
 
     expect(updateSpy).toHaveBeenCalledTimes(1);
@@ -877,6 +1034,7 @@ describe('email-write/Draft Preview (issue #75)', () => {
       draft_id: created.draftId!,
       subject: 'Updated',
       body: 'New body',
+      replace_body: true,
     });
 
     expect(result.success).toBe(true);
@@ -928,6 +1086,7 @@ describe('email-write/Draft Preview (issue #75)', () => {
     const result = await updateDraftAction.run(ctx, {
       draft_id: created.draftId!,
       body: 'Updated',
+      replace_body: true,
     });
 
     expect(result.success).toBe(true);

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -32,6 +32,10 @@ const DraftOutput = z.object({
   draftId: z.string().optional(),
   preview: DraftPreviewSchema.optional(),
   previewError: PreviewErrorSchema.optional(),
+  warnings: z.array(z.object({
+    code: z.string(),
+    message: z.string(),
+  })).optional(),
   error: z.object({
     code: z.string(),
     message: z.string(),
@@ -330,6 +334,8 @@ const UpdateDraftInput = z.object({
   subject: z.string().optional(),
   body: z.string().optional(),
   body_file: z.string().optional(),
+  replace_body: z.boolean().optional()
+    .describe('Required as true to replace the body of a non-reply draft wholesale. Reply draft bodies cannot be edited; create a new draft instead.'),
   include_quoted: z.boolean().optional().default(false)
     .describe('Include provider-assembled quoted history in preview.bodyHtml. This affects only the preview, never the stored or sent body.'),
   mailbox: z.string().optional(),
@@ -346,7 +352,7 @@ export const updateDraftAction: EmailAction<
   z.infer<typeof DraftOutput>
 > = {
   name: 'update_draft',
-  description: 'Update a draft email. Allowlist is enforced at send_draft time, not here.',
+  description: 'Update a draft email. Body edits are refused for reply drafts; non-reply body edits require replace_body=true and replace the body wholesale. Subject, recipients, and attachments remain editable. Allowlist is enforced at send_draft time, not here.',
   input: UpdateDraftInput,
   output: DraftOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -373,16 +379,46 @@ export const updateDraftAction: EmailAction<
 
     const { to, cc, subject, format, forceBlack } = fields;
     let { body } = fields;
+    const hasBodyEdit = input.body !== undefined || input.body_file !== undefined;
 
-    // Drafts bypass allowlist — enforcement happens at send_draft time
-
-    // Re: threading guardrail on subject if changed
-    if (subject) {
-      const threadingError = checkReplyThreading(subject);
-      if (threadingError) {
-        return { success: false, error: threadingError };
+    // Reply status is provider metadata, never inferred from body content. Only
+    // body and subject changes need it: recipient/attachment-only updates must
+    // remain editable even if metadata lookup is unavailable.
+    let isReplyDraft = false;
+    if (hasBodyEdit || subject !== undefined) {
+      try {
+        const status = await ctx.provider.getDraftReplyStatus?.(input.draft_id);
+        isReplyDraft = status !== 'non_reply';
+      } catch {
+        // Fail closed. An unavailable or failed determination must never make a
+        // destructive body replacement look safe.
+        isReplyDraft = true;
       }
     }
+
+    if (hasBodyEdit && isReplyDraft) {
+      return {
+        success: false,
+        error: {
+          code: 'REPLY_DRAFT_BODY_IMMUTABLE',
+          message: 'The body of a reply draft cannot be edited safely because its quoted history must be preserved. Create a new draft instead.',
+          recoverable: true,
+        },
+      };
+    }
+
+    if (hasBodyEdit && input.replace_body !== true) {
+      return {
+        success: false,
+        error: {
+          code: 'DRAFT_BODY_REPLACE_CONFIRMATION_REQUIRED',
+          message: 'Replacing a non-reply draft body is destructive. Pass replace_body: true to replace it wholesale.',
+          recoverable: true,
+        },
+      };
+    }
+
+    // Drafts bypass allowlist — enforcement happens at send_draft time
 
     // Build partial update — parse name-address strings only for fields the caller actually provided.
     const partial: Partial<import('../types.js').ComposeMessage> = {};
@@ -409,7 +445,7 @@ export const updateDraftAction: EmailAction<
       partial.attachments = attResult.files!;
     }
 
-    if (body) {
+    if (hasBodyEdit) {
       const rendered = renderEmailBody(body, { format, forceBlack });
       let outBody = rendered.body;
       let outBodyHtml = rendered.bodyHtml;
@@ -439,6 +475,12 @@ export const updateDraftAction: EmailAction<
         success: result.success,
         draftId: result.draftId,
         ...previewResult,
+        ...(result.success && subject !== undefined && isReplyDraft
+          ? { warnings: [{
+            code: 'REPLY_SUBJECT_THREADING_WARNING',
+            message: 'Changing a reply draft subject may break threading in clients that group messages by subject.',
+          }] }
+          : {}),
         error: result.error ? { code: result.error.code, message: result.error.message, recoverable: result.error.recoverable } : undefined,
       };
     } catch (err) {

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -462,10 +462,9 @@ export const updateDraftAction: EmailAction<
 
     try {
       const result = await ctx.provider.updateDraft(input.draft_id, partial);
-      // Note: Gmail's updateDraft already does an internal getMessage to merge
-      // partial updates, so this read-back is a second redundant GET on Gmail.
-      // Acceptable for v1 — see buildDraftPreview docs for the optimization
-      // path (provider returning the persisted draft directly).
+      // Read the persisted draft back for the preview. Providers whose draft
+      // resources have distinct identifiers (Gmail) use their draft-specific
+      // read path through buildDraftPreview.
       const previewResult = result.success && result.draftId
         ? await buildDraftPreview(ctx.provider, result.draftId, {
           authoredOnly: !input.include_quoted,

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -31,6 +31,7 @@ export type {
   DownloadedAttachment,
   EmailProvider,
   AuthManager,
+  DraftReplyStatus,
 } from './providers/provider.js';
 export { ProviderError, AttachmentNotSupportedError, AttachmentNotFoundError } from './providers/provider.js';
 export {

--- a/packages/email-core/src/providers/provider.ts
+++ b/packages/email-core/src/providers/provider.ts
@@ -26,8 +26,11 @@ export interface EmailSender {
   createDraft(msg: ComposeMessage): Promise<DraftResult>;
   sendDraft(draftId: string): Promise<SendResult>;
   createReplyDraft?(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult>;
+  getDraftReplyStatus?(draftId: string): Promise<DraftReplyStatus>;
   updateDraft?(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult>;
 }
+
+export type DraftReplyStatus = 'reply' | 'non_reply' | 'indeterminate';
 
 export interface EmailScheduledSender {
   scheduleMessage(msg: ComposeMessage, scheduledSendAt: string): Promise<ScheduledSendResult>;

--- a/packages/email-core/src/providers/provider.ts
+++ b/packages/email-core/src/providers/provider.ts
@@ -16,6 +16,7 @@ import type {
 export interface EmailReader {
   listMessages(opts: ListOptions): Promise<EmailMessage[]>;
   getMessage(id: string): Promise<EmailMessage>;
+  getDraft?(draftId: string): Promise<EmailMessage>;
   searchMessages(query: string, folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]>;
   getThread(messageId: string): Promise<EmailThread>;
 }

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -22,11 +22,13 @@ import {
   type EmailAttachmentHandler,
   type EmailScheduledSender,
   type DownloadedAttachment,
+  type DraftReplyStatus,
 } from '../providers/provider.js';
 
 export class MockEmailProvider implements EmailReader, EmailSender, EmailScheduledSender, EmailSubscriber, EmailCategorizer, EmailAttachmentHandler {
   private messages: EmailMessage[] = [];
   private drafts: Map<string, ComposeMessage> = new Map();
+  private replyDraftIds: Set<string> = new Set();
   private sentMessages: ComposeMessage[] = [];
   private scheduledSends: ScheduledSend[] = [];
   private subscriptions: Map<string, (msg: EmailMessage) => void> = new Map();
@@ -259,6 +261,7 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
       throw new ProviderError('DRAFT_NOT_FOUND', `Draft not found: ${draftId}`, 'mock', false);
     }
     this.drafts.delete(draftId);
+    this.replyDraftIds.delete(draftId);
     this.sentMessages.push(draft);
     return { success: true, messageId: `sent-${this.nextId++}` };
   }
@@ -324,7 +327,14 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
       bodyHtml: opts?.bodyHtml,
       attachments: opts?.attachments,
     });
+    this.replyDraftIds.add(draftId);
     return { success: true, draftId };
+  }
+
+  async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
+    this.maybeThrow();
+    if (!this.drafts.has(draftId)) return 'indeterminate';
+    return this.replyDraftIds.has(draftId) ? 'reply' : 'non_reply';
   }
 
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -29,6 +29,7 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
   private messages: EmailMessage[] = [];
   private drafts: Map<string, ComposeMessage> = new Map();
   private replyDraftIds: Set<string> = new Set();
+  private nonReplyDraftIds: Set<string> = new Set();
   private sentMessages: ComposeMessage[] = [];
   private scheduledSends: ScheduledSend[] = [];
   private subscriptions: Map<string, (msg: EmailMessage) => void> = new Map();
@@ -251,6 +252,8 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
     this.maybeThrow();
     const draftId = `draft-${this.nextId++}`;
     this.drafts.set(draftId, msg);
+    // Simulate the explicit origin stamp written by real providers.
+    this.nonReplyDraftIds.add(draftId);
     return { success: true, draftId };
   }
 
@@ -262,6 +265,7 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
     }
     this.drafts.delete(draftId);
     this.replyDraftIds.delete(draftId);
+    this.nonReplyDraftIds.delete(draftId);
     this.sentMessages.push(draft);
     return { success: true, messageId: `sent-${this.nextId++}` };
   }
@@ -270,6 +274,8 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
     this.maybeThrow();
     const draftId = `scheduled-${this.nextId++}`;
     this.drafts.set(draftId, msg);
+    // Simulate the explicit origin stamp written by real providers.
+    this.nonReplyDraftIds.add(draftId);
     this.scheduledSends.push({
       messageId: draftId,
       subject: msg.subject,
@@ -310,6 +316,8 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
     }
     this.scheduledSends.splice(index, 1);
     this.drafts.delete(messageId);
+    this.replyDraftIds.delete(messageId);
+    this.nonReplyDraftIds.delete(messageId);
   }
 
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
@@ -334,7 +342,9 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
   async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
     this.maybeThrow();
     if (!this.drafts.has(draftId)) return 'indeterminate';
-    return this.replyDraftIds.has(draftId) ? 'reply' : 'non_reply';
+    if (this.replyDraftIds.has(draftId)) return 'reply';
+    if (this.nonReplyDraftIds.has(draftId)) return 'non_reply';
+    return 'indeterminate';
   }
 
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -352,6 +352,8 @@ describe('provider-gmail/Draft Operations', () => {
     expect(result.draftId).toBe('draft-abc');
     // Interface now accepts optional threadId; absent here because ComposeMessage.threadId is unset.
     expect(client.createDraft).toHaveBeenCalledWith(expect.any(String), undefined);
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('X-Agent-Draft-Origin: non_reply');
   });
 
   it('Scenario: sendDraft calls Gmail API with draft ID', async () => {
@@ -831,6 +833,7 @@ describe('provider-gmail/Reply Drafts', () => {
     expect(raw).toContain('To: "Alice" <alice@corp.com>');
     expect(raw).toMatch(/Cc: .*bob@corp\.com.*carol@corp\.com/);
     expect(raw).toContain('Subject: Re: Original thread');
+    expect(raw).toContain('X-Agent-Draft-Origin: reply');
     expect(raw).toContain('In-Reply-To: <msg-a@corp.com>');
     // References appends the original's Message-ID to its existing list.
     expect(raw).toContain('References: <msg-r1@corp.com> <msg-a@corp.com>');
@@ -1025,10 +1028,15 @@ describe('provider-gmail/Update Draft', () => {
   }
 
   it('Scenario: updateDraft merges partial over current draft and preserves threading', async () => {
+    const stampedReplyDraft = draftMessageMock();
+    stampedReplyDraft.payload.headers.push({
+      name: 'X-Agent-Draft-Origin',
+      value: 'reply',
+    });
     const client = createMockGmailClient({
       getDraft: vi.fn().mockResolvedValue({
         id: 'draft-existing',
-        message: draftMessageMock(),
+        message: stampedReplyDraft,
       }),
     });
     const provider = new GmailEmailProvider(client);
@@ -1048,6 +1056,7 @@ describe('provider-gmail/Update Draft', () => {
     // New subject applied
     expect(raw).toContain('Subject: New subject');
     // Threading preserved across the replace
+    expect(raw).toContain('X-Agent-Draft-Origin: reply');
     expect(raw).toContain('In-Reply-To: <parent@corp.com>');
     expect(raw).toContain('References: <root@corp.com> <parent@corp.com>');
   });
@@ -1180,6 +1189,41 @@ describe('provider-gmail/Update Draft', () => {
     await expect(provider.getDraftReplyStatus('draft-resource-1')).resolves.toBe('reply');
     expect(client.getDraft).toHaveBeenCalledWith('draft-resource-1');
     expect(client.getMessage).not.toHaveBeenCalled();
+  });
+
+  it('Scenario: unstamped draft without In-Reply-To is indeterminate', async () => {
+    const backingMessage = draftMessageMock();
+    backingMessage.payload.headers = backingMessage.payload.headers.filter(
+      header => header.name !== 'In-Reply-To',
+    );
+    const client = createMockGmailClient({
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-resource-unstamped',
+        message: backingMessage,
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('draft-resource-unstamped'))
+      .resolves.toBe('indeterminate');
+  });
+
+  it('Scenario: stamped fresh draft is non-reply', async () => {
+    const backingMessage = draftMessageMock();
+    backingMessage.payload.headers = [
+      ...backingMessage.payload.headers.filter(header => header.name !== 'In-Reply-To'),
+      { name: 'X-Agent-Draft-Origin', value: 'non_reply' },
+    ];
+    const client = createMockGmailClient({
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-resource-fresh',
+        message: backingMessage,
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('draft-resource-fresh'))
+      .resolves.toBe('non_reply');
   });
 
 });

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -27,6 +27,22 @@ function createMockGmailClient(overrides: Partial<GmailApiClient> = {}): GmailAp
       },
       internalDate: String(new Date('2024-03-15T10:00:00Z').getTime()),
     }),
+    getDraft: vi.fn().mockResolvedValue({
+      id: 'draft-abc',
+      message: {
+        id: 'msg-draft',
+        threadId: 'thread-draft',
+        labelIds: ['DRAFT'],
+        payload: {
+          headers: [
+            { name: 'From', value: 'me@corp.com' },
+            { name: 'To', value: 'bob@corp.com' },
+            { name: 'Subject', value: 'Draft' },
+          ],
+          body: { data: Buffer.from('Draft body').toString('base64url') },
+        },
+      },
+    }),
     getAttachment: vi.fn().mockResolvedValue({
       data: Buffer.from('attachment bytes').toString('base64url'),
       size: 16,
@@ -989,7 +1005,7 @@ describe('provider-gmail/Reply Threading on Send', () => {
 describe('provider-gmail/Update Draft', () => {
   function draftMessageMock() {
     return {
-      id: 'draft-existing',
+      id: 'msg-backing-existing',
       threadId: 'thread-draft',
       labelIds: ['DRAFT'],
       payload: {
@@ -1010,13 +1026,18 @@ describe('provider-gmail/Update Draft', () => {
 
   it('Scenario: updateDraft merges partial over current draft and preserves threading', async () => {
     const client = createMockGmailClient({
-      getMessage: vi.fn().mockResolvedValue(draftMessageMock()),
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-existing',
+        message: draftMessageMock(),
+      }),
     });
     const provider = new GmailEmailProvider(client);
 
     const result = await provider.updateDraft('draft-existing', { subject: 'New subject' });
 
     expect(result.success).toBe(true);
+    expect(client.getDraft).toHaveBeenCalledWith('draft-existing');
+    expect(client.getMessage).not.toHaveBeenCalled();
     expect(client.updateDraft).toHaveBeenCalledWith('draft-existing', expect.any(String), 'thread-draft');
 
     // updateDraft signature is (draftId, raw, threadId) — raw is at index 1.
@@ -1048,7 +1069,10 @@ describe('provider-gmail/Update Draft', () => {
 
   it('Scenario: updateDraft returns structured UPDATE_DRAFT_FAILED on error', async () => {
     const client = createMockGmailClient({
-      getMessage: vi.fn().mockResolvedValue(draftMessageMock()),
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-existing',
+        message: draftMessageMock(),
+      }),
       updateDraft: vi.fn().mockRejectedValue(new Error('draft not found')),
     });
     const provider = new GmailEmailProvider(client);
@@ -1086,6 +1110,10 @@ describe('provider-gmail/Update Draft', () => {
       size: attachmentBytes.length,
     });
     const client = createMockGmailClient({
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-existing',
+        message: draftWithAttachment,
+      }),
       getMessage: vi.fn().mockResolvedValue(draftWithAttachment),
       getAttachment,
     });
@@ -1126,7 +1154,10 @@ describe('provider-gmail/Update Draft', () => {
       internalDate: String(Date.now()),
     };
     const client = createMockGmailClient({
-      getMessage: vi.fn().mockResolvedValue(draftWithInline),
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-existing',
+        message: draftWithInline,
+      }),
     });
     const provider = new GmailEmailProvider(client);
 
@@ -1135,6 +1166,22 @@ describe('provider-gmail/Update Draft', () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe('INLINE_ATTACHMENTS_UNSUPPORTED');
   });
+
+  it('Scenario: reply status reads the nested draft message by draft resource id', async () => {
+    const backingMessage = draftMessageMock();
+    const client = createMockGmailClient({
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-resource-1',
+        message: backingMessage,
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('draft-resource-1')).resolves.toBe('reply');
+    expect(client.getDraft).toHaveBeenCalledWith('draft-resource-1');
+    expect(client.getMessage).not.toHaveBeenCalled();
+  });
+
 });
 
 describe('provider-gmail/buildRawMessage attachments', () => {

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -1208,6 +1208,45 @@ describe('provider-gmail/Update Draft', () => {
       .resolves.toBe('indeterminate');
   });
 
+  it('Scenario: conflicting duplicate origin headers are indeterminate', async () => {
+    // Codex round 3: a forged non_reply stamp alongside a genuine reply header
+    // must not be resolvable by header order.
+    const backingMessage = draftMessageMock();
+    backingMessage.payload.headers = [
+      ...backingMessage.payload.headers,
+      { name: 'X-Agent-Draft-Origin', value: 'non_reply' },
+      { name: 'X-Agent-Draft-Origin', value: 'reply' },
+    ];
+    const client = createMockGmailClient({
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-resource-conflicted',
+        message: backingMessage,
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('draft-resource-conflicted'))
+      .resolves.toBe('indeterminate');
+  });
+
+  it('Scenario: unrecognised origin header value is indeterminate', async () => {
+    const backingMessage = draftMessageMock();
+    backingMessage.payload.headers = [
+      ...backingMessage.payload.headers.filter(header => header.name !== 'In-Reply-To'),
+      { name: 'X-Agent-Draft-Origin', value: 'whatever' },
+    ];
+    const client = createMockGmailClient({
+      getDraft: vi.fn().mockResolvedValue({
+        id: 'draft-resource-bogus',
+        message: backingMessage,
+      }),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('draft-resource-bogus'))
+      .resolves.toBe('indeterminate');
+  });
+
   it('Scenario: stamped fresh draft is non-reply', async () => {
     const backingMessage = draftMessageMock();
     backingMessage.payload.headers = [

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -12,6 +12,7 @@ import type {
   ReplyOptions,
   DownloadedAttachment,
   OutboundAttachment,
+  DraftReplyStatus,
 } from '@usejunior/email-core';
 import { AttachmentNotFoundError } from '@usejunior/email-core';
 
@@ -355,6 +356,12 @@ export class GmailEmailProvider {
         },
       };
     }
+  }
+
+  async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
+    const draft = await this.getMessage(draftId);
+    if (draft.isDraft !== true) return 'indeterminate';
+    return draft.inReplyTo && draft.inReplyTo.trim().length > 0 ? 'reply' : 'non_reply';
   }
 
   // NemoClaw egress domains

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -34,6 +34,7 @@ const SUBJECT_MAX_LENGTH = 255;
 export interface GmailApiClient {
   listMessages(opts: { labelIds?: string[]; maxResults?: number; q?: string }): Promise<{ messages?: Array<{ id: string; threadId: string }>; resultSizeEstimate?: number }>;
   getMessage(id: string): Promise<GmailMessage>;
+  getDraft(draftId: string): Promise<{ id: string; message: GmailMessage }>;
   getAttachment(messageId: string, attachmentId: string): Promise<{ data?: string; size?: number }>;
   /**
    * Send a raw RFC 2822 message. Optional `threadId` routes the send into
@@ -111,6 +112,11 @@ export class GmailEmailProvider {
   async getMessage(id: string): Promise<EmailMessage> {
     const msg = await this.client.getMessage(id);
     return mapGmailMessage(msg);
+  }
+
+  async getDraft(draftId: string): Promise<EmailMessage> {
+    const draft = await this.client.getDraft(draftId);
+    return mapGmailMessage(draft.message);
   }
 
   async searchMessages(query: string, _folder?: string, limit?: number, offset?: number): Promise<EmailMessage[]> {
@@ -293,7 +299,7 @@ export class GmailEmailProvider {
       // current draft, merge the partial over it, and re-upload. Preserve
       // threading headers from the original draft so edits don't silently
       // lose thread association.
-      const current = await this.getMessage(draftId);
+      const current = await this.getDraft(draftId);
 
       // Attachments: drafts.update is a full replacement, so an omitted
       // `attachments` field must be rehydrated from the existing draft or it
@@ -359,7 +365,7 @@ export class GmailEmailProvider {
   }
 
   async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
-    const draft = await this.getMessage(draftId);
+    const draft = await this.getDraft(draftId);
     if (draft.isDraft !== true) return 'indeterminate';
     return draft.inReplyTo && draft.inReplyTo.trim().length > 0 ? 'reply' : 'non_reply';
   }

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -377,9 +377,16 @@ export class GmailEmailProvider {
     const draft = mapGmailMessage(draftResource.message);
     if (draft.isDraft !== true) return 'indeterminate';
 
-    const originStamp = getHeader(draftResource.message, DRAFT_ORIGIN_HEADER);
-    if (originStamp !== undefined) {
-      return getRecognizedDraftOrigin(originStamp) ?? 'indeterminate';
+    // Duplicate stamps are ambiguous: a draft carrying two conflicting origin
+    // headers gives no basis to pick one, and taking the first match would make
+    // the answer depend on header ordering. Only a single, unanimous stamp is
+    // authoritative; anything else falls through to indeterminate, which
+    // refuses the edit.
+    const originStamps = getHeaders(draftResource.message, DRAFT_ORIGIN_HEADER);
+    if (originStamps.length > 0) {
+      const recognized = originStamps.map(getRecognizedDraftOrigin);
+      const unanimous = recognized.every(value => value !== undefined && value === recognized[0]);
+      return unanimous ? recognized[0]! : 'indeterminate';
     }
 
     return draft.inReplyTo && draft.inReplyTo.trim().length > 0 ? 'reply' : 'indeterminate';
@@ -393,6 +400,12 @@ export class GmailEmailProvider {
 
 function getHeader(msg: GmailMessage, name: string): string | undefined {
   return msg.payload?.headers?.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function getHeaders(msg: GmailMessage, name: string): string[] {
+  return (msg.payload?.headers ?? [])
+    .filter(h => h.name.toLowerCase() === name.toLowerCase())
+    .map(h => h.value);
 }
 
 function getRecognizedDraftOrigin(value: string | undefined): DraftOrigin | undefined {

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -30,6 +30,8 @@ const FOLDER_TO_LABEL: Record<string, string> = {
 
 // Matches Microsoft's SUBJECT_MAX_LENGTH — keeps cross-provider behaviour consistent.
 const SUBJECT_MAX_LENGTH = 255;
+const DRAFT_ORIGIN_HEADER = 'X-Agent-Draft-Origin';
+type DraftOrigin = 'reply' | 'non_reply';
 
 export interface GmailApiClient {
   listMessages(opts: { labelIds?: string[]; maxResults?: number; q?: string }): Promise<{ messages?: Array<{ id: string; threadId: string }>; resultSizeEstimate?: number }>;
@@ -234,7 +236,7 @@ export class GmailEmailProvider {
   }
 
   async createDraft(msg: ComposeMessage): Promise<DraftResult> {
-    const raw = buildRawMessage(msg);
+    const raw = buildRawMessage(msg, { draftOrigin: 'non_reply' });
     const result = await this.client.createDraft(raw, msg.threadId);
     return { success: true, draftId: result.id };
   }
@@ -266,6 +268,7 @@ export class GmailEmailProvider {
         {
           inReplyTo: original.messageId,
           references,
+          draftOrigin: 'reply',
         },
       );
 
@@ -299,7 +302,11 @@ export class GmailEmailProvider {
       // current draft, merge the partial over it, and re-upload. Preserve
       // threading headers from the original draft so edits don't silently
       // lose thread association.
-      const current = await this.getDraft(draftId);
+      const draftResource = await this.client.getDraft(draftId);
+      const current = mapGmailMessage(draftResource.message);
+      const draftOrigin = getRecognizedDraftOrigin(
+        getHeader(draftResource.message, DRAFT_ORIGIN_HEADER),
+      );
 
       // Attachments: drafts.update is a full replacement, so an omitted
       // `attachments` field must be rehydrated from the existing draft or it
@@ -348,6 +355,7 @@ export class GmailEmailProvider {
       const raw = buildRawMessage(merged, {
         inReplyTo: current.inReplyTo,
         references: current.references,
+        draftOrigin,
       });
 
       const result = await this.client.updateDraft(draftId, raw, current.threadId);
@@ -365,9 +373,16 @@ export class GmailEmailProvider {
   }
 
   async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
-    const draft = await this.getDraft(draftId);
+    const draftResource = await this.client.getDraft(draftId);
+    const draft = mapGmailMessage(draftResource.message);
     if (draft.isDraft !== true) return 'indeterminate';
-    return draft.inReplyTo && draft.inReplyTo.trim().length > 0 ? 'reply' : 'non_reply';
+
+    const originStamp = getHeader(draftResource.message, DRAFT_ORIGIN_HEADER);
+    if (originStamp !== undefined) {
+      return getRecognizedDraftOrigin(originStamp) ?? 'indeterminate';
+    }
+
+    return draft.inReplyTo && draft.inReplyTo.trim().length > 0 ? 'reply' : 'indeterminate';
   }
 
   // NemoClaw egress domains
@@ -378,6 +393,11 @@ export class GmailEmailProvider {
 
 function getHeader(msg: GmailMessage, name: string): string | undefined {
   return msg.payload?.headers?.find(h => h.name.toLowerCase() === name.toLowerCase())?.value;
+}
+
+function getRecognizedDraftOrigin(value: string | undefined): DraftOrigin | undefined {
+  if (value === 'reply' || value === 'non_reply') return value;
+  return undefined;
 }
 
 function getPartHeader(part: GmailMessagePart, name: string): string | undefined {
@@ -655,6 +675,7 @@ function generateBoundary(content: string): string {
 interface BuildRawOptions {
   inReplyTo?: string;
   references?: string[];
+  draftOrigin?: DraftOrigin;
 }
 
 const CRLF = '\r\n';
@@ -778,6 +799,7 @@ function buildRawMessage(msg: ComposeMessage, opts: BuildRawOptions = {}): strin
   if (msg.cc && msg.cc.length > 0) headers.push(`Cc: ${formatAddressList(msg.cc)}`);
   if (msg.bcc && msg.bcc.length > 0) headers.push(`Bcc: ${formatAddressList(msg.bcc)}`);
   headers.push(`Subject: ${escapeHeader(msg.subject)}`);
+  if (opts.draftOrigin) headers.push(`${DRAFT_ORIGIN_HEADER}: ${opts.draftOrigin}`);
   if (opts.inReplyTo) headers.push(`In-Reply-To: ${escapeHeader(opts.inReplyTo)}`);
   if (opts.references && opts.references.length > 0) {
     headers.push(`References: ${opts.references.map(r => r.replace(/[\r\n]+/g, '')).join(' ')}`);

--- a/packages/provider-gmail/src/googleapis-client.test.ts
+++ b/packages/provider-gmail/src/googleapis-client.test.ts
@@ -86,6 +86,22 @@ describe('provider-gmail/GoogleapisGmailClient', () => {
     expect(result.threadId).toBe('t-1');
   });
 
+  it('Scenario: getDraft requests the draft resource and returns its backing message', async () => {
+    const api = createMockApi();
+    const client = createClient(api);
+
+    const result = await client.getDraft('d-1');
+
+    expect(api.users.drafts.get).toHaveBeenCalledWith({
+      userId: 'me',
+      id: 'd-1',
+      format: 'full',
+    });
+    expect(api.users.messages.get).not.toHaveBeenCalled();
+    expect(result.id).toBe('d-1');
+    expect(result.message.id).toBe('m-draft');
+  });
+
   it('Scenario: getMessage falls back to drafts.get for draft ids', async () => {
     const api = createMockApi();
     api.users.messages.get.mockRejectedValueOnce({ code: 404 });

--- a/packages/provider-gmail/src/googleapis-client.ts
+++ b/packages/provider-gmail/src/googleapis-client.ts
@@ -193,6 +193,21 @@ export class GoogleapisGmailClient implements GmailApiClient {
     }
   }
 
+  async getDraft(draftId: string): Promise<{ id: string; message: GmailMessage }> {
+    const response = await this.api.users.drafts.get({
+      userId: 'me',
+      id: draftId,
+      format: 'full',
+    });
+    if (!response.data?.id || !response.data.message?.id || !response.data.message.threadId) {
+      throw new Error('Gmail API drafts.get returned an incomplete draft payload');
+    }
+    return {
+      id: response.data.id,
+      message: response.data.message,
+    };
+  }
+
   async getAttachment(messageId: string, attachmentId: string): Promise<{ data?: string; size?: number }> {
     const response = await this.api.users.messages.attachments.get({
       userId: 'me',

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -951,11 +951,16 @@ describe('provider-microsoft/Draft-Then-Send via createReplyAll', () => {
     const patch = patchArgs[1] as {
       body: { content: string };
       ccRecipients: Array<{ emailAddress: { address: string } }>;
+      singleValueExtendedProperties: Array<{ id: string; value: string }>;
     };
     expect(patch.body.content).toContain('<p>rendered</p>');
     expect(patch.body.content).toContain('From:</b> Alice');
     const addresses = patch.ccRecipients.map(r => r.emailAddress.address.toLowerCase()).sort();
     expect(addresses).toEqual(['alice@corp.com', 'bob@corp.com']);
+    expect(patch.singleValueExtendedProperties).toContainEqual({
+      id: 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailDraftOrigin',
+      value: 'reply',
+    });
   });
 });
 
@@ -1235,14 +1240,16 @@ describe('provider-microsoft/Graph Scheduled Send Inspection and Cancellation', 
 });
 
 describe('provider-microsoft/update_draft Reply Metadata', () => {
+  const draftOriginProperty = 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailDraftOrigin';
+
   it('Scenario: update_draft preserves Graph auto-quoted thread', async () => {
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
         id: 'reply-draft',
         isDraft: true,
-        conversationId: 'conversation-1',
-        internetMessageHeaders: [
-          { name: 'In-Reply-To', value: '<original@example.com>' },
+        conversationIndex: Buffer.alloc(22).toString('base64'),
+        singleValueExtendedProperties: [
+          { id: draftOriginProperty, value: 'reply' },
         ],
       }),
     });
@@ -1250,19 +1257,22 @@ describe('provider-microsoft/update_draft Reply Metadata', () => {
 
     await expect(provider.getDraftReplyStatus('reply-draft')).resolves.toBe('reply');
     expect(client.get).toHaveBeenCalledWith(expect.stringContaining(
-      '$select=isDraft,conversationId,internetMessageHeaders',
+      '$select=isDraft,conversationIndex',
+    ));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining(
+      `$expand=singleValueExtendedProperties($filter=id eq '${draftOriginProperty}')`,
     ));
     expect(client.patch).not.toHaveBeenCalled();
   });
 
-  it('Scenario: A fresh draft is identified when metadata has no in-reply-to relationship', async () => {
+  it('Scenario: stamped non-reply draft is authoritative', async () => {
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
         id: 'fresh-draft',
         isDraft: true,
-        conversationId: 'conversation-2',
-        internetMessageHeaders: [
-          { name: 'Message-ID', value: '<fresh@example.com>' },
+        conversationIndex: Buffer.alloc(27).toString('base64'),
+        singleValueExtendedProperties: [
+          { id: draftOriginProperty, value: 'non_reply' },
         ],
       }),
     });
@@ -1272,10 +1282,32 @@ describe('provider-microsoft/update_draft Reply Metadata', () => {
   });
 
   it.each([
-    { isDraft: true, internetMessageHeaders: [] },
-    { isDraft: true, conversationId: 'conversation-3' },
-    { conversationId: 'conversation-3', internetMessageHeaders: [] },
-  ])('Scenario: Incomplete Graph metadata is indeterminate', async (metadata) => {
+    { bytes: 22, expected: 'non_reply' as const },
+    { bytes: 27, expected: 'reply' as const },
+  ])('Scenario: unstamped conversationIndex with $bytes bytes is $expected', async ({ bytes, expected }) => {
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'external-draft',
+        isDraft: true,
+        conversationIndex: Buffer.alloc(bytes, 0x5a).toString('base64url'),
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('external-draft')).resolves.toBe(expected);
+  });
+
+  it.each([
+    {
+      isDraft: true,
+      conversationId: 'conversation-3',
+      internetMessageHeaders: [],
+    },
+    { isDraft: true },
+    { isDraft: true, conversationIndex: 'not base64!' },
+    { isDraft: true, conversationIndex: 42 },
+    { isDraft: true, conversationIndex: Buffer.alloc(21).toString('base64') },
+  ])('Scenario: absent or invalid reply evidence is indeterminate', async (metadata) => {
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({ id: 'unknown-draft', ...metadata }),
     });
@@ -2339,10 +2371,15 @@ describe('provider-microsoft/Outbound Recipients', () => {
       toRecipients: Array<{ emailAddress: { address: string } }>;
       ccRecipients?: Array<{ emailAddress: { address: string; name?: string } }>;
       bccRecipients?: Array<{ emailAddress: { address: string } }>;
+      singleValueExtendedProperties: Array<{ id: string; value: string }>;
     };
     expect(msg.toRecipients.map(r => r.emailAddress.address)).toEqual(['alice@corp.com']);
     expect(msg.ccRecipients).toEqual([{ emailAddress: { address: 'carol@corp.com', name: 'Carol' } }]);
     expect(msg.bccRecipients).toEqual([{ emailAddress: { address: 'dave@corp.com', name: undefined } }]);
+    expect(msg.singleValueExtendedProperties).toContainEqual({
+      id: 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailDraftOrigin',
+      value: 'non_reply',
+    });
   });
 
   // Asserted against the real wire body, not the provider-level payload: the

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1004,6 +1004,10 @@ describe('provider-microsoft/Deferred Delivery via Graph Extended Property', () 
       }],
       singleValueExtendedProperties: expect.arrayContaining([
         { id: 'SystemTime 0x3FEF', value: '2026-07-24T12:00:00.000Z' },
+        {
+          id: 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailDraftOrigin',
+          value: 'non_reply',
+        },
       ]),
     }));
     expect(post).toHaveBeenNthCalledWith(
@@ -1281,20 +1285,34 @@ describe('provider-microsoft/update_draft Reply Metadata', () => {
     await expect(provider.getDraftReplyStatus('fresh-draft')).resolves.toBe('non_reply');
   });
 
-  it.each([
-    { bytes: 22, expected: 'non_reply' as const },
-    { bytes: 27, expected: 'reply' as const },
-  ])('Scenario: unstamped conversationIndex with $bytes bytes is $expected', async ({ bytes, expected }) => {
+  it('Scenario: unstamped valid root conversationIndex is indeterminate', async () => {
+    const rootConversationIndex = Buffer.alloc(22);
+    rootConversationIndex[0] = 0x01;
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
         id: 'external-draft',
         isDraft: true,
-        conversationIndex: Buffer.alloc(bytes, 0x5a).toString('base64url'),
+        conversationIndex: rootConversationIndex.toString('base64'),
       }),
     });
     const provider = new GraphEmailProvider(client);
 
-    await expect(provider.getDraftReplyStatus('external-draft')).resolves.toBe(expected);
+    await expect(provider.getDraftReplyStatus('external-draft')).resolves.toBe('indeterminate');
+  });
+
+  it('Scenario: unstamped child conversationIndex is positive reply evidence', async () => {
+    const childConversationIndex = Buffer.alloc(27);
+    childConversationIndex[0] = 0x01;
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'external-reply-draft',
+        isDraft: true,
+        conversationIndex: childConversationIndex.toString('base64'),
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('external-reply-draft')).resolves.toBe('reply');
   });
 
   it.each([
@@ -1307,6 +1325,12 @@ describe('provider-microsoft/update_draft Reply Metadata', () => {
     { isDraft: true, conversationIndex: 'not base64!' },
     { isDraft: true, conversationIndex: 42 },
     { isDraft: true, conversationIndex: Buffer.alloc(21).toString('base64') },
+    {
+      isDraft: true,
+      singleValueExtendedProperties: [
+        { id: draftOriginProperty, value: 'unexpected' },
+      ],
+    },
   ])('Scenario: absent or invalid reply evidence is indeterminate', async (metadata) => {
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({ id: 'unknown-draft', ...metadata }),

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1246,6 +1246,40 @@ describe('provider-microsoft/Graph Scheduled Send Inspection and Cancellation', 
 describe('provider-microsoft/update_draft Reply Metadata', () => {
   const draftOriginProperty = 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailDraftOrigin';
 
+  it('Scenario: conflicting duplicate origin stamps are indeterminate', async () => {
+    // A forged or colliding second stamp must not be resolvable by read order.
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'double-stamped',
+        isDraft: true,
+        conversationIndex: Buffer.alloc(27).toString('base64'),
+        singleValueExtendedProperties: [
+          { id: draftOriginProperty, value: 'non_reply' },
+          { id: draftOriginProperty, value: 'reply' },
+        ],
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('double-stamped')).resolves.toBe('indeterminate');
+  });
+
+  it('Scenario: duplicate but unanimous origin stamps still resolve', async () => {
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({
+        id: 'twice-stamped',
+        isDraft: true,
+        singleValueExtendedProperties: [
+          { id: draftOriginProperty, value: 'non_reply' },
+          { id: draftOriginProperty, value: 'non_reply' },
+        ],
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('twice-stamped')).resolves.toBe('non_reply');
+  });
+
   it('Scenario: update_draft preserves Graph auto-quoted thread', async () => {
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1234,56 +1234,59 @@ describe('provider-microsoft/Graph Scheduled Send Inspection and Cancellation', 
   });
 });
 
-describe('provider-microsoft/update_draft Quote Preservation', () => {
-  // Compose the realistic "post-prepareReplyDraft" fixture by simulating the
-  // create-path: caller fragment inserted by the same merge logic the production
-  // code uses. Round-trips through the merge helper so the fixture stays in sync
-  // with the splice anatomy if either side changes.
-  function replyDraftWith(callerFragment: string): string {
-    const bodyOpenEnd = QUOTED_REPLY_BODY.match(/<body[^>]*>/i);
-    if (!bodyOpenEnd || bodyOpenEnd.index === undefined) {
-      throw new Error('QUOTED_REPLY_BODY fixture missing <body> tag');
-    }
-    const idx = bodyOpenEnd.index + bodyOpenEnd[0].length;
-    return QUOTED_REPLY_BODY.slice(0, idx) + callerFragment + QUOTED_REPLY_BODY.slice(idx);
-  }
-
+describe('provider-microsoft/update_draft Reply Metadata', () => {
   it('Scenario: update_draft preserves Graph auto-quoted thread', async () => {
-    const replyDraftBody = replyDraftWith('<div>Old caller content</div>');
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
-        id: 'draft-update-1',
-        body: { contentType: 'html', content: replyDraftBody },
+        id: 'reply-draft',
+        isDraft: true,
+        conversationId: 'conversation-1',
+        internetMessageHeaders: [
+          { name: 'In-Reply-To', value: '<original@example.com>' },
+        ],
       }),
-      patch: vi.fn().mockResolvedValueOnce({}),
     });
     const provider = new GraphEmailProvider(client);
 
-    const result = await provider.updateDraft('draft-update-1', { body: 'Updated reply text' });
-
-    expect(result.success).toBe(true);
-    // Narrowed GET — only the body field is fetched
-    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('$select=body'));
-    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
-    expect(patchBody.contentType).toBe('HTML');
-    expect(patchBody.content).toContain('Updated reply text');
-    expect(patchBody.content).not.toContain('Old caller content');
-    // Quoted thread preserved (divider, header block, prior message body)
-    expect(patchBody.content).toContain('divRplyFwdMsg');
-    expect(patchBody.content).toContain('From:</b> Alice');
-    expect(patchBody.content).toContain('Original message content');
+    await expect(provider.getDraftReplyStatus('reply-draft')).resolves.toBe('reply');
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining(
+      '$select=isDraft,conversationId,internetMessageHeaders',
+    ));
+    expect(client.patch).not.toHaveBeenCalled();
   });
 
-  it('Scenario: update_draft does not mistake an authored horizontal rule for the Graph boundary', async () => {
-    const replyDraftBody = replyDraftWith(
-      '<div>Old authored start<hr><p>Old authored tail</p></div>',
-    );
+  it('Scenario: A fresh draft is identified when metadata has no in-reply-to relationship', async () => {
     const client = createMockClient({
       get: vi.fn().mockResolvedValueOnce({
-        id: 'draft-update-authored-hr',
-        body: { contentType: 'html', content: replyDraftBody },
+        id: 'fresh-draft',
+        isDraft: true,
+        conversationId: 'conversation-2',
+        internetMessageHeaders: [
+          { name: 'Message-ID', value: '<fresh@example.com>' },
+        ],
       }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('fresh-draft')).resolves.toBe('non_reply');
+  });
+
+  it.each([
+    { isDraft: true, internetMessageHeaders: [] },
+    { isDraft: true, conversationId: 'conversation-3' },
+    { conversationId: 'conversation-3', internetMessageHeaders: [] },
+  ])('Scenario: Incomplete Graph metadata is indeterminate', async (metadata) => {
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValueOnce({ id: 'unknown-draft', ...metadata }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await expect(provider.getDraftReplyStatus('unknown-draft')).resolves.toBe('indeterminate');
+  });
+
+  it('Scenario: update_draft on a fresh draft replaces body wholesale', async () => {
+    const client = createMockClient({
+      get: vi.fn(),
       patch: vi.fn().mockResolvedValueOnce({}),
     });
     const provider = new GraphEmailProvider(client);
@@ -1292,35 +1295,13 @@ describe('provider-microsoft/update_draft Quote Preservation', () => {
       bodyHtml: '<div>Replacement authored body<hr><p>Replacement tail</p></div>',
     });
 
-    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    const patchBody = (patchArgs[1] as { body: { content: string } }).body;
-    expect(patchBody.content).toContain('Replacement authored body');
-    expect(patchBody.content).toContain('Replacement tail');
-    expect(patchBody.content).not.toContain('Old authored start');
-    expect(patchBody.content).not.toContain('Old authored tail');
-    expect(patchBody.content).toContain('divRplyFwdMsg');
-    expect(patchBody.content).toContain('Original message content');
-  });
-
-  it('Scenario: update_draft on a fresh draft replaces body wholesale', async () => {
-    // No <hr> after <body> → no recognizable Graph reply anatomy → fall through to buildGraphBody
-    const FRESH_DRAFT_BODY = '<html><body><div>Old fresh content</div></body></html>';
-    const client = createMockClient({
-      get: vi.fn().mockResolvedValueOnce({
-        id: 'draft-update-2',
-        body: { contentType: 'html', content: FRESH_DRAFT_BODY },
-      }),
-      patch: vi.fn().mockResolvedValueOnce({}),
-    });
-    const provider = new GraphEmailProvider(client);
-
-    await provider.updateDraft('draft-update-2', { body: 'New body' });
-
+    expect(client.get).not.toHaveBeenCalled();
     const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
     const patchBody = (patchArgs[1] as { body: { contentType: string; content: string } }).body;
-    expect(patchBody.contentType).toBe('Text');
-    expect(patchBody.content).toBe('New body');
-    expect(patchBody.content).not.toContain('Old fresh content');
+    expect(patchBody).toEqual({
+      contentType: 'HTML',
+      content: '<div>Replacement authored body<hr><p>Replacement tail</p></div>',
+    });
   });
 });
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -113,6 +113,7 @@ class GraphAttachmentError extends Error {
 
 // Sent message tracking via custom extended property
 const TRACKING_PROPERTY = 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailTrackingId';
+const DRAFT_ORIGIN_PROPERTY = 'String {66f5a359-4659-4830-9070-00047ec6ac6e} Name AgentEmailDraftOrigin';
 const DEFERRED_SEND_PROPERTY = 'SystemTime 0x3FEF';
 
 const WELL_KNOWN_FOLDER_ALIASES: Record<string, string> = {
@@ -834,6 +835,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
       toRecipients: toGraphRecipients(msg.to),
       ccRecipients: toGraphRecipients(msg.cc),
       bccRecipients: toGraphRecipients(msg.bcc),
+      singleValueExtendedProperties: [
+        { id: DRAFT_ORIGIN_PROPERTY, value: 'non_reply' },
+      ],
     };
     if (msg.attachments && msg.attachments.length > 0) {
       graphMsg.attachments = msg.attachments.map(toGraphFileAttachment);
@@ -1054,6 +1058,9 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
 
     const patch: Record<string, unknown> = {
       body: { contentType: 'HTML', content: truncateBody(merged) },
+      singleValueExtendedProperties: [
+        { id: DRAFT_ORIGIN_PROPERTY, value: 'reply' },
+      ],
     };
 
     const ccMerged = mergeRecipients(draftCc, opts?.cc ?? []);
@@ -1086,26 +1093,28 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
   }
 
   async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
+    const propertyFilter = `$filter=id eq '${DRAFT_ORIGIN_PROPERTY}'`;
     const metadata = await this.client.get(
-      `${this.basePath}/messages/${encodeGraphPathId(draftId)}?$select=isDraft,conversationId,internetMessageHeaders`,
+      `${this.basePath}/messages/${encodeGraphPathId(draftId)}`
+      + `?$select=isDraft,conversationIndex`
+      + `&$expand=singleValueExtendedProperties(${propertyFilter})`,
     ) as unknown as GraphMessage;
 
-    if (
-      metadata.isDraft !== true
-      || typeof metadata.conversationId !== 'string'
-      || metadata.conversationId.trim().length === 0
-      || !Array.isArray(metadata.internetMessageHeaders)
-    ) {
+    if (metadata.isDraft !== true) return 'indeterminate';
+
+    const originStamp = metadata.singleValueExtendedProperties?.find(
+      property => property.id.toLowerCase() === DRAFT_ORIGIN_PROPERTY.toLowerCase(),
+    );
+    if (originStamp) {
+      if (originStamp.value === 'reply') return 'reply';
+      if (originStamp.value === 'non_reply') return 'non_reply';
       return 'indeterminate';
     }
 
-    const inReplyTo = metadata.internetMessageHeaders.find(
-      header => typeof header.name === 'string'
-        && header.name.toLowerCase() === 'in-reply-to',
-    );
-    if (!inReplyTo) return 'non_reply';
-    if (typeof inReplyTo.value !== 'string') return 'indeterminate';
-    return inReplyTo.value.trim().length > 0 ? 'reply' : 'indeterminate';
+    const conversationIndexBytes = decodeConversationIndex(metadata.conversationIndex);
+    if (conversationIndexBytes === undefined) return 'indeterminate';
+    if (conversationIndexBytes === 22) return 'non_reply';
+    return conversationIndexBytes > 22 ? 'reply' : 'indeterminate';
   }
 
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {
@@ -1511,6 +1520,25 @@ function findDeferredSendProperty(
   );
 }
 
+function decodeConversationIndex(value: unknown): number | undefined {
+  if (typeof value !== 'string' || value.length === 0 || value !== value.trim()) {
+    return undefined;
+  }
+  if (!/^[A-Za-z0-9+/_-]+={0,2}$/.test(value)) return undefined;
+
+  const firstPadding = value.indexOf('=');
+  if (firstPadding >= 0 && value.length % 4 !== 0) return undefined;
+
+  const unpadded = value.replace(/=+$/, '');
+  if (unpadded.length % 4 === 1) return undefined;
+  const normalized = unpadded.replace(/-/g, '+').replace(/_/g, '/');
+
+  const decoded = Buffer.from(normalized, 'base64');
+  const canonical = decoded.toString('base64').replace(/=+$/, '');
+  if (canonical !== normalized) return undefined;
+  return decoded.length;
+}
+
 function scheduledDraftSendFailure(
   draftId: string,
   scheduledSendAt: string,
@@ -1566,6 +1594,7 @@ interface GraphMessage {
   uniqueBody?: { contentType: string; content: string };
   categories?: string[];
   conversationId?: string;
+  conversationIndex?: string;
   flag?: { flagStatus?: string };
   internetMessageId?: string;
   internetMessageHeaders?: Array<{ name: string; value: string }>;

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -866,6 +866,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
       singleValueExtendedProperties: [
         { id: TRACKING_PROPERTY, value: trackingId },
         { id: DEFERRED_SEND_PROPERTY, value: scheduledSendAt },
+        { id: DRAFT_ORIGIN_PROPERTY, value: 'non_reply' },
       ],
     };
     if (msg.attachments && msg.attachments.length > 0) {
@@ -1113,7 +1114,6 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
 
     const conversationIndexBytes = decodeConversationIndex(metadata.conversationIndex);
     if (conversationIndexBytes === undefined) return 'indeterminate';
-    if (conversationIndexBytes === 22) return 'non_reply';
     return conversationIndexBytes > 22 ? 'reply' : 'indeterminate';
   }
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -24,6 +24,7 @@ import type {
   ScheduledSend,
   ScheduledSendResult,
   EmailScheduledSender,
+  DraftReplyStatus,
 } from '@usejunior/email-core';
 import { AttachmentNotSupportedError, AttachmentNotFoundError, ProviderError } from '@usejunior/email-core';
 
@@ -1084,34 +1085,36 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
     return draft.id;
   }
 
+  async getDraftReplyStatus(draftId: string): Promise<DraftReplyStatus> {
+    const metadata = await this.client.get(
+      `${this.basePath}/messages/${encodeGraphPathId(draftId)}?$select=isDraft,conversationId,internetMessageHeaders`,
+    ) as unknown as GraphMessage;
+
+    if (
+      metadata.isDraft !== true
+      || typeof metadata.conversationId !== 'string'
+      || metadata.conversationId.trim().length === 0
+      || !Array.isArray(metadata.internetMessageHeaders)
+    ) {
+      return 'indeterminate';
+    }
+
+    const inReplyTo = metadata.internetMessageHeaders.find(
+      header => typeof header.name === 'string'
+        && header.name.toLowerCase() === 'in-reply-to',
+    );
+    if (!inReplyTo) return 'non_reply';
+    if (typeof inReplyTo.value !== 'string') return 'indeterminate';
+    return inReplyTo.value.trim().length > 0 ? 'reply' : 'indeterminate';
+  }
+
   async updateDraft(draftId: string, msg: Partial<ComposeMessage>): Promise<DraftResult> {
     const patch: Record<string, unknown> = {};
     if (msg.body !== undefined || msg.bodyHtml !== undefined) {
-      // For reply drafts, GET the existing body so we can preserve Graph's auto-quoted
-      // thread (divider + From/Sent/To/Subject + prior message). Replacing the body
-      // wholesale via PATCH would drop the quoted history that prepareReplyDraft set up.
-      // For non-reply drafts (no quoted-thread anatomy), this falls through to the
-      // normal buildGraphBody path so behavior is unchanged.
-      // $select=body narrows the response — we only need the body field here.
-      const current = await this.client.get(
-        `${this.basePath}/messages/${encodeGraphPathId(draftId)}?$select=body`,
-      );
-      const currentBody = current.body as { contentType?: string; content?: string } | undefined;
-      const currentContent = typeof currentBody?.content === 'string' ? currentBody.content : '';
-      const currentIsHtml = currentBody?.contentType?.toLowerCase() === 'html';
-      const region = currentIsHtml ? findGraphQuotedReplyRegion(currentContent) : null;
-
-      if (region) {
-        const callerFragment = msg.bodyHtml !== undefined
-          ? stripHtmlBodyWrappers(msg.bodyHtml)
-          : wrapPlainTextAsHtml(msg.body ?? '');
-        const merged = currentContent.slice(0, region.bodyOpenEnd)
-          + callerFragment
-          + currentContent.slice(region.dividerStart);
-        patch.body = { contentType: 'HTML', content: truncateBody(merged) };
-      } else {
-        patch.body = buildGraphBody(msg.bodyHtml, msg.body ?? '');
-      }
+      // update_draft admits body writes only for provider-confirmed non-reply
+      // drafts with explicit caller opt-in. Graph PATCH replaces that body
+      // wholesale; no quoted-history boundary inspection belongs here.
+      patch.body = buildGraphBody(msg.bodyHtml, msg.body ?? '');
     }
     if (msg.subject !== undefined) patch.subject = msg.subject.slice(0, SUBJECT_MAX_LENGTH);
     // An omitted list leaves the draft's existing recipients untouched (Graph

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -1103,12 +1103,18 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
 
     if (metadata.isDraft !== true) return 'indeterminate';
 
-    const originStamp = metadata.singleValueExtendedProperties?.find(
+    // Duplicate stamps are ambiguous: taking the first match would make the
+    // answer depend on the order Graph returns the collection. Only a single,
+    // unanimous stamp is authoritative.
+    const originStamps = (metadata.singleValueExtendedProperties ?? []).filter(
       property => property.id.toLowerCase() === DRAFT_ORIGIN_PROPERTY.toLowerCase(),
     );
-    if (originStamp) {
-      if (originStamp.value === 'reply') return 'reply';
-      if (originStamp.value === 'non_reply') return 'non_reply';
+    if (originStamps.length > 0) {
+      const values = originStamps.map(property => property.value);
+      const unanimous = values.every(value => value === values[0]);
+      if (!unanimous) return 'indeterminate';
+      if (values[0] === 'reply') return 'reply';
+      if (values[0] === 'non_reply') return 'non_reply';
       return 'indeterminate';
     }
 


### PR DESCRIPTION
## Summary

`update_draft` decided how to PATCH a body by searching the body HTML for a quoted-history boundary. Both shipped variants failed silently and in opposite directions — one stacked a second copy of the message, the other deleted the entire quoted thread. This retires the heuristic and replaces it with a provider-level determination that fails closed.

Implements the OpenSpec change `update-draft-body-safety` (proposal committed in the first commit on this branch; `openspec validate --strict` passes).

## Implementation

- **Reply status from Graph metadata, not body content.** New optional `getDraftReplyStatus(draftId)` on the `EmailSender` capability returning `'reply' | 'non_reply' | 'indeterminate'`. Indeterminate is treated as a reply, so a detection miss cannot destroy quoted history.
- **Reply draft + `body`** → recoverable `REPLY_DRAFT_BODY_IMMUTABLE`, body untouched, message names the remedy (create a new draft).
- **Non-reply draft + `body`** → requires explicit `replace_body: true`, then replaces wholesale.
- **`subject` / `attachments` / `to` / `cc` remain editable on any draft.** Renaming a reply is permitted and emits a non-blocking threading warning — deliberately *not* refused, since marking a superseded draft is a legitimate and needed operation.
- **New non-blocking `warnings` channel** on draft-write responses.
- The `<hr>` / `divRplyFwdMsg` splice is removed from the draft-update path. It is retained in `mapGraphMessage` (read path) where it selects `authoredBodyHtml` for previews — read-only and cosmetic, and out of scope for this change.

## Verification

- [x] `npm run build` clean
- [x] `npm run test:run` — 1,005 workspace tests + 31 script tests pass, no pre-existing failures
- [x] `npm run lint` clean
- [x] `npx openspec validate update-draft-body-safety --strict`
- [x] `npm run check:spec-coverage` — 262/262 scenarios
- [ ] Peer review (agy + Codex) — pending, will be appended
- [ ] **Live Graph verification — see risk below. Not merged until confirmed.**

## Risk: the `internetMessageHeaders` assumption is unverified against live Graph

`getDraftReplyStatus` reads `?$select=isDraft,conversationId,internetMessageHeaders` and returns `'indeterminate'` when `internetMessageHeaders` is not an array, looking for an `In-Reply-To` header to classify a reply.

**Microsoft Graph may not populate `internetMessageHeaders` on unsent drafts** — those headers are generally produced at send/transport time. If it is absent, every draft classifies as `indeterminate`, fail-closed refuses *all* body edits, and `replace_body: true` becomes unreachable. The unit tests mock the Graph response, so they prove the branching logic but cannot catch this.

The prior live probe recorded on #87 verified `isDraft`, `body` and `uniqueBody` on real reply and non-reply drafts, but **did not test `internetMessageHeaders`**. That probe did establish a working discriminator: a `createReply` draft's full body contains the Graph reply boundary while a fresh non-reply draft's does not — but that is body-sniffing, which is what this change exists to remove.

Needs a live `GET /me/messages/{draftId}?$select=isDraft,conversationId,internetMessageHeaders` against (a) a `createReply` draft and (b) a fresh `createDraft`, on a throwaway draft that is never sent. Auto-merge is intentionally NOT armed.

## Closes
- #159