### PR TITLE
feat(scope-profile): add full and observe email scope profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ compatibility.
 
 | Profile | Microsoft delegated scopes | Exposed tools |
 |---------|-----------------------------|---------------|
-| `observe` | `Mail.Read`, `User.Read`, `offline_access` | Read-only email tools plus local mailbox configuration/authentication tools |
+| `observe` | `Mail.Read`, `MailboxSettings.Read`, `User.Read`, `offline_access` | Read-only email tools plus local mailbox configuration/authentication tools |
 | `full` (default) | `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.ReadWrite`, `User.Read`, `offline_access` | All tools |
 
 For an observation-only deployment, set the profile for both configuration and

--- a/README.md
+++ b/README.md
@@ -142,7 +142,36 @@ If your mailbox status name is not an email address, pass `--reply-sender <email
 
 ## Tool Reference
 
-Agent Email exposes 26 MCP tools:
+### Scope profiles
+
+Set `EMAIL_AGENT_MCP_SCOPE_PROFILE` before configuring and starting the server to
+choose the permissions exposed to an agent. The default is `full` for backward
+compatibility.
+
+| Profile | Microsoft delegated scopes | Exposed tools |
+|---------|-----------------------------|---------------|
+| `observe` | `Mail.Read`, `User.Read`, `offline_access` | Read-only email tools plus local mailbox configuration/authentication tools |
+| `full` (default) | `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.ReadWrite`, `User.Read`, `offline_access` | All tools |
+
+For an observation-only deployment, set the profile for both configuration and
+runtime so the OAuth consent and MCP tool list agree:
+
+```bash
+export EMAIL_AGENT_MCP_SCOPE_PROFILE=observe
+npx email-agent-mcp configure
+npx email-agent-mcp serve
+```
+
+Changing profiles changes the Microsoft OAuth scope set. MSAL caches tokens by
+scope, so restart the server and run `email-agent-mcp configure` again to grant
+the new scopes. In particular, switching from `observe` to `full` requires a new
+interactive consent before write tools can be used. An invalid profile value
+stops startup instead of silently granting broader access.
+
+### Tools
+
+The `full` profile exposes 26 MCP tools; `observe` omits every tool whose action
+is marked as mailbox-mutating:
 
 | Tool | Description | Type |
 |------|-------------|------|

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -1,6 +1,15 @@
 // @usejunior/email-core — Actions, content engine, security, and provider interfaces
 export { EMAIL_ACTIONS } from './actions/registry.js';
 export type { EmailAction, AllowlistConfig } from './actions/registry.js';
+export {
+  EMAIL_SCOPE_PROFILES,
+  EMAIL_SCOPE_PROFILE_ENV,
+  filterActionsForProfile,
+  getEmailScopeProfile,
+  isActionAllowedForProfile,
+  profileBlockedActionError,
+} from './scope-profile.js';
+export type { EmailScopeProfile } from './scope-profile.js';
 export type {
   EmailAddress,
   EmailMessage,

--- a/packages/email-core/src/scope-profile.test.ts
+++ b/packages/email-core/src/scope-profile.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import type { EmailAction } from './actions/registry.js';
+import {
+  EMAIL_SCOPE_PROFILE_ENV,
+  filterActionsForProfile,
+  getEmailScopeProfile,
+} from './scope-profile.js';
+
+const action = (name: string, readOnlyHint: boolean) => ({
+  name,
+  annotations: { readOnlyHint, destructiveHint: false },
+}) as EmailAction;
+
+describe('email scope profiles', () => {
+  const originalProfile = process.env[EMAIL_SCOPE_PROFILE_ENV];
+
+  afterEach(() => {
+    if (originalProfile === undefined) delete process.env[EMAIL_SCOPE_PROFILE_ENV];
+    else process.env[EMAIL_SCOPE_PROFILE_ENV] = originalProfile;
+  });
+
+  it('Scenario: full is the backwards-compatible default', () => {
+    delete process.env[EMAIL_SCOPE_PROFILE_ENV];
+    expect(getEmailScopeProfile()).toBe('full');
+  });
+
+  it('Scenario: observe retains reads and local mailbox configuration', () => {
+    const actions = [
+      action('read_email', true),
+      action('send_email', false),
+      action('configure_mailbox', false),
+      action('remove_mailbox', false),
+    ];
+
+    expect(filterActionsForProfile(actions, 'observe').map(item => item.name)).toEqual([
+      'read_email',
+      'configure_mailbox',
+      'remove_mailbox',
+    ]);
+  });
+
+  it('Scenario: invalid profile fails closed with an actionable error', () => {
+    process.env[EMAIL_SCOPE_PROFILE_ENV] = 'readonly';
+    expect(() => getEmailScopeProfile()).toThrow(
+      `Invalid ${EMAIL_SCOPE_PROFILE_ENV} value "readonly"`,
+    );
+  });
+});

--- a/packages/email-core/src/scope-profile.ts
+++ b/packages/email-core/src/scope-profile.ts
@@ -1,0 +1,47 @@
+import type { EmailAction } from './actions/registry.js';
+
+export const EMAIL_SCOPE_PROFILES = ['full', 'observe'] as const;
+export type EmailScopeProfile = (typeof EMAIL_SCOPE_PROFILES)[number];
+
+export const EMAIL_SCOPE_PROFILE_ENV = 'EMAIL_AGENT_MCP_SCOPE_PROFILE';
+
+// These actions change only local connection metadata. They must remain
+// available in observe mode so an installation can configure and repair its
+// own authentication without gaining permission to mutate mailbox contents.
+const OBSERVE_CONFIGURATION_ACTIONS = new Set([
+  'configure_mailbox',
+  'remove_mailbox',
+  'list_mailboxes',
+]);
+
+export function getEmailScopeProfile(
+  value = process.env[EMAIL_SCOPE_PROFILE_ENV],
+): EmailScopeProfile {
+  if (value === undefined || value.trim() === '') return 'full';
+  if (value === 'full' || value === 'observe') return value;
+  throw new Error(
+    `Invalid ${EMAIL_SCOPE_PROFILE_ENV} value "${value}". Expected "full" or "observe".`,
+  );
+}
+
+export function isActionAllowedForProfile(
+  action: Pick<EmailAction, 'name' | 'annotations'>,
+  profile: EmailScopeProfile,
+): boolean {
+  return profile === 'full'
+    || action.annotations.readOnlyHint
+    || OBSERVE_CONFIGURATION_ACTIONS.has(action.name);
+}
+
+export function filterActionsForProfile<T extends Pick<EmailAction, 'name' | 'annotations'>>(
+  actions: readonly T[],
+  profile: EmailScopeProfile,
+): T[] {
+  return actions.filter(action => isActionAllowedForProfile(action, profile));
+}
+
+export function profileBlockedActionError(actionName: string): Error {
+  return new Error(
+    `Tool "${actionName}" is unavailable under the "observe" scope profile because it can modify mailbox data. Set ${EMAIL_SCOPE_PROFILE_ENV}=full and re-authenticate to enable write tools.`,
+  );
+}

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -342,6 +342,26 @@ describe('mcp-transport/Lazy Provider State', () => {
     ]));
   });
 
+  it('Scenario: observe profile exposes only read-only tools', async () => {
+    const previous = process.env['EMAIL_AGENT_MCP_SCOPE_PROFILE'];
+    process.env['EMAIL_AGENT_MCP_SCOPE_PROFILE'] = 'observe';
+    try {
+      const state = createLazyProviderState();
+      const actions = await buildLazyActions(state, noAllowlist);
+
+      expect(actions.length).toBeGreaterThan(0);
+      expect(actions.every(action => action.annotations.readOnlyHint)).toBe(true);
+      expect(actions.map(action => action.name)).toContain('read_email');
+      expect(actions.map(action => action.name)).not.toContain('send_email');
+      await expect(executeTool(actions, {}, 'send_email', {})).rejects.toThrow(
+        'unavailable under the "observe" scope profile',
+      );
+    } finally {
+      if (previous === undefined) delete process.env['EMAIL_AGENT_MCP_SCOPE_PROFILE'];
+      else process.env['EMAIL_AGENT_MCP_SCOPE_PROFILE'] = previous;
+    }
+  });
+
   it('Scenario: get_mailbox_status is non-blocking during pending/connecting', async () => {
     const state = createLazyProviderState();
     const actions = await buildLazyActions(state, noAllowlist);

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -6,6 +6,9 @@ import {
   EmailThreadFieldsSchema,
   getEmailDraftStatus,
   getEmailThreadFields,
+  filterActionsForProfile,
+  getEmailScopeProfile,
+  profileBlockedActionError,
 } from '@usejunior/email-core';
 import { z } from 'zod';
 
@@ -99,6 +102,8 @@ export interface EmailActionDef {
   annotations: { readOnlyHint: boolean; destructiveHint: boolean };
   run: (ctx: unknown, input: unknown) => Promise<unknown>;
 }
+
+type ProfiledActionList = EmailActionDef[] & { profileBlockedActionNames?: ReadonlySet<string> };
 
 /**
  * Generate MCP tool list from action registry.
@@ -240,6 +245,9 @@ export async function executeTool(
 ): Promise<{ result: unknown; input: unknown }> {
   const action = actions.find(a => a.name === toolName);
   if (!action) {
+    if ((actions as ProfiledActionList).profileBlockedActionNames?.has(toolName)) {
+      throw profileBlockedActionError(toolName);
+    }
     throw new Error(`Unknown tool: ${toolName}`);
   }
 
@@ -764,7 +772,7 @@ export async function buildLazyActions(
     isDraft: false,
   });
 
-  return [
+  const actions: EmailActionDef[] = [
     {
       name: 'list_emails',
       description: 'List recent emails with filtering by unread status, folder, sender, and limit. Use offset for pagination. A row with `isDraft: true` is an unsent draft — it has NOT been sent, and its `receivedAt` is provider-supplied metadata, not evidence of delivery. Never describe such a row as a sent, delivered, or received email.',
@@ -1069,6 +1077,17 @@ export async function buildLazyActions(
     wrapAction(createInboxRuleAction),
     wrapAction(deleteInboxRuleAction),
   ];
+
+  const profile = getEmailScopeProfile();
+  const filtered = filterActionsForProfile(actions, profile) as ProfiledActionList;
+  if (profile === 'observe') {
+    const exposedNames = new Set(filtered.map(action => action.name));
+    Object.defineProperty(filtered, 'profileBlockedActionNames', {
+      value: new Set(actions.filter(action => !exposedNames.has(action.name)).map(action => action.name)),
+      enumerable: false,
+    });
+  }
+  return filtered;
 }
 
 /**
@@ -1105,6 +1124,7 @@ export async function runServer(): Promise<void> {
   // Build tool registry with lazy provider state (no auth yet).
   const state = createLazyProviderState();
   const actions = await buildLazyActions(state, getSendAllowlist, getDeletePolicy);
+  const scopeProfile = getEmailScopeProfile();
 
   const server = new Server(
     { name: 'email-agent-mcp', version: PACKAGE_VERSION },
@@ -1129,7 +1149,7 @@ export async function runServer(): Promise<void> {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error(`[email-agent-mcp] MCP server started on stdio (${tools.length} tools) — provider init deferred`);
+  console.error(`[email-agent-mcp] MCP server started on stdio (${tools.length} tools, ${scopeProfile} scope profile) — provider init deferred`);
 
   // Fire-and-forget: warm up the provider in the background so most first tool
   // calls hit a ready provider. initProvider is safe to call without awaiting

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -72,12 +72,16 @@ describe('provider-interface/Microsoft Mailbox Settings Consent', () => {
   });
 
   it('Scenario: Observe profile requests only read and identity scopes', () => {
-    expect(GRAPH_SCOPES_BY_PROFILE.observe).toEqual(['Mail.Read', 'User.Read', 'offline_access']);
+    expect(GRAPH_SCOPES_BY_PROFILE.observe).toEqual(['Mail.Read', 'MailboxSettings.Read', 'User.Read', 'offline_access']);
     expect(GRAPH_SCOPES_FULL_BY_PROFILE.observe).toEqual([
       'https://graph.microsoft.com/Mail.Read',
+      'https://graph.microsoft.com/MailboxSettings.Read',
       'https://graph.microsoft.com/User.Read',
       'offline_access',
     ]);
+    // Observe must never request a write-capable scope.
+    expect(GRAPH_SCOPES_BY_PROFILE.observe.some(scope => /ReadWrite|\.Send/.test(scope))).toBe(false);
+    expect(GRAPH_SCOPES_FULL_BY_PROFILE.observe.some(scope => /ReadWrite|\.Send/.test(scope))).toBe(false);
     expect(GRAPH_SCOPES_BY_PROFILE.full).toBe(GRAPH_SCOPES);
     expect(GRAPH_SCOPES_FULL_BY_PROFILE.full).toBe(GRAPH_SCOPES_FULL);
   });

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { DelegatedAuthManager, ClientCredentialsAuthManager, toFilesystemSafeKey, listConfiguredMailboxesWithMetadata, getConfigDir, GRAPH_SCOPES, GRAPH_SCOPES_FULL, isAuthError } from './auth.js';
+import { DelegatedAuthManager, ClientCredentialsAuthManager, toFilesystemSafeKey, listConfiguredMailboxesWithMetadata, getConfigDir, GRAPH_SCOPES, GRAPH_SCOPES_FULL, GRAPH_SCOPES_BY_PROFILE, GRAPH_SCOPES_FULL_BY_PROFILE, isAuthError } from './auth.js';
 import { GraphApiError } from './email-graph-provider.js';
 import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
@@ -11,6 +11,8 @@ const testHome = join(tmpdir(), `email-agent-mcp-auth-test-${Date.now()}-${Math.
 const mockDeviceCodeState = vi.hoisted(() => ({
   authenticateCalls: 0,
   getTokenCalls: 0,
+  authenticateScopes: [] as string[][],
+  getTokenScopes: [] as string[][],
   constructorOptions: [] as Record<string, unknown>[],
 }));
 
@@ -26,13 +28,15 @@ vi.mock('@azure/identity', () => {
       mockDeviceCodeState.constructorOptions.push(options);
     }
 
-    async getToken() {
+    async getToken(scopes: string[]) {
       mockDeviceCodeState.getTokenCalls++;
+      mockDeviceCodeState.getTokenScopes.push(scopes);
       return { token: 'mock-access-token', expiresOnTimestamp: Date.now() + 3600000 };
     }
 
-    async authenticate() {
+    async authenticate(scopes: string[]) {
       mockDeviceCodeState.authenticateCalls++;
+      mockDeviceCodeState.authenticateScopes.push(scopes);
       return { authority: 'https://login.microsoftonline.com', homeAccountId: 'test', clientId: 'test', tenantId: 'test' };
     }
   }
@@ -66,6 +70,17 @@ describe('provider-interface/Microsoft Mailbox Settings Consent', () => {
     expect(GRAPH_SCOPES).toContain('MailboxSettings.ReadWrite');
     expect(GRAPH_SCOPES_FULL).toContain('https://graph.microsoft.com/MailboxSettings.ReadWrite');
   });
+
+  it('Scenario: Observe profile requests only read and identity scopes', () => {
+    expect(GRAPH_SCOPES_BY_PROFILE.observe).toEqual(['Mail.Read', 'User.Read', 'offline_access']);
+    expect(GRAPH_SCOPES_FULL_BY_PROFILE.observe).toEqual([
+      'https://graph.microsoft.com/Mail.Read',
+      'https://graph.microsoft.com/User.Read',
+      'offline_access',
+    ]);
+    expect(GRAPH_SCOPES_BY_PROFILE.full).toBe(GRAPH_SCOPES);
+    expect(GRAPH_SCOPES_FULL_BY_PROFILE.full).toBe(GRAPH_SCOPES_FULL);
+  });
 });
 
 describe('provider-microsoft/Delegated OAuth Authentication', () => {
@@ -76,6 +91,8 @@ describe('provider-microsoft/Delegated OAuth Authentication', () => {
     process.env['EMAIL_AGENT_MCP_HOME'] = testHome;
     mockDeviceCodeState.authenticateCalls = 0;
     mockDeviceCodeState.getTokenCalls = 0;
+    mockDeviceCodeState.authenticateScopes.length = 0;
+    mockDeviceCodeState.getTokenScopes.length = 0;
     mockDeviceCodeState.constructorOptions.length = 0;
   });
 
@@ -112,6 +129,19 @@ describe('provider-microsoft/Delegated OAuth Authentication', () => {
     expect(mockDeviceCodeState.getTokenCalls).toBe(1);
     expect(auth.isTokenExpired()).toBe(false);
     expect(auth.needsReauth).toBe(false);
+  });
+
+  it('Scenario: Observe authentication uses the profile-specific scope set', async () => {
+    const auth = new DelegatedAuthManager(
+      { mode: 'delegated', clientId: 'test-client-id', scopeProfile: 'observe' },
+      'observe-mailbox',
+    );
+
+    await auth.connect({});
+    await auth.getAccessToken();
+
+    expect(mockDeviceCodeState.authenticateScopes).toEqual([GRAPH_SCOPES_FULL_BY_PROFILE.observe]);
+    expect(mockDeviceCodeState.getTokenScopes).toEqual([GRAPH_SCOPES_FULL_BY_PROFILE.observe]);
   });
 
   it('Scenario: Silent reconnect uses persisted cache name', async () => {

--- a/packages/provider-microsoft/src/auth.ts
+++ b/packages/provider-microsoft/src/auth.ts
@@ -1,5 +1,5 @@
 // Microsoft Graph authentication — real MSAL device code flow + cache persistence
-import type { AuthManager } from '@usejunior/email-core';
+import { getEmailScopeProfile, type AuthManager, type EmailScopeProfile } from '@usejunior/email-core';
 import { DeviceCodeCredential, ClientSecretCredential, useIdentityPlugin, type DeviceCodeInfo, type AuthenticationRecord } from '@azure/identity';
 import { cachePersistencePlugin } from '@azure/identity-cache-persistence';
 import { randomUUID } from 'node:crypto';
@@ -22,6 +22,20 @@ export const GRAPH_SCOPES_FULL = [
   'offline_access',
 ];
 
+export const GRAPH_SCOPES_BY_PROFILE: Record<EmailScopeProfile, string[]> = {
+  full: GRAPH_SCOPES,
+  observe: ['Mail.Read', 'User.Read', 'offline_access'],
+};
+
+export const GRAPH_SCOPES_FULL_BY_PROFILE: Record<EmailScopeProfile, string[]> = {
+  full: GRAPH_SCOPES_FULL,
+  observe: [
+    'https://graph.microsoft.com/Mail.Read',
+    'https://graph.microsoft.com/User.Read',
+    'offline_access',
+  ],
+};
+
 const TOKEN_EXPIRY_BUFFER_MS = 10 * 60 * 1000; // 10 minutes
 /**
  * Resolve the config directory for token storage.
@@ -37,6 +51,7 @@ export interface MicrosoftAuthConfig {
   clientId: string;
   clientSecret?: string;
   tenantId?: string;
+  scopeProfile?: EmailScopeProfile;
 }
 
 export interface MailboxMetadata {
@@ -75,6 +90,7 @@ export class DelegatedAuthManager implements AuthManager {
   private cacheName: string | null = null;
   private readonly config: MicrosoftAuthConfig;
   private readonly mailboxName: string;
+  private readonly scopes: string[];
   private _needsReauth = false;
   private _lastInteractiveAuthAt: string | null = null;
   private _emailAddress: string | null = null;
@@ -84,6 +100,7 @@ export class DelegatedAuthManager implements AuthManager {
   constructor(config: MicrosoftAuthConfig, mailboxName = 'default') {
     this.config = config;
     this.mailboxName = mailboxName;
+    this.scopes = GRAPH_SCOPES_FULL_BY_PROFILE[config.scopeProfile ?? getEmailScopeProfile()];
   }
 
   /** Set the email address for this mailbox (called after profile fetch during configure). */
@@ -126,7 +143,7 @@ export class DelegatedAuthManager implements AuthManager {
       },
     });
 
-    this.authRecord = (await this.credential.authenticate(GRAPH_SCOPES_FULL)) ?? null;
+    this.authRecord = (await this.credential.authenticate(this.scopes)) ?? null;
     if (!this.authRecord) throw new Error('Authentication failed — no record received');
     this._lastInteractiveAuthAt = new Date().toISOString();
     this._needsReauth = false;
@@ -157,7 +174,7 @@ export class DelegatedAuthManager implements AuthManager {
 
     // Verify the token still works
     try {
-      const token = await this.credential.getToken(GRAPH_SCOPES_FULL);
+      const token = await this.credential.getToken(this.scopes);
       this._tokenExpiresAt = token.expiresOnTimestamp;
       this._needsReauth = false;
     } catch (err) {
@@ -178,7 +195,7 @@ export class DelegatedAuthManager implements AuthManager {
       throw new Error('Not connected. Call connect() or reconnect() first.');
     }
     try {
-      const token = await this.credential.getToken(GRAPH_SCOPES_FULL);
+      const token = await this.credential.getToken(this.scopes);
       if (!token) throw new Error('Failed to acquire token');
       this._tokenExpiresAt = token.expiresOnTimestamp;
       return token.token;

--- a/packages/provider-microsoft/src/auth.ts
+++ b/packages/provider-microsoft/src/auth.ts
@@ -22,15 +22,20 @@ export const GRAPH_SCOPES_FULL = [
   'offline_access',
 ];
 
+// MailboxSettings.Read is the read-only half of the full profile's
+// MailboxSettings.ReadWrite. list_inbox_rules is a read-only tool that stays
+// exposed under observe, and Graph gates /mailFolders/inbox/messageRules behind
+// MailboxSettings — without it that tool is guaranteed to 403.
 export const GRAPH_SCOPES_BY_PROFILE: Record<EmailScopeProfile, string[]> = {
   full: GRAPH_SCOPES,
-  observe: ['Mail.Read', 'User.Read', 'offline_access'],
+  observe: ['Mail.Read', 'MailboxSettings.Read', 'User.Read', 'offline_access'],
 };
 
 export const GRAPH_SCOPES_FULL_BY_PROFILE: Record<EmailScopeProfile, string[]> = {
   full: GRAPH_SCOPES_FULL,
   observe: [
     'https://graph.microsoft.com/Mail.Read',
+    'https://graph.microsoft.com/MailboxSettings.Read',
     'https://graph.microsoft.com/User.Read',
     'offline_access',
   ],

--- a/packages/provider-microsoft/src/index.ts
+++ b/packages/provider-microsoft/src/index.ts
@@ -1,6 +1,6 @@
 // @usejunior/provider-microsoft — Microsoft Graph API email provider
 export { GraphEmailProvider, RealGraphApiClient, GraphApiError, type GraphApiClient, type DeltaResult } from './email-graph-provider.js';
-export { DelegatedAuthManager, ClientCredentialsAuthManager, listConfiguredMailboxes, listConfiguredMailboxesWithMetadata, loadMailboxMetadata, toFilesystemSafeKey, getConfigDir, GRAPH_SCOPES, isAuthError } from './auth.js';
+export { DelegatedAuthManager, ClientCredentialsAuthManager, listConfiguredMailboxes, listConfiguredMailboxesWithMetadata, loadMailboxMetadata, toFilesystemSafeKey, getConfigDir, GRAPH_SCOPES, GRAPH_SCOPES_BY_PROFILE, GRAPH_SCOPES_FULL_BY_PROFILE, isAuthError } from './auth.js';
 export type { MailboxMetadata } from './auth.js';
 export {
   handleValidationToken,


### PR DESCRIPTION
## Summary

- add `full` and `observe` email scope profiles selected with `EMAIL_AGENT_MCP_SCOPE_PROFILE`
- derive the observe tool surface from each action's existing `readOnlyHint`, while retaining local mailbox configuration and auth-bootstrap actions
- request only `Mail.Read`, `User.Read`, and `offline_access` for Microsoft delegated auth in observe mode
- return an actionable profile error when a hidden write tool is called directly
- document exact Microsoft scopes and the re-consent requirement when changing profiles

## Why

Observation-only deployments should not request permission to send or modify mailbox data. Tying OAuth scopes to tool registration makes the least-privilege boundary visible both in Microsoft consent and in MCP tool discovery.

The existing `GRAPH_SCOPES` and `GRAPH_SCOPES_FULL` constants remain unchanged for compatibility; profile-specific lists are derived alongside them.

## Validation

- `npm run build`
- `npm run lint`
- email-core scope-profile tests: 3 passed
- provider-microsoft auth tests: 43 passed
- email-mcp server tests: 75 passed

The full email-core suite also passed 460 tests; four unrelated watched-allowlist tests could not run because the host reached its file-watcher limit (`EMFILE`).

Closes #161
