### PR TITLE
feat(gmail): add Maton transport

### DIFF
--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -492,6 +492,10 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
         GmailAuthManager,
         GmailEmailProvider,
         GoogleapisGmailClient,
+        MatonGmailApiClient,
+        loadMatonGmailConnections,
+        parseMatonGmailAccounts,
+        resolveMatonGmailConnection,
         formatGmailAuthError,
       },
     ] = await Promise.all([
@@ -499,9 +503,41 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
       import('@usejunior/provider-gmail'),
     ]);
     const microsoftMailboxes = await listConfiguredMailboxesWithMetadata();
-    const gmailMailboxes = await listConfiguredGmailMailboxes();
+    const gmailTransport = process.env['EMAIL_AGENT_MCP_GMAIL_TRANSPORT'];
+    if (gmailTransport && gmailTransport !== 'oauth' && gmailTransport !== 'maton') {
+      throw new Error(`Unsupported Gmail transport: ${gmailTransport}`);
+    }
+    const gmailMatonMode = gmailTransport === 'maton';
+    const matonGmailAccounts = gmailMatonMode
+      ? parseMatonGmailAccounts(process.env['EMAIL_AGENT_MCP_MATON_GMAIL_ACCOUNTS'])
+      : [];
+    const gmailMailboxes = gmailMatonMode ? [] : await listConfiguredGmailMailboxes();
+    const matonConnectionsPath = process.env['EMAIL_AGENT_MCP_MATON_CONNECTIONS_PATH'];
+    const matonApiKey = process.env['MATON_API_KEY'];
+    let matonGmailConnections = null;
+    let matonGmailSetupError: Error | null = null;
+    if (gmailMatonMode) {
+      try {
+        if (!matonConnectionsPath) {
+          throw new Error('EMAIL_AGENT_MCP_MATON_CONNECTIONS_PATH is required for Maton transport');
+        }
+        if (!matonApiKey) {
+          throw new Error('MATON_API_KEY is required for Maton transport');
+        }
+        matonGmailConnections = await loadMatonGmailConnections(
+          matonConnectionsPath,
+          matonGmailAccounts,
+        );
+      } catch (err) {
+        matonGmailSetupError = err instanceof Error ? err : new Error(String(err));
+      }
+    }
 
-    if (microsoftMailboxes.length === 0 && gmailMailboxes.length === 0) {
+    if (
+      microsoftMailboxes.length === 0 &&
+      gmailMailboxes.length === 0 &&
+      matonGmailAccounts.length === 0
+    ) {
       state.isDemo = true;
       state.status = 'not_configured';
       state.mailboxes = [];
@@ -556,6 +592,43 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
         console.error(
           `[email-agent-mcp] Skipping mailbox "${displayName}": ${err instanceof Error ? err.message : err}`,
         );
+      }
+    }
+
+    for (const account of matonGmailAccounts) {
+      try {
+        if (matonGmailSetupError) throw matonGmailSetupError;
+        const connection = resolveMatonGmailConnection(matonGmailConnections!, account);
+        const client = new MatonGmailApiClient(matonApiKey!, connection.connectionId);
+        const provider = new GmailEmailProvider(client);
+        connectedMailboxes.push({
+          name: account,
+          emailAddress: account,
+          displayName: account,
+          providerType: 'gmail',
+          provider,
+          auth: {
+            getTokenHealthWarning: () => undefined,
+            tryReconnect: async () => false,
+          },
+          isDefault: false,
+          status: 'connected',
+        });
+        console.error(`[email-agent-mcp] Connected to Gmail mailbox "${account}" via Maton`);
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        failedMailboxes.push({
+          name: account,
+          emailAddress: account,
+          displayName: account,
+          providerType: 'gmail',
+          provider: null,
+          auth: null,
+          isDefault: false,
+          status: 'error',
+          error,
+        });
+        console.error(`[email-agent-mcp] Skipping Gmail mailbox "${account}": ${error}`);
       }
     }
 

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -51,7 +51,7 @@ function createMockGmailClient(overrides: Partial<GmailApiClient> = {}): GmailAp
     modifyMessage: vi.fn().mockResolvedValue(undefined),
     getThread: vi.fn().mockResolvedValue({ id: 'thread-1', messages: [] }),
     createDraft: vi.fn().mockResolvedValue({ id: 'draft-abc', message: { id: 'msg-draft', threadId: 'thread-draft' } }),
-    sendDraft: vi.fn().mockResolvedValue({ id: 'draft-abc', message: { id: 'sent-draft-msg', threadId: 'thread-draft' } }),
+    sendDraft: vi.fn().mockResolvedValue({ id: 'sent-draft-msg', threadId: 'thread-draft' }),
     updateDraft: vi.fn().mockResolvedValue({ id: 'draft-abc', message: { id: 'msg-updated', threadId: 'thread-draft' } }),
     ...overrides,
   };

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -51,7 +51,7 @@ export interface GmailApiClient {
    * the draft into an existing thread (used by reply-draft flows).
    */
   createDraft(raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }>;
-  sendDraft(draftId: string): Promise<{ id: string; message: { id: string; threadId: string } }>;
+  sendDraft(draftId: string): Promise<{ id: string; threadId: string }>;
   /**
    * Update an existing draft by full replacement with a raw RFC 2822
    * message. Optional `threadId` preserves the draft's thread association
@@ -243,7 +243,7 @@ export class GmailEmailProvider {
 
   async sendDraft(draftId: string): Promise<SendResult> {
     const result = await this.client.sendDraft(draftId);
-    return { success: true, messageId: result.message.id };
+    return { success: true, messageId: result.id };
   }
 
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {

--- a/packages/provider-gmail/src/googleapis-client.test.ts
+++ b/packages/provider-gmail/src/googleapis-client.test.ts
@@ -31,7 +31,7 @@ function createMockApi() {
       drafts: {
         create: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: { id: 'm-draft', threadId: 't-draft' } } }),
         get: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: message('m-draft', 't-draft') } }),
-        send: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: { id: 'm-sent-draft', threadId: 't-draft' } } }),
+        send: vi.fn().mockResolvedValue({ data: { id: 'm-sent-draft', threadId: 't-draft' } }),
         update: vi.fn().mockResolvedValue({ data: { id: 'd-1', message: { id: 'm-updated-draft', threadId: 't-draft' } } }),
       },
       threads: {
@@ -280,8 +280,8 @@ describe('provider-gmail/GoogleapisGmailClient', () => {
       requestBody: { id: 'd-1' },
     });
     expect(result).toEqual({
-      id: 'd-1',
-      message: { id: 'm-sent-draft', threadId: 't-draft' },
+      id: 'm-sent-draft',
+      threadId: 't-draft',
     });
   });
 

--- a/packages/provider-gmail/src/googleapis-client.ts
+++ b/packages/provider-gmail/src/googleapis-client.ts
@@ -55,7 +55,7 @@ interface GmailDraftsApi {
   send(args: {
     userId: string;
     requestBody: { id: string };
-  }): Promise<{ data?: GmailDraft }>;
+  }): Promise<{ data?: MessageSummary }>;
   update(args: {
     userId: string;
     id: string;
@@ -269,13 +269,13 @@ export class GoogleapisGmailClient implements GmailApiClient {
     return requireDraft(response.data, 'drafts.create');
   }
 
-  async sendDraft(draftId: string): Promise<{ id: string; message: { id: string; threadId: string } }> {
+  async sendDraft(draftId: string): Promise<{ id: string; threadId: string }> {
     const response = await this.api.users.drafts.send({
       userId: 'me',
       requestBody: { id: draftId },
     });
 
-    return requireDraft(response.data, 'drafts.send');
+    return requireMessageSummary(response.data, 'drafts.send');
   }
 
   async updateDraft(draftId: string, raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }> {

--- a/packages/provider-gmail/src/index.ts
+++ b/packages/provider-gmail/src/index.ts
@@ -25,4 +25,11 @@ export {
 } from './config.js';
 export type { GmailMailboxMetadata, GmailAuthSource } from './config.js';
 export { GoogleapisGmailClient } from './googleapis-client.js';
+export {
+  MatonGmailApiClient,
+  loadMatonGmailConnections,
+  parseMatonGmailAccounts,
+  resolveMatonGmailConnection,
+} from './maton.js';
+export type { MatonGmailConnection } from './maton.js';
 export { registerWatch, needsRenewal, pollHistory } from './push.js';

--- a/packages/provider-gmail/src/maton.test.ts
+++ b/packages/provider-gmail/src/maton.test.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  MatonGmailApiClient,
+  loadMatonGmailConnections,
+  parseMatonGmailAccounts,
+  resolveMatonGmailConnection,
+} from './maton.js';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Maton Gmail connection isolation', () => {
+  it('loads only exact ACTIVE google-mail accounts', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maton-gmail-'));
+    const path = join(dir, 'connections.json');
+    await writeFile(path, JSON.stringify({
+      connections: [
+        { app: 'google-mail', account: 'User@Example.com', connection_id: 'gmail-1', status: 'ACTIVE' },
+        { app: 'outlook', account: 'user@example.com', connection_id: 'wrong', status: 'ACTIVE' },
+        { app: 'google-mail', account: 'other@example.com', connection_id: 'unscoped', status: 'EXPIRED' },
+      ],
+    }));
+
+    const connections = await loadMatonGmailConnections(path, ['user@example.com']);
+    expect([...connections.keys()]).toEqual(['user@example.com']);
+    expect(resolveMatonGmailConnection(connections, ' USER@example.com ')).toEqual({
+      account: 'user@example.com',
+      connectionId: 'gmail-1',
+    });
+  });
+
+  it('fails closed on missing, duplicate, or inactive expected accounts', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maton-gmail-'));
+    const path = join(dir, 'connections.json');
+    await writeFile(path, JSON.stringify({
+      connections: [
+        { app: 'google-mail', account: 'user@example.com', connection_id: 'a', status: 'ACTIVE' },
+        { app: 'google-mail', account: 'USER@example.com', connection_id: 'b', status: 'ACTIVE' },
+      ],
+    }));
+    await expect(loadMatonGmailConnections(path, ['user@example.com'])).rejects.toThrow('Duplicate');
+
+    await writeFile(path, JSON.stringify({
+      connections: [
+        { app: 'google-mail', account: 'user@example.com', connection_id: 'a', status: 'EXPIRED' },
+      ],
+    }));
+    await expect(loadMatonGmailConnections(path, ['user@example.com'])).rejects.toThrow('not ACTIVE');
+
+    await writeFile(path, JSON.stringify({ connections: [] }));
+    const connections = await loadMatonGmailConnections(path, ['user@example.com']);
+    expect(() => resolveMatonGmailConnection(connections, 'user@example.com')).toThrow('No ACTIVE');
+  });
+
+  it('requires an explicit unique account allowlist', () => {
+    expect(parseMatonGmailAccounts('USER@example.com,other@example.com')).toEqual([
+      'user@example.com',
+      'other@example.com',
+    ]);
+    expect(() => parseMatonGmailAccounts(undefined)).toThrow('is required');
+    expect(() => parseMatonGmailAccounts('user@example.com,USER@example.com')).toThrow('Duplicate');
+  });
+});
+
+describe('MatonGmailApiClient', () => {
+  it('preserves list query semantics and sends credentials only to the fixed gateway', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      messages: [{ id: 'm-1', threadId: 't-1' }],
+      nextPageToken: 'next',
+      resultSizeEstimate: 2,
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new MatonGmailApiClient('secret-key', 'connection-1', 1000);
+
+    await expect(client.listMessages({
+      labelIds: ['INBOX', 'STARRED'],
+      maxResults: 10,
+      q: 'from:a+b@example.com',
+      pageToken: 'page/2',
+    })).resolves.toEqual({
+      messages: [{ id: 'm-1', threadId: 't-1' }],
+      nextPageToken: 'next',
+      resultSizeEstimate: 2,
+    });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.origin + parsed.pathname).toBe(
+      'https://gateway.maton.ai/google-mail/gmail/v1/users/me/messages',
+    );
+    expect(parsed.searchParams.getAll('labelIds')).toEqual(['INBOX', 'STARRED']);
+    expect(parsed.searchParams.get('q')).toBe('from:a+b@example.com');
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer secret-key',
+      'Maton-Connection': 'connection-1',
+    });
+  });
+
+  it('preserves draft fallback, thread association, attachment bytes, and mutation methods', async () => {
+    const responses = [
+      new Response(JSON.stringify({ error: { message: 'Invalid id value' } }), { status: 400 }),
+      new Response(JSON.stringify({ id: 'd-1', message: { id: 'm-draft', threadId: 't-1' } }), { status: 200 }),
+      new Response(JSON.stringify({ id: 'd-1', message: { id: 'm-draft', threadId: 't-1' } }), { status: 200 }),
+      new Response(JSON.stringify({ data: 'YWJj', size: 3 }), { status: 200 }),
+      new Response(JSON.stringify({ id: 'd-1', message: { id: 'm-draft', threadId: 't-1' } }), { status: 200 }),
+      new Response(JSON.stringify({ id: 'd-1', message: { id: 'm-updated', threadId: 't-1' } }), { status: 200 }),
+      new Response(JSON.stringify({ id: 'm-sent', threadId: 't-1' }), { status: 200 }),
+    ];
+    const fetchMock = vi.fn(async () => responses.shift()!);
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new MatonGmailApiClient('secret-key', 'connection-1', 1000);
+
+    await expect(client.getMessage('d/1')).resolves.toMatchObject({ id: 'm-draft', threadId: 't-1' });
+    await expect(client.getDraft('d/1')).resolves.toMatchObject({
+      id: 'd-1',
+      message: { id: 'm-draft', threadId: 't-1' },
+    });
+    await expect(client.getAttachment('m/1', 'a/1')).resolves.toEqual({ data: 'YWJj', size: 3 });
+    await client.createDraft('raw', 't-1');
+    await client.updateDraft('d/1', 'updated', 't-1');
+    await expect(client.sendDraft('d-1')).resolves.toEqual({ id: 'm-sent', threadId: 't-1' });
+
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('/messages/d%2F1?format=full');
+    expect(String(fetchMock.mock.calls[1]![0])).toContain('/drafts/d%2F1?format=full');
+    expect(fetchMock.mock.calls[4]![1].method).toBe('POST');
+    expect(fetchMock.mock.calls[5]![1].method).toBe('PUT');
+    expect(fetchMock.mock.calls[6]![1].method).toBe('POST');
+    expect(JSON.parse(String(fetchMock.mock.calls[4]![1].body))).toEqual({
+      message: { raw: 'raw', threadId: 't-1' },
+    });
+  });
+
+  it('does not retry failed mutations or expose credentials echoed by an upstream error', async () => {
+    const fetchMock = vi.fn(async () => new Response(
+      'upstream unavailable for secret-key and connection-1',
+      { status: 503 },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+    const client = new MatonGmailApiClient('secret-key', 'connection-1', 1000);
+
+    await expect(client.sendMessage('raw')).rejects.toThrow('Gmail API error 503');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    try {
+      await client.sendMessage('raw');
+    } catch (err) {
+      expect(String(err)).not.toContain('secret-key');
+      expect(String(err)).not.toContain('connection-1');
+    }
+  });
+});

--- a/packages/provider-gmail/src/maton.ts
+++ b/packages/provider-gmail/src/maton.ts
@@ -1,0 +1,339 @@
+import { readFile } from 'node:fs/promises';
+import type { GmailApiClient, GmailMessage } from './email-gmail-provider.js';
+
+const MATON_GMAIL_ROOT = 'https://gateway.maton.ai/google-mail/gmail/v1';
+const DEFAULT_DEADLINE_MS = 90_000;
+
+interface MatonConnectionRecord {
+  app?: unknown;
+  account?: unknown;
+  connection_id?: unknown;
+  status?: unknown;
+}
+
+interface MatonConnectionsFile {
+  connections?: unknown;
+}
+
+interface MessageSummary {
+  id?: string | null;
+  threadId?: string | null;
+}
+
+interface GmailDraft {
+  id?: string | null;
+  message?: GmailMessage;
+}
+
+export interface MatonGmailConnection {
+  account: string;
+  connectionId: string;
+}
+
+function normalizeAccount(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function assertAccount(value: string): string {
+  const account = normalizeAccount(value);
+  if (
+    account.length < 3 ||
+    account.length > 254 ||
+    !account.includes('@') ||
+    /[\s\u0000-\u001f\u007f]/.test(account)
+  ) {
+    throw new Error('Invalid Maton Gmail account');
+  }
+  return account;
+}
+
+function assertConnectionId(value: unknown, account: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length < 1 ||
+    value.length > 256 ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`Invalid Maton Gmail connection id for ${account}`);
+  }
+  return value;
+}
+
+function encodePathSegment(value: string): string {
+  if (!value || value.length > 2048 || /[\u0000-\u001f\u007f]/.test(value)) {
+    throw new Error('Invalid Gmail resource id');
+  }
+  return encodeURIComponent(value);
+}
+
+function requireMessage(message: GmailMessage | undefined, op: string): GmailMessage {
+  if (!message?.id || !message.threadId) {
+    throw new Error(`Gmail API ${op} returned an incomplete message payload`);
+  }
+  return message;
+}
+
+function requireMessageSummary(summary: MessageSummary | undefined, op: string): { id: string; threadId: string } {
+  if (!summary?.id || !summary.threadId) {
+    throw new Error(`Gmail API ${op} returned an incomplete message summary`);
+  }
+  return { id: summary.id, threadId: summary.threadId };
+}
+
+function requireDraft(draft: GmailDraft | undefined, op: string): { id: string; message: { id: string; threadId: string } } {
+  if (!draft?.id || !draft.message?.id || !draft.message.threadId) {
+    throw new Error(`Gmail API ${op} returned an incomplete draft payload`);
+  }
+  return {
+    id: draft.id,
+    message: { id: draft.message.id, threadId: draft.message.threadId },
+  };
+}
+
+export function parseMatonGmailAccounts(value: string | undefined): string[] {
+  if (!value) throw new Error('EMAIL_AGENT_MCP_MATON_GMAIL_ACCOUNTS is required for Maton Gmail transport');
+  const accounts = value.split(',').map(assertAccount);
+  if (accounts.length === 0) throw new Error('At least one Maton Gmail account is required');
+  if (new Set(accounts).size !== accounts.length) {
+    throw new Error('Duplicate Maton Gmail account in configured account list');
+  }
+  return accounts;
+}
+
+export async function loadMatonGmailConnections(
+  path: string,
+  expectedAccounts: Iterable<string>,
+): Promise<Map<string, MatonGmailConnection>> {
+  let parsed: MatonConnectionsFile;
+  try {
+    parsed = JSON.parse(await readFile(path, 'utf8')) as MatonConnectionsFile;
+  } catch (err) {
+    throw new Error(
+      `Unable to load Maton connections file: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!Array.isArray(parsed.connections)) {
+    throw new Error('Invalid Maton connections file: "connections" must be an array');
+  }
+
+  const expected = new Set([...expectedAccounts].map(assertAccount));
+  const result = new Map<string, MatonGmailConnection>();
+  for (const raw of parsed.connections as MatonConnectionRecord[]) {
+    if (raw.app !== 'google-mail' || typeof raw.account !== 'string' || !raw.account.trim()) continue;
+    const account = normalizeAccount(raw.account);
+    if (!expected.has(account)) continue;
+    if (result.has(account)) throw new Error(`Duplicate Maton Gmail connection for ${account}`);
+    if (raw.status !== 'ACTIVE') throw new Error(`Maton Gmail connection for ${account} is not ACTIVE`);
+    result.set(account, {
+      account,
+      connectionId: assertConnectionId(raw.connection_id, account),
+    });
+  }
+  return result;
+}
+
+export function resolveMatonGmailConnection(
+  connections: Map<string, MatonGmailConnection>,
+  emailAddress: string,
+): MatonGmailConnection {
+  const account = assertAccount(emailAddress);
+  const connection = connections.get(account);
+  if (!connection) throw new Error(`No ACTIVE Maton Gmail connection for ${account}`);
+  return connection;
+}
+
+class MatonGmailApiError extends Error {
+  readonly code: number;
+  readonly response: { status: number; data: { error: { message: string } } };
+
+  constructor(status: number, message: string) {
+    super(`Gmail API error ${status}: ${message}`);
+    this.name = 'MatonGmailApiError';
+    this.code = status;
+    this.response = { status, data: { error: { message } } };
+  }
+}
+
+function shouldFallbackToDraftLookup(err: unknown): boolean {
+  const record = err as { code?: unknown; response?: { status?: unknown; data?: { error?: { message?: unknown } } } } | null;
+  if (!record || typeof record !== 'object') return false;
+  const status = typeof record.code === 'number' ? record.code : record.response?.status;
+  if (status === 404) return true;
+  return status === 400 &&
+    typeof record.response?.data?.error?.message === 'string' &&
+    /invalid id value/i.test(record.response.data.error.message);
+}
+
+export class MatonGmailApiClient implements GmailApiClient {
+  constructor(
+    private readonly apiKey: string,
+    private readonly connectionId: string,
+    private readonly deadlineMs = DEFAULT_DEADLINE_MS,
+  ) {
+    if (!apiKey) throw new Error('MATON_API_KEY is required for Gmail transport');
+    assertConnectionId(connectionId, 'configured mailbox');
+    if (!Number.isSafeInteger(deadlineMs) || deadlineMs < 1 || deadlineMs > 300_000) {
+      throw new Error('Invalid Maton request deadline');
+    }
+  }
+
+  private async request<T>(path: string, method: string, body?: unknown): Promise<T> {
+    const url = new URL(`${MATON_GMAIL_ROOT}${path}`);
+    if (
+      url.protocol !== 'https:' ||
+      url.hostname !== 'gateway.maton.ai' ||
+      url.port !== '' ||
+      url.username !== '' ||
+      url.password !== '' ||
+      !url.pathname.startsWith('/google-mail/gmail/v1/')
+    ) {
+      throw new Error('Untrusted Maton Gmail URL');
+    }
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Maton-Connection': this.connectionId,
+    };
+    const init: RequestInit = {
+      method,
+      headers,
+      signal: AbortSignal.timeout(this.deadlineMs),
+    };
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(body);
+    }
+    const response = await fetch(url, init);
+    const text = await response.text();
+    if (!response.ok) {
+      let message = text.slice(0, 500) || response.statusText || 'request failed';
+      try {
+        const parsed = JSON.parse(text) as { error?: { message?: unknown } };
+        if (typeof parsed.error?.message === 'string') message = parsed.error.message.slice(0, 500);
+      } catch {
+        // Preserve the bounded plain-text error.
+      }
+      message = message
+        .replaceAll(this.apiKey, '[redacted]')
+        .replaceAll(this.connectionId, '[redacted]');
+      throw new MatonGmailApiError(response.status, message);
+    }
+    return (text ? JSON.parse(text) : {}) as T;
+  }
+
+  async listMessages(opts: {
+    labelIds?: string[];
+    maxResults?: number;
+    q?: string;
+    pageToken?: string;
+  }): Promise<{ messages?: Array<{ id: string; threadId: string }>; resultSizeEstimate?: number; nextPageToken?: string }> {
+    const params = new URLSearchParams();
+    for (const labelId of opts.labelIds ?? []) params.append('labelIds', labelId);
+    if (opts.maxResults !== undefined) params.set('maxResults', String(opts.maxResults));
+    if (opts.q !== undefined) params.set('q', opts.q);
+    if (opts.pageToken) params.set('pageToken', opts.pageToken);
+    const query = params.size ? `?${params.toString()}` : '';
+    const response = await this.request<{
+      messages?: MessageSummary[];
+      resultSizeEstimate?: number | null;
+      nextPageToken?: string | null;
+    }>(`/users/me/messages${query}`, 'GET');
+    return {
+      messages: response.messages
+        ?.filter((message): message is { id: string; threadId: string } => !!message.id && !!message.threadId)
+        .map(message => ({ id: message.id, threadId: message.threadId })),
+      resultSizeEstimate: response.resultSizeEstimate ?? undefined,
+      ...(response.nextPageToken ? { nextPageToken: response.nextPageToken } : {}),
+    };
+  }
+
+  async getMessage(id: string): Promise<GmailMessage> {
+    try {
+      return requireMessage(
+        await this.request<GmailMessage>(`/users/me/messages/${encodePathSegment(id)}?format=full`, 'GET'),
+        'messages.get',
+      );
+    } catch (err) {
+      if (!shouldFallbackToDraftLookup(err)) throw err;
+      const draft = await this.request<GmailDraft>(
+        `/users/me/drafts/${encodePathSegment(id)}?format=full`,
+        'GET',
+      );
+      return requireMessage(draft.message, 'drafts.get');
+    }
+  }
+
+  async getDraft(draftId: string): Promise<{ id: string; message: GmailMessage }> {
+    const draft = await this.request<GmailDraft>(
+      `/users/me/drafts/${encodePathSegment(draftId)}?format=full`,
+      'GET',
+    );
+    if (!draft.id) {
+      throw new Error('Gmail API drafts.get returned an incomplete draft payload');
+    }
+    return {
+      id: draft.id,
+      message: requireMessage(draft.message, 'drafts.get'),
+    };
+  }
+
+  async getAttachment(messageId: string, attachmentId: string): Promise<{ data?: string; size?: number }> {
+    const response = await this.request<{ data?: string | null; size?: number | null }>(
+      `/users/me/messages/${encodePathSegment(messageId)}/attachments/${encodePathSegment(attachmentId)}`,
+      'GET',
+    );
+    return { data: response.data ?? undefined, size: response.size ?? undefined };
+  }
+
+  async sendMessage(raw: string, threadId?: string): Promise<{ id: string; threadId: string }> {
+    return requireMessageSummary(
+      await this.request<MessageSummary>('/users/me/messages/send', 'POST', threadId ? { raw, threadId } : { raw }),
+      'messages.send',
+    );
+  }
+
+  async modifyMessage(id: string, opts: { addLabelIds?: string[]; removeLabelIds?: string[] }): Promise<void> {
+    await this.request(
+      `/users/me/messages/${encodePathSegment(id)}/modify`,
+      'POST',
+      { addLabelIds: opts.addLabelIds, removeLabelIds: opts.removeLabelIds },
+    );
+  }
+
+  async getThread(threadId: string): Promise<{ id: string; messages: GmailMessage[] }> {
+    const response = await this.request<{ id?: string | null; messages?: GmailMessage[] }>(
+      `/users/me/threads/${encodePathSegment(threadId)}?format=full`,
+      'GET',
+    );
+    if (!response.id || !response.messages) {
+      throw new Error('Gmail API threads.get returned an incomplete thread payload');
+    }
+    return { id: response.id, messages: response.messages };
+  }
+
+  async createDraft(raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }> {
+    const message = threadId ? { raw, threadId } : { raw };
+    return requireDraft(
+      await this.request<GmailDraft>('/users/me/drafts', 'POST', { message }),
+      'drafts.create',
+    );
+  }
+
+  async sendDraft(draftId: string): Promise<{ id: string; threadId: string }> {
+    return requireMessageSummary(
+      await this.request<MessageSummary>('/users/me/drafts/send', 'POST', { id: draftId }),
+      'drafts.send',
+    );
+  }
+
+  async updateDraft(draftId: string, raw: string, threadId?: string): Promise<{ id: string; message: { id: string; threadId: string } }> {
+    const message = threadId ? { raw, threadId } : { raw };
+    return requireDraft(
+      await this.request<GmailDraft>(
+        `/users/me/drafts/${encodePathSegment(draftId)}`,
+        'PUT',
+        { message },
+      ),
+      'drafts.update',
+    );
+  }
+}


### PR DESCRIPTION
## What changed

- adds a Maton-backed Gmail API client using native Gmail REST passthrough
- requires an explicit Gmail account allowlist and exact ACTIVE `google-mail` connection matching
- preserves Gmail message, draft, thread, attachment, label, pagination, and RFC 2822 semantics
- keeps local OAuth as the default unless Maton transport is explicitly selected
- corrects the Gmail `drafts.send` response contract to return the sent Message

## Why

Long-running and headless agent processes should not need to own local Gmail refresh-token lifecycle. Maton stores and refreshes the underlying OAuth credentials while the MCP runtime uses a stable API key and exact per-account connection identifier.

## Safety

- credentials are sent only to the fixed HTTPS Maton Gmail gateway
- upstream errors redact the API key and connection identifier
- duplicate, inactive, missing, or cross-app connections fail closed
- mutations are not retried
- request deadlines are bounded

## Validation

- build passed
- TypeScript lint passed
- full v0.1.10 suite passed: 1,056 tests
- local deployment parity passed 18/18 fixtures across Gmail and Outlook, including message bodies, threads, and attachment byte hashes
- two adversarial security and protocol reviews completed