### PR TITLE
fix(draft): honor caller-supplied to on reply drafts (closes #164)

### DIFF
--- a/openspec/specs/email-write/spec.md
+++ b/openspec/specs/email-write/spec.md
@@ -209,7 +209,9 @@ On `create_draft`, `reply_all` is meaningful only alongside `reply_to`; for a no
 
 `create_draft` requires `to` on every path, so on the reply path it SHALL forward those recipients to the provider rather than discarding them. `ReplyOptions` SHALL carry an optional `to` list for this purpose.
 
-An explicit `to` SHALL **replace** the provider-derived To rather than merge with it, unlike `cc`, which merges with the thread's. Replacing is what makes redirecting a thread to a different recipient expressible, and it matches what `to` means on every other compose surface. Other thread participants remain reachable through `reply_all` or an explicit `cc`.
+An explicit `to` SHALL **replace** the provider-derived To rather than merge with it, unlike `cc`, which merges with the thread's. Replacing is what makes redirecting a thread to a different recipient expressible, and it matches what `to` means on every other compose surface.
+
+Replacing the To line SHALL NOT drop recipients. Under reply-all, providers SHALL move participants displaced from the To line onto Cc, so the effective audience of a reply-all is never narrowed by supplying `to`; a recipient now addressed on To SHALL NOT also appear on Cc. Under `reply_all: false` nothing is preserved — narrowing to an explicit recipient set is the point.
 
 When `to` is absent or empty, providers SHALL leave their derived To untouched: Microsoft omits `toRecipients` from the follow-up PATCH so Graph's auto-populated recipients stand, and Gmail addresses the original sender. `reply_to_email` has no `to` input and therefore SHALL continue to use the provider-derived To on both its send and draft paths.
 

--- a/openspec/specs/email-write/spec.md
+++ b/openspec/specs/email-write/spec.md
@@ -184,7 +184,7 @@ The `code` SHALL remain `MAILBOX_REQUIRED` and the message SHALL remain `mailbox
 
 Every reply-producing surface SHALL let the caller choose between a reply-all and a sender-only reply through the same `reply_all` boolean parameter, defaulting to `true`.
 
-This applies to `reply_to_email` (both its send and `draft: true` paths) and to `create_draft` when `reply_to` is set. When `reply_all` is `false`, the system SHALL NOT populate recipients automatically derived from the original thread's To/Cc participants; the reply SHALL address the original sender plus any Cc recipients the caller supplied explicitly. There is no provider-level override for the reply To list — `ReplyOptions` carries `cc`, `bcc`, `attachments`, `bodyHtml`, and `replyAll`, but no `to` — so a caller-supplied `to` does NOT add reply recipients. Recipients supplied via `cc` SHALL still be honored — `reply_all: false` narrows the *derived* audience, not the caller's stated one.
+This applies to `reply_to_email` (both its send and `draft: true` paths) and to `create_draft` when `reply_to` is set. When `reply_all` is `false`, the system SHALL NOT populate recipients automatically derived from the original thread's To/Cc participants; the reply SHALL address the caller-supplied To (see Reply Recipient Override) plus any Cc recipients the caller supplied explicitly, falling back to the original sender when no To was supplied. Recipients supplied via `cc` SHALL still be honored — `reply_all: false` narrows the *derived* audience, not the caller's stated one.
 
 On `create_draft`, `reply_all` is meaningful only alongside `reply_to`; for a non-reply draft it SHALL have no effect on the composed recipients. This requirement does not alter `create_draft`'s existing required-field validation: `to` and `subject` remain required on every path, including reply drafts.
 
@@ -204,6 +204,33 @@ On `create_draft`, `reply_all` is meaningful only alongside `reply_to`; for a no
 #### Scenario: Send-path reply honors the same toggle
 - **WHEN** `reply_to_email` is called with `{message_id: "msg123", body: "…", reply_all: false}`
 - **THEN** the reply is addressed only to the original sender, with the thread's other participants omitted
+
+### Requirement: Reply Recipient Override
+
+`create_draft` requires `to` on every path, so on the reply path it SHALL forward those recipients to the provider rather than discarding them. `ReplyOptions` SHALL carry an optional `to` list for this purpose.
+
+An explicit `to` SHALL **replace** the provider-derived To rather than merge with it, unlike `cc`, which merges with the thread's. Replacing is what makes redirecting a thread to a different recipient expressible, and it matches what `to` means on every other compose surface. Other thread participants remain reachable through `reply_all` or an explicit `cc`.
+
+When `to` is absent or empty, providers SHALL leave their derived To untouched: Microsoft omits `toRecipients` from the follow-up PATCH so Graph's auto-populated recipients stand, and Gmail addresses the original sender. `reply_to_email` has no `to` input and therefore SHALL continue to use the provider-derived To on both its send and draft paths.
+
+This override SHALL NOT weaken send gating. `create_draft` bypasses the send allowlist by design; `send_draft` re-reads the stored draft's own To/Cc/Bcc, so a caller-supplied reply To is gated at send time exactly like the To of a non-reply draft.
+
+#### Scenario: Reply draft to a self-sent message honors caller-supplied to (issue #164)
+- **WHEN** `create_draft` is called with `{reply_to: "<id of a message the mailbox owner sent>", to: "recipient@example.com", cc: ["someone-else@example.com"], subject: "Re: Topic", body: "…", reply_all: false}`
+- **THEN** the created draft is addressed to `recipient@example.com`
+- **AND** the mailbox owner's own address, which the provider would otherwise derive from the parent's sender, is absent from the To list
+
+#### Scenario: Reply draft with multiple to recipients forwards all of them (issue #164)
+- **WHEN** `create_draft` is called on the reply path with several `to` entries, including one in name-address form
+- **THEN** every parsed recipient reaches the provider in order, with display names preserved
+
+#### Scenario: Reply draft to blocked recipient is still gated at send_draft time (issue #164)
+- **WHEN** a reply draft is created with a `to` outside the send allowlist, and `send_draft` is then called on it
+- **THEN** `create_draft` succeeds, `send_draft` returns `ALLOWLIST_BLOCKED`, and nothing is sent
+
+#### Scenario: reply_to_email draft keeps the provider-derived To (issue #164 no-op guard)
+- **WHEN** `reply_to_email` is called with `{message_id: "msg123", body: "…", draft: true}`
+- **THEN** no `to` is passed to the provider and the draft is addressed to the original sender, unchanged
 
 ### Requirement: Authored-Only Reply Draft Preview
 

--- a/openspec/specs/provider-gmail/spec.md
+++ b/openspec/specs/provider-gmail/spec.md
@@ -65,6 +65,35 @@ The system SHALL map Gmail message format to the common `EmailMessage` type, inc
 - **WHEN** a Gmail message is fetched
 - **THEN** it is mapped to `EmailMessage` with `threadId`, labels, and standard fields
 
+### Requirement: Reply To Recipients
+
+Gmail composes replies itself rather than delegating to a provider-side reply endpoint, so it derives the To from the parent's sender. When `ReplyOptions.to` is supplied and non-empty, `replyToMessage` and `createReplyDraft` SHALL address the message to exactly those recipients instead, replacing the derived sender rather than merging with it. When `to` is absent or empty, both SHALL continue to address the original sender, unchanged. Cc derivation is unaffected on either path.
+
+#### Scenario: explicit to replaces the original sender on a self-sent parent (issue #164)
+- **WHEN** `createReplyDraft` is called with `replyAll: false` and an explicit `to`, against a parent whose sender is the mailbox owner
+- **THEN** the raw message's To header carries the caller's recipient with its display name
+- **AND** the mailbox owner's address does not appear in the message
+
+#### Scenario: explicit to with several addresses lands on the To header (issue #164)
+- **WHEN** `createReplyDraft` is called with several `to` entries
+- **THEN** the To header carries all of them and the original sender is absent
+
+#### Scenario: omitted to keeps the original sender as To (issue #164 no-op guard)
+- **WHEN** `createReplyDraft` is called with no `to`
+- **THEN** the To header is the original sender, unchanged
+
+#### Scenario: empty to array keeps the original sender as To (issue #164)
+- **WHEN** `createReplyDraft` is called with `to: []`
+- **THEN** the To header is the original sender, unchanged
+
+#### Scenario: replyToMessage honors explicit to (issue #164)
+- **WHEN** `replyToMessage` is called with an explicit `to`
+- **THEN** the sent raw message is addressed to those recipients rather than the original sender
+
+#### Scenario: replyToMessage without to keeps the original sender (issue #164 no-op guard)
+- **WHEN** `replyToMessage` is called with no `to`
+- **THEN** the sent raw message is addressed to the original sender, unchanged
+
 ### Requirement: Dual Watch Mode
 
 The system SHALL support Pub/Sub push notifications (requires Google Cloud project, auto-renewal every 7 days) and `history.list` polling as a fallback for local/NAT environments.

--- a/openspec/specs/provider-gmail/spec.md
+++ b/openspec/specs/provider-gmail/spec.md
@@ -67,7 +67,9 @@ The system SHALL map Gmail message format to the common `EmailMessage` type, inc
 
 ### Requirement: Reply To Recipients
 
-Gmail composes replies itself rather than delegating to a provider-side reply endpoint, so it derives the To from the parent's sender. When `ReplyOptions.to` is supplied and non-empty, `replyToMessage` and `createReplyDraft` SHALL address the message to exactly those recipients instead, replacing the derived sender rather than merging with it. When `to` is absent or empty, both SHALL continue to address the original sender, unchanged. Cc derivation is unaffected on either path.
+Gmail composes replies itself rather than delegating to a provider-side reply endpoint, so it derives the To from the parent's sender. When `ReplyOptions.to` is supplied and non-empty, `replyToMessage` and `createReplyDraft` SHALL address the message to exactly those recipients instead, replacing the derived sender rather than merging with it. When `to` is absent or empty, both SHALL continue to address the original sender with Cc computed exactly as before, unchanged.
+
+Under reply-all, an explicit `to` displaces the parent's sender from the To line; that sender SHALL be carried onto Cc so the thread's audience is never narrowed, and any address now on To SHALL be excluded from Cc so nobody is listed twice. Under `replyAll: false` no such preservation applies. Both reply methods SHALL resolve recipients through one shared helper so the send and draft paths cannot drift apart.
 
 #### Scenario: explicit to replaces the original sender on a self-sent parent (issue #164)
 - **WHEN** `createReplyDraft` is called with `replyAll: false` and an explicit `to`, against a parent whose sender is the mailbox owner
@@ -77,6 +79,15 @@ Gmail composes replies itself rather than delegating to a provider-side reply en
 #### Scenario: explicit to with several addresses lands on the To header (issue #164)
 - **WHEN** `createReplyDraft` is called with several `to` entries
 - **THEN** the To header carries all of them and the original sender is absent
+
+#### Scenario: explicit to under reply-all moves the displaced sender to Cc (issue #164)
+- **WHEN** `createReplyDraft` is called with an explicit `to` and reply-all left at its default
+- **THEN** the To header carries the caller's recipient
+- **AND** the parent's sender appears on Cc alongside the thread's other participants
+
+#### Scenario: a caller addressed on To is not also listed on Cc (issue #164)
+- **WHEN** a caller `to` entry matches a thread participant, differing only in case
+- **THEN** that address appears on To and is absent from the Cc header
 
 #### Scenario: omitted to keeps the original sender as To (issue #164 no-op guard)
 - **WHEN** `createReplyDraft` is called with no `to`

--- a/openspec/specs/provider-microsoft/spec.md
+++ b/openspec/specs/provider-microsoft/spec.md
@@ -59,6 +59,8 @@ The system SHALL use `createReplyAll` for replies. `createReplyAll` preserves em
 
 Graph's `createReply` / `createReplyAll` auto-populate the draft's To from the parent message. When `ReplyOptions.to` is supplied and non-empty, the follow-up PATCH SHALL set `toRecipients` to exactly those addresses, replacing Graph's derived To. Unlike `ccRecipients` and `bccRecipients`, which merge with the thread's, `toRecipients` SHALL NOT merge — merging would leave the parent's sender addressed, which is the failure this replaces. When `to` is absent or empty, the PATCH SHALL omit `toRecipients` entirely so Graph's derived To stands.
 
+On the `createReplyAll` endpoint, Graph places both the parent's sender and the thread's other To participants on the draft's To. When an explicit `to` displaces them, those addresses SHALL be merged into `ccRecipients` with case-insensitive deduplication, so a reply-all's audience is never narrowed by supplying `to`. Addresses now on the caller's To SHALL be excluded from that demotion. On the `createReply` endpoint no demotion SHALL occur.
+
 #### Scenario: explicit to replaces Graph auto-populated recipients (issue #164)
 - **WHEN** a reply draft is created against a parent the mailbox owner sent, with `replyAll: false` and an explicit `to`
 - **THEN** the PATCH sets `toRecipients` to the caller's addresses, with display names preserved
@@ -67,6 +69,19 @@ Graph's `createReply` / `createReplyAll` auto-populate the draft's To from the p
 #### Scenario: explicit to with several addresses patches all of them (issue #164)
 - **WHEN** a reply draft is created with several `to` entries
 - **THEN** the PATCH carries every address in order
+
+#### Scenario: explicit to under reply-all demotes displaced participants to Cc (issue #164)
+- **WHEN** `createReplyAll` returns several auto-populated `toRecipients` and the caller supplies an explicit `to`
+- **THEN** the PATCH addresses only the caller's recipients on `toRecipients`
+- **AND** every displaced participant appears on `ccRecipients` alongside Graph's existing Cc
+
+#### Scenario: a caller addressed on To is not also demoted to Cc (issue #164)
+- **WHEN** one of Graph's auto-populated To recipients matches a caller `to` entry, differing only in case
+- **THEN** that address stays on To and is absent from `ccRecipients`
+
+#### Scenario: replyAll false does not demote the displaced sender to Cc (issue #164)
+- **WHEN** a reply draft is created with `replyAll: false` and an explicit `to`
+- **THEN** the PATCH has no `ccRecipients` property — the parent's sender is deliberately dropped
 
 #### Scenario: omitted to leaves toRecipients out of the PATCH (issue #164 no-op guard)
 - **WHEN** a reply draft is created with a `cc` but no `to`

--- a/openspec/specs/provider-microsoft/spec.md
+++ b/openspec/specs/provider-microsoft/spec.md
@@ -55,6 +55,27 @@ The system SHALL use `createReplyAll` for replies. `createReplyAll` preserves em
 - **WHEN** `update_draft` is called on a draft with no quoted-thread marker
 - **THEN** the body is PATCHed wholesale via `buildGraphBody` (existing behavior unchanged)
 
+### Requirement: Reply To Recipients
+
+Graph's `createReply` / `createReplyAll` auto-populate the draft's To from the parent message. When `ReplyOptions.to` is supplied and non-empty, the follow-up PATCH SHALL set `toRecipients` to exactly those addresses, replacing Graph's derived To. Unlike `ccRecipients` and `bccRecipients`, which merge with the thread's, `toRecipients` SHALL NOT merge — merging would leave the parent's sender addressed, which is the failure this replaces. When `to` is absent or empty, the PATCH SHALL omit `toRecipients` entirely so Graph's derived To stands.
+
+#### Scenario: explicit to replaces Graph auto-populated recipients (issue #164)
+- **WHEN** a reply draft is created against a parent the mailbox owner sent, with `replyAll: false` and an explicit `to`
+- **THEN** the PATCH sets `toRecipients` to the caller's addresses, with display names preserved
+- **AND** the mailbox owner's auto-populated address is not among them
+
+#### Scenario: explicit to with several addresses patches all of them (issue #164)
+- **WHEN** a reply draft is created with several `to` entries
+- **THEN** the PATCH carries every address in order
+
+#### Scenario: omitted to leaves toRecipients out of the PATCH (issue #164 no-op guard)
+- **WHEN** a reply draft is created with a `cc` but no `to`
+- **THEN** the PATCH body has no `toRecipients` property at all
+
+#### Scenario: empty to array leaves toRecipients out of the PATCH (issue #164)
+- **WHEN** a reply draft is created with `to: []`
+- **THEN** the PATCH body has no `toRecipients` property at all
+
 ### Requirement: Validation Token Handling
 
 The system SHALL respond to Graph validation requests on BOTH GET and POST methods. The `validationToken` query parameter SHALL be HTML-escaped and returned as `200 OK` plaintext.

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -94,6 +94,93 @@ Body from file.`);
     expect(result.draftId).toBeDefined();
   });
 
+  it('Scenario: Reply draft to a self-sent message honors caller-supplied to (issue #164)', async () => {
+    // The reported failure: replying to a message the mailbox owner sent makes
+    // the provider derive To from the parent's sender — the owner. With
+    // reply_all false there is nobody else on the draft, so it ends up
+    // addressed to nobody but the mailbox owner and the intended recipient is
+    // silently absent.
+    provider.addMessage({
+      id: 'self-sent-msg',
+      subject: 'Self Sent',
+      from: { email: 'me@company.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'recipient@allowed.com',
+      cc: ['someone-else@allowed.com'],
+      subject: 'Re: Self Sent',
+      body: 'Reply draft body',
+      reply_to: 'self-sent-msg',
+      reply_all: false,
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.to.map(a => a.email)).toEqual(['recipient@allowed.com']);
+    expect(draft.to.map(a => a.email)).not.toContain('me@company.com');
+    expect(draft.cc?.map(a => a.email)).toEqual(['someone-else@allowed.com']);
+  });
+
+  it('Scenario: Reply draft with multiple to recipients forwards all of them (issue #164)', async () => {
+    provider.addMessage({
+      id: 'multi-orig-msg',
+      subject: 'Multi',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await createDraftAction.run(ctx, {
+      to: ['First Recipient <first@allowed.com>', 'second@allowed.com'],
+      subject: 'Re: Multi',
+      body: 'Reply draft body',
+      reply_to: 'multi-orig-msg',
+    });
+
+    expect(result.success).toBe(true);
+    const draft = [...provider.getDrafts().values()][0]!;
+    expect(draft.to.map(a => a.email)).toEqual(['first@allowed.com', 'second@allowed.com']);
+    expect(draft.to[0]!.name).toBe('First Recipient');
+  });
+
+  it('Scenario: Reply draft to blocked recipient is still gated at send_draft time (issue #164)', async () => {
+    // create_draft bypasses the allowlist by design. Letting the caller set To
+    // on a reply draft must not smuggle a recipient past enforcement: send_draft
+    // re-reads the stored draft's own recipients, so the explicit To is gated
+    // exactly like a To on a non-reply draft.
+    provider.addMessage({
+      id: 'gate-orig-msg',
+      subject: 'Gate',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const draftResult = await createDraftAction.run(ctx, {
+      to: 'hacker@evil.com',
+      subject: 'Re: Gate',
+      body: 'Body',
+      reply_to: 'gate-orig-msg',
+      reply_all: false,
+    });
+    expect(draftResult.success).toBe(true);
+
+    const sendResult = await sendDraftAction.run(ctx, { draft_id: draftResult.draftId! });
+
+    expect(sendResult.success).toBe(false);
+    expect(sendResult.error!.code).toBe('ALLOWLIST_BLOCKED');
+    expect(provider.getSentMessages()).toHaveLength(0);
+  });
+
   it('Scenario: Create reply draft when provider lacks createReplyDraft', async () => {
     // Remove createReplyDraft from provider
     (provider as Record<string, unknown>).createReplyDraft = undefined;

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -48,7 +48,8 @@ const DraftOutput = z.object({
 // --- create_draft ---
 
 const CreateDraftInput = z.object({
-  to: z.string().or(z.array(z.string())).optional(),
+  to: z.string().or(z.array(z.string())).optional()
+    .describe('Recipient address(es). With reply_to set, this replaces the provider-derived To rather than adding to it, so the draft is addressed to exactly these recipients; other thread participants remain reachable via reply_all or an explicit cc.'),
   cc: z.array(z.string()).optional(),
   subject: z.string().optional(),
   body: z.string().optional(),
@@ -144,6 +145,10 @@ export const createDraftAction: EmailAction<
       }
       try {
         const result = await ctx.provider.createReplyDraft(replyTo, body, {
+          // `to` is a required input on this action, so forward it rather than
+          // letting the provider derive the To from the parent (issue #164).
+          // Providers treat an explicit `to` as a replacement, not a merge.
+          to: parsed.to,
           cc: parsed.cc,
           bodyHtml: outBodyHtml,
           attachments: attachments.length > 0 ? attachments : undefined,

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -49,7 +49,7 @@ const DraftOutput = z.object({
 
 const CreateDraftInput = z.object({
   to: z.string().or(z.array(z.string())).optional()
-    .describe('Recipient address(es). With reply_to set, this replaces the provider-derived To rather than adding to it, so the draft is addressed to exactly these recipients; other thread participants remain reachable via reply_all or an explicit cc.'),
+    .describe('Recipient address(es). With reply_to set, this replaces the provider-derived To rather than adding to it, so the draft is addressed to exactly these recipients. Under reply_all, thread participants displaced from the To line move to Cc rather than being dropped; pass reply_all=false to address the reply to these recipients alone.'),
   cc: z.array(z.string()).optional(),
   subject: z.string().optional(),
   body: z.string().optional(),

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -171,6 +171,21 @@ describe('email-write/Reply Draft', () => {
     expect(provider.getSentMessages()).toHaveLength(0);
   });
 
+  it('Scenario: reply_to_email draft keeps the provider-derived To (issue #164 no-op guard)', async () => {
+    // reply_to_email has no `to` input, so it passes no ReplyOptions.to and the
+    // provider default must stand exactly as it did before the #164 change.
+    const result = await replyToEmailAction.run(ctx, {
+      message_id: VALID_MSG_ID,
+      body: 'Draft reply!',
+      draft: true,
+    });
+
+    expect(result.success).toBe(true);
+    const draft = provider.getDrafts().get(result.draftId!)!;
+    const original = await provider.getMessage(VALID_MSG_ID);
+    expect(draft.to.map(a => a.email)).toEqual([original.from.email]);
+  });
+
   it('Scenario: Reply draft to blocked recipient succeeds (drafts bypass allowlist)', async () => {
     const blockedMsgId = 'blocked_msg_1234567890ab';
     provider.addMessage({

--- a/packages/email-core/src/testing/mock-provider.ts
+++ b/packages/email-core/src/testing/mock-provider.ts
@@ -328,7 +328,9 @@ export class MockEmailProvider implements EmailReader, EmailSender, EmailSchedul
     }
     const draftId = `draft-${this.nextId++}`;
     this.drafts.set(draftId, {
-      to: [original.from],
+      // Mirror both real providers: an explicit opts.to replaces the derived
+      // recipient; absent it, the reply is addressed to the original sender.
+      to: opts?.to && opts.to.length > 0 ? opts.to : [original.from],
       cc: opts?.cc,
       subject: `Re: ${original.subject}`,
       body,

--- a/packages/email-core/src/types.ts
+++ b/packages/email-core/src/types.ts
@@ -139,6 +139,21 @@ export interface ListOptions {
 }
 
 export interface ReplyOptions {
+  /**
+   * Explicit To recipients for the reply. When set, this **replaces** the
+   * provider-derived To (Graph's auto-populated recipients on Microsoft, the
+   * original sender on Gmail) rather than merging into it — unlike `cc`, which
+   * merges with the thread's. Replacing is deliberate: it is what makes
+   * redirecting a thread to a different recipient expressible, and it matches
+   * what `to` means on every other compose surface in this API. When unset,
+   * providers keep their existing derived-recipient behavior byte-for-byte.
+   *
+   * Security note: action-layer *send* paths must include these addresses in
+   * their allowlist collection before passing them through. Today only the
+   * draft path supplies `to`, and drafts are gated at `send_draft` time by
+   * re-reading the stored draft's own recipients.
+   */
+  to?: EmailAddress[];
   cc?: EmailAddress[];
   bcc?: EmailAddress[];
   attachments?: OutboundAttachment[];

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -925,6 +925,74 @@ describe('provider-gmail/Reply Drafts', () => {
     const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
     expect(raw).toMatch(/Cc: .*bob@corp\.com.*carol@corp\.com/);
   });
+
+  it('Scenario: explicit to replaces the original sender on a self-sent parent (issue #164)', async () => {
+    // Parent sent by the mailbox owner, so original.from is the owner. Without
+    // an explicit To the draft comes back addressed to the owner alone.
+    const selfSent = {
+      ...originalMessageMock(),
+      payload: {
+        ...originalMessageMock().payload,
+        headers: [
+          ...originalMessageMock().payload.headers.filter(h => h.name !== 'From'),
+          { name: 'From', value: '"Owner" <owner@corp.com>' },
+        ],
+      },
+    };
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(selfSent),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', {
+      replyAll: false,
+      to: [{ email: 'recipient@corp.com', name: 'Recipient' }],
+    });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('To: "Recipient" <recipient@corp.com>');
+    expect(raw).not.toContain('owner@corp.com');
+  });
+
+  it('Scenario: explicit to with several addresses lands on the To header (issue #164)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', {
+      replyAll: false,
+      to: [{ email: 'first@corp.com' }, { email: 'second@corp.com' }],
+    });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toMatch(/^To: .*first@corp\.com.*second@corp\.com/m);
+    expect(raw).not.toContain('alice@corp.com');
+  });
+
+  it('Scenario: omitted to keeps the original sender as To (issue #164 no-op guard)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', { replyAll: false });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('To: "Alice" <alice@corp.com>');
+  });
+
+  it('Scenario: empty to array keeps the original sender as To (issue #164)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', { replyAll: false, to: [] });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('To: "Alice" <alice@corp.com>');
+  });
 });
 
 describe('provider-gmail/Reply Threading on Send', () => {
@@ -975,6 +1043,37 @@ describe('provider-gmail/Reply Threading on Send', () => {
     expect(raw).toContain('In-Reply-To: <msg-xyz@corp.com>');
     expect(raw).toContain('References: <msg-xyz@corp.com>');
     expect(raw).toContain('Subject: Re: Urgent');
+  });
+
+  it('Scenario: replyToMessage honors explicit to (issue #164)', async () => {
+    // Parity with the draft path. No action-layer send path passes `to` today —
+    // reply_to_email has no such input — so this only fixes the provider
+    // contract; any future send caller must allowlist-check these addresses.
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(ccThreadMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.replyToMessage('msg-original', 'redirected', {
+      replyAll: false,
+      to: [{ email: 'recipient@corp.com' }],
+    });
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toMatch(/^To: .*recipient@corp\.com/m);
+    expect(raw).not.toContain('alice@corp.com');
+  });
+
+  it('Scenario: replyToMessage without to keeps the original sender (issue #164 no-op guard)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(ccThreadMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.replyToMessage('msg-original', 'reply');
+
+    const raw = lastRaw(client.sendMessage as ReturnType<typeof vi.fn>);
+    expect(raw).toContain('To: "Alice" <alice@corp.com>');
   });
 
   it('Scenario: replyToMessage with replyAll: false omits thread participants from Cc', async () => {

--- a/packages/provider-gmail/src/email-gmail-provider.test.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.test.ts
@@ -970,6 +970,42 @@ describe('provider-gmail/Reply Drafts', () => {
     expect(raw).not.toContain('alice@corp.com');
   });
 
+  it('Scenario: explicit to under reply-all moves the displaced sender to Cc (issue #164)', async () => {
+    // Parity with Microsoft: replacing the To line must not drop the parent's
+    // sender when the caller asked for reply-all.
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', {
+      to: [{ email: 'recipient@corp.com' }],
+    });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    expect(raw).toMatch(/^To: .*recipient@corp\.com/m);
+    // alice (the parent's sender) survives on Cc alongside the thread.
+    expect(raw).toMatch(/^Cc: .*alice@corp\.com.*bob@corp\.com.*carol@corp\.com/m);
+  });
+
+  it('Scenario: a caller addressed on To is not also listed on Cc (issue #164)', async () => {
+    const client = createMockGmailClient({
+      getMessage: vi.fn().mockResolvedValue(originalMessageMock()),
+    });
+    const provider = new GmailEmailProvider(client);
+
+    await provider.createReplyDraft('msg-original', 'reply', {
+      to: [{ email: 'BOB@corp.com' }],
+    });
+
+    const raw = lastRaw(client.createDraft as ReturnType<typeof vi.fn>);
+    const ccLine = raw.split(/\r?\n/).find(l => l.startsWith('Cc: '))!;
+    // Case-insensitive: bob is addressed on To, so he is absent from Cc.
+    expect(ccLine.toLowerCase()).not.toContain('bob@corp.com');
+    expect(ccLine).toContain('alice@corp.com');
+    expect(ccLine).toContain('carol@corp.com');
+  });
+
   it('Scenario: omitted to keeps the original sender as To (issue #164 no-op guard)', async () => {
     const client = createMockGmailClient({
       getMessage: vi.fn().mockResolvedValue(originalMessageMock()),

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -209,15 +209,11 @@ export class GmailEmailProvider {
     // either way. No self-exclusion — an agent that replies to its own sent
     // mail may cc itself; documented caveat.
     const original = await this.getMessage(messageId);
-    const replyCc = opts?.replyAll === false
-      ? (opts?.cc ?? [])
-      : mergeAddressLists(original.to, original.cc, opts?.cc);
+    // No action-layer send path supplies opts.to today; if one ever does, its
+    // allowlist collection must cover those addresses (issue #164).
+    const { to: replyTo, cc: replyCc } = resolveReplyRecipients(original, opts);
     const subject = prefixReSubject(original.subject);
     const references = buildReferences(original.references, original.messageId);
-    // Explicit To replaces the original sender rather than merging (issue
-    // #164). No action-layer send path supplies opts.to today; if one ever
-    // does, its allowlist collection must cover these addresses.
-    const replyTo = opts?.to && opts.to.length > 0 ? opts.to : [original.from];
 
     const raw = buildRawMessage(
       {
@@ -253,15 +249,11 @@ export class GmailEmailProvider {
   async createReplyDraft(messageId: string, body: string, opts?: ReplyOptions): Promise<DraftResult> {
     try {
       const original = await this.getMessage(messageId);
-      const replyCc = opts?.replyAll === false
-        ? (opts?.cc ?? [])
-        : mergeAddressLists(original.to, original.cc, opts?.cc);
+      // Drafts stay allowlist-exempt; send_draft re-reads the stored draft's
+      // recipients and gates them there (issue #164).
+      const { to: replyTo, cc: replyCc } = resolveReplyRecipients(original, opts);
       const subject = prefixReSubject(original.subject);
       const references = buildReferences(original.references, original.messageId);
-      // Explicit To replaces the original sender rather than merging (issue
-      // #164). Drafts stay allowlist-exempt; send_draft re-reads the stored
-      // draft's recipients and gates them there.
-      const replyTo = opts?.to && opts.to.length > 0 ? opts.to : [original.from];
 
       const raw = buildRawMessage(
         {
@@ -863,6 +855,46 @@ function buildRawMessage(msg: ComposeMessage, opts: BuildRawOptions = {}): strin
  * reply-all, preserving order and de-duplicating by email address. Returns
  * a new array; inputs are not mutated.
  */
+/**
+ * Resolve a reply's To and Cc from the parent message plus caller options.
+ * Shared by `replyToMessage` and `createReplyDraft` so the send and draft paths
+ * cannot drift apart.
+ *
+ * Default reply-all: cc every other thread participant (matches Microsoft's
+ * createReplyAll semantics). When `replyAll` is explicitly false, reply only to
+ * the original sender. Caller-supplied cc layers on top either way. No
+ * self-exclusion — an agent that replies to its own sent mail may cc itself;
+ * documented caveat.
+ *
+ * An explicit `to` replaces the original sender on the To line rather than
+ * merging with it (issue #164). Under reply-all the displaced sender is moved
+ * to Cc so nobody silently falls off the thread, and anyone now addressed on To
+ * is dropped from Cc so they are not listed twice. Under `replyAll: false`
+ * there is nothing to preserve — narrowing to an explicit recipient set is the
+ * point. With `to` absent or empty, both the To and the Cc are computed exactly
+ * as they were before the option existed.
+ */
+function resolveReplyRecipients(
+  original: EmailMessage,
+  opts?: ReplyOptions,
+): { to: EmailAddress[]; cc: EmailAddress[] } {
+  const hasExplicitTo = Boolean(opts?.to && opts.to.length > 0);
+  const to = hasExplicitTo ? opts!.to! : [original.from];
+
+  if (opts?.replyAll === false) {
+    return { to, cc: opts?.cc ?? [] };
+  }
+
+  if (!hasExplicitTo) {
+    return { to, cc: mergeAddressLists(original.to, original.cc, opts?.cc) };
+  }
+
+  const addressed = new Set(to.map(a => a.email.toLowerCase()));
+  const cc = mergeAddressLists([original.from], original.to, original.cc, opts?.cc)
+    .filter(a => !addressed.has(a.email.toLowerCase()));
+  return { to, cc };
+}
+
 function mergeAddressLists(
   ...lists: Array<EmailAddress[] | undefined>
 ): EmailAddress[] {

--- a/packages/provider-gmail/src/email-gmail-provider.ts
+++ b/packages/provider-gmail/src/email-gmail-provider.ts
@@ -214,10 +214,14 @@ export class GmailEmailProvider {
       : mergeAddressLists(original.to, original.cc, opts?.cc);
     const subject = prefixReSubject(original.subject);
     const references = buildReferences(original.references, original.messageId);
+    // Explicit To replaces the original sender rather than merging (issue
+    // #164). No action-layer send path supplies opts.to today; if one ever
+    // does, its allowlist collection must cover these addresses.
+    const replyTo = opts?.to && opts.to.length > 0 ? opts.to : [original.from];
 
     const raw = buildRawMessage(
       {
-        to: [original.from],
+        to: replyTo,
         cc: replyCc.length > 0 ? replyCc : undefined,
         bcc: opts?.bcc,
         subject,
@@ -254,10 +258,14 @@ export class GmailEmailProvider {
         : mergeAddressLists(original.to, original.cc, opts?.cc);
       const subject = prefixReSubject(original.subject);
       const references = buildReferences(original.references, original.messageId);
+      // Explicit To replaces the original sender rather than merging (issue
+      // #164). Drafts stay allowlist-exempt; send_draft re-reads the stored
+      // draft's recipients and gates them there.
+      const replyTo = opts?.to && opts.to.length > 0 ? opts.to : [original.from];
 
       const raw = buildRawMessage(
         {
-          to: [original.from],
+          to: replyTo,
           cc: replyCc.length > 0 ? replyCc : undefined,
           bcc: opts?.bcc,
           subject,

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1467,6 +1467,72 @@ describe('provider-microsoft/Reply-All Routing', () => {
     const patch = patchArgs[1] as { ccRecipients?: Array<{ emailAddress: { address: string } }> };
     expect(patch.ccRecipients?.map(r => r.emailAddress.address)).toEqual(['manager@corp.com']);
   });
+
+  it('Scenario: explicit to replaces Graph auto-populated recipients (issue #164)', async () => {
+    // Self-sent parent: Graph's createReply addresses the draft back to the
+    // mailbox owner. An explicit To must replace that, not merge with it.
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse({
+        ccRecipients: [],
+        toRecipients: [{ emailAddress: { address: 'owner@corp.com' } }],
+      })),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      replyAll: false,
+      to: [{ email: 'recipient@corp.com', name: 'Recipient' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as { toRecipients?: Array<{ emailAddress: { address: string; name?: string } }> };
+    expect(patch.toRecipients?.map(r => r.emailAddress.address)).toEqual(['recipient@corp.com']);
+    expect(patch.toRecipients?.[0]!.emailAddress.name).toBe('Recipient');
+  });
+
+  it('Scenario: explicit to with several addresses patches all of them (issue #164)', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      to: [{ email: 'first@corp.com' }, { email: 'second@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as { toRecipients?: Array<{ emailAddress: { address: string } }> };
+    expect(patch.toRecipients?.map(r => r.emailAddress.address)).toEqual(['first@corp.com', 'second@corp.com']);
+  });
+
+  it('Scenario: omitted to leaves toRecipients out of the PATCH (issue #164 no-op guard)', async () => {
+    // Regression guard: without an explicit To the PATCH must not mention
+    // toRecipients at all, so Graph's derived To stands untouched.
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      cc: [{ email: 'manager@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as Record<string, unknown>;
+    expect(patch).not.toHaveProperty('toRecipients');
+  });
+
+  it('Scenario: empty to array leaves toRecipients out of the PATCH (issue #164)', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse()),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', { to: [] });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(patchArgs[1] as Record<string, unknown>).not.toHaveProperty('toRecipients');
+  });
 });
 
 describe('provider-microsoft/Size Limits', () => {

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -1497,12 +1497,85 @@ describe('provider-microsoft/Reply-All Routing', () => {
     const provider = new GraphEmailProvider(client);
 
     await provider.createReplyDraft('msg-1', 'reply', {
+      replyAll: false,
       to: [{ email: 'first@corp.com' }, { email: 'second@corp.com' }],
     });
 
     const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
     const patch = patchArgs[1] as { toRecipients?: Array<{ emailAddress: { address: string } }> };
     expect(patch.toRecipients?.map(r => r.emailAddress.address)).toEqual(['first@corp.com', 'second@corp.com']);
+  });
+
+  it('Scenario: explicit to under reply-all demotes displaced participants to Cc (issue #164)', async () => {
+    // Graph's createReplyAll puts the parent's sender AND its other To
+    // participants on the draft's To. Replacing that list must not drop them —
+    // reply-all means the thread stays on the message.
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse({
+        toRecipients: [
+          { emailAddress: { address: 'alice@corp.com' } },
+          { emailAddress: { address: 'bob@corp.com' } },
+        ],
+        ccRecipients: [{ emailAddress: { address: 'carol@corp.com' } }],
+      })),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      to: [{ email: 'recipient@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as {
+      toRecipients?: Array<{ emailAddress: { address: string } }>;
+      ccRecipients?: Array<{ emailAddress: { address: string } }>;
+    };
+    expect(patch.toRecipients?.map(r => r.emailAddress.address)).toEqual(['recipient@corp.com']);
+    expect(patch.ccRecipients?.map(r => r.emailAddress.address))
+      .toEqual(['carol@corp.com', 'alice@corp.com', 'bob@corp.com']);
+  });
+
+  it('Scenario: a caller addressed on To is not also demoted to Cc (issue #164)', async () => {
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse({
+        toRecipients: [
+          { emailAddress: { address: 'Alice@Corp.com' } },
+          { emailAddress: { address: 'bob@corp.com' } },
+        ],
+        ccRecipients: [],
+      })),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      to: [{ email: 'alice@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as { ccRecipients?: Array<{ emailAddress: { address: string } }> };
+    // Case-insensitive: alice stays on To only; bob is the sole demoted address.
+    expect(patch.ccRecipients?.map(r => r.emailAddress.address)).toEqual(['bob@corp.com']);
+  });
+
+  it('Scenario: replyAll false does not demote the displaced sender to Cc (issue #164)', async () => {
+    // createReply's To is just the parent's sender. A narrowed redirect is
+    // meant to drop them, so nothing is demoted.
+    const client = createMockClient({
+      post: vi.fn().mockResolvedValueOnce(quotedReplyResponse({
+        toRecipients: [{ emailAddress: { address: 'alice@corp.com' } }],
+        ccRecipients: [],
+      })),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    await provider.createReplyDraft('msg-1', 'reply', {
+      replyAll: false,
+      to: [{ email: 'recipient@corp.com' }],
+    });
+
+    const patchArgs = (client.patch as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const patch = patchArgs[1] as Record<string, unknown>;
+    expect(patch).not.toHaveProperty('ccRecipients');
   });
 
   it('Scenario: omitted to leaves toRecipients out of the PATCH (issue #164 no-op guard)', async () => {

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -1064,6 +1064,18 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
       ],
     };
 
+    // `to` REPLACES Graph's auto-populated recipients; `cc`/`bcc` below MERGE
+    // with the thread's. The asymmetry is deliberate (issue #164): merging a
+    // caller-supplied To would leave the parent's sender on the To line, which
+    // is exactly the failure being fixed — a reply to your own sent message
+    // stays addressed to yourself. Absent `to`, the patch omits toRecipients
+    // entirely and Graph's derived To stands, unchanged from before.
+    // mergeRecipients([], …) is reused only for its EmailAddress →
+    // GraphRecipient conversion and case-insensitive dedupe.
+    if (opts?.to && opts.to.length > 0) {
+      patch.toRecipients = mergeRecipients([], opts.to);
+    }
+
     const ccMerged = mergeRecipients(draftCc, opts?.cc ?? []);
     if (ccMerged.length > 0) patch.ccRecipients = ccMerged;
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -1039,6 +1039,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
     if (!draft.id) throw new Error(`${endpoint} did not return a draft id`);
 
     let draftBody = draft.body as { contentType?: string; content?: string } | undefined;
+    let draftTo = (draft.toRecipients as GraphRecipient[] | undefined) ?? [];
     let draftCc = (draft.ccRecipients as GraphRecipient[] | undefined) ?? [];
     let draftBcc = (draft.bccRecipients as GraphRecipient[] | undefined) ?? [];
 
@@ -1047,6 +1048,7 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
     if (typeof draftBody?.content !== 'string' || draftBody.contentType?.toLowerCase() !== 'html') {
       const fetched = await this.client.get(`${this.basePath}/messages/${encodeGraphPathId(draft.id)}`);
       draftBody = fetched.body as { contentType?: string; content?: string } | undefined;
+      draftTo = (fetched.toRecipients as GraphRecipient[] | undefined) ?? [];
       draftCc = (fetched.ccRecipients as GraphRecipient[] | undefined) ?? [];
       draftBcc = (fetched.bccRecipients as GraphRecipient[] | undefined) ?? [];
     }
@@ -1072,11 +1074,28 @@ export class GraphEmailProvider implements EmailReader, EmailSender, EmailSchedu
     // entirely and Graph's derived To stands, unchanged from before.
     // mergeRecipients([], …) is reused only for its EmailAddress →
     // GraphRecipient conversion and case-insensitive dedupe.
-    if (opts?.to && opts.to.length > 0) {
-      patch.toRecipients = mergeRecipients([], opts.to);
+    const hasExplicitTo = Boolean(opts?.to && opts.to.length > 0);
+    if (hasExplicitTo) {
+      patch.toRecipients = mergeRecipients([], opts!.to!);
     }
 
-    const ccMerged = mergeRecipients(draftCc, opts?.cc ?? []);
+    // Replacing the To line must not silently drop anyone. On the reply-all
+    // endpoint Graph puts the parent's sender AND its other To participants on
+    // the draft's To; an explicit `to` displaces all of them, so demote the
+    // displaced ones to Cc — reply-all means the thread stays on the message,
+    // and `to` only decides who it is addressed to. This also brings Microsoft
+    // in line with Gmail, which already carries the thread's participants on Cc
+    // under reply-all. On the sender-only endpoint there is nothing to preserve:
+    // Graph's To is just the parent's sender, and replacing that is the point of
+    // a narrowed redirect.
+    const displacedTo = hasExplicitTo && opts?.replyAll !== false
+      ? draftTo.filter(r => {
+        const address = r.emailAddress?.address?.toLowerCase();
+        return address ? !opts!.to!.some(a => a.email.toLowerCase() === address) : false;
+      })
+      : [];
+
+    const ccMerged = mergeRecipients([...draftCc, ...displacedTo], opts?.cc ?? []);
     if (ccMerged.length > 0) patch.ccRecipients = ccMerged;
 
     const bccMerged = mergeRecipients(draftBcc, opts?.bcc ?? []);


### PR DESCRIPTION
Closes #164.

## The bug

`create_draft` **requires** `to`, parses it, and then on the `reply_to` path forwarded only `cc` to the provider — `parsed.to` was silently discarded. The draft ended up addressed to whatever the provider derived from the parent message.

The worst case is replying to a message you sent: the provider derives the reply's To from the parent's *sender*, which is you. Combined with `reply_all: false`, the draft comes back addressed to nobody but the mailbox owner, and the intended recipient is nowhere on it. No error, no warning.

The drop was structural, not a missed argument: `ReplyOptions` had no `to` field at all, so there was nothing to plumb through. Both providers supplied their own To — Graph via `createReply`/`createReplyAll` auto-population, Gmail via a hardcoded `[original.from]`.

## The fix

Option 1 from the issue — honor it.

- `ReplyOptions` gains `to?: EmailAddress[]`.
- `create_draft` forwards `parsed.to` on the reply path.
- **Microsoft**: the follow-up PATCH sets `toRecipients` only when the caller supplied `to`.
- **Gmail**: `opts.to ?? [original.from]` in both `replyToMessage` and `createReplyDraft`.

### Replace, not merge — and non-lossy

An explicit `to` **replaces** the provider-derived To rather than merging with it, unlike `cc`, which merges with the thread's. The asymmetry is deliberate: merging would leave the parent's sender on the To line, which is precisely the failure being fixed. Replacing is also what makes the redirect case expressible ("Bob moved teams, send this to Carol instead") and matches what `to` means on every other compose surface.

Replacing must not drop anyone, though. On `createReplyAll` Graph places the parent's sender *and* the thread's other To participants on the draft's To, so a naive replace would silently narrow a reply-all's audience — the same silent-recipient-loss family as #48 and #102. Under reply-all, participants displaced from the To line are therefore **moved to Cc** on both providers (case-insensitive dedupe, excluding anyone the caller addressed on To so nobody is listed twice). Under `reply_all: false` nothing is preserved — narrowing to an explicit recipient set is the point.

Net effect: the effective audience of a reply is a superset of today's on both providers. No existing caller loses a recipient, whatever they pass for `to`.

When `to` is absent or empty, behavior is byte-identical to before on both providers: Microsoft omits `toRecipients` from the PATCH entirely so Graph's derived To stands, and Gmail addresses the original sender with Cc computed exactly as before. Four dedicated no-op guard tests pin this.

Gmail's two reply methods now resolve recipients through a single shared `resolveReplyRecipients` helper, so the send and draft paths cannot drift apart.

## Security check — no allowlist bypass

`create_draft` deliberately bypasses the send allowlist ("enforcement happens at `send_draft` time"). Letting a caller set To on a reply draft does **not** smuggle a recipient past that enforcement: `send_draft` re-fetches the draft via `getMessage(draft_id)` and gates To + Cc + Bcc read back from the provider's *stored* copy, so a caller-supplied reply To is checked exactly like the To of a non-reply draft. Same for the scheduled-send path, which runs the identical gate before `scheduleDraft`. Covered by a new test that creates a reply draft to a non-allowlisted address and asserts `send_draft` returns `ALLOWLIST_BLOCKED` with nothing sent.

One latent edge worth noting: `replyToMessage` is a *send* path and now honors `opts.to` on both providers, while `reply.ts`'s `collectReplyAllowlistRecipients` derives allowlist recipients from the original message rather than from `opts.to`. This is unreachable today — `reply_to_email` has no `to` input and its sole production call site passes none (verified by grepping every call site) — and it is called out in a comment on `ReplyOptions.to` so a future send caller has to reckon with it.

## `reply_to_email` deliberately left out

The issue notes `reply_to_email` has no `to` input either. Left out to keep this PR tight, and because an explicit To on a *send* path has real allowlist implications the draft path does not — it would need to join `collectReplyAllowlistRecipients` in the same change. The draft path is the reported bug. `reply_to_email` keeps the provider-derived To, guarded by a no-op regression test.

## Tests

The issue's closing line was that a test asserting the resolved To of a reply draft created against a **self-sent** message would have caught this. That test now exists, on both providers.

Coverage: explicit `to` honored; multi-recipient forwarding with display names; reply-all demotion to Cc; case-insensitive To/Cc de-duplication; `reply_all: false` correctly does *not* demote; `to` omitted and `to: []` leave provider defaults untouched; and the send-time allowlist gate. Every positive test was verified to fail without the corresponding source change; every no-op guard passes both before and after.

`npm run build`, `npm run lint`, `npm run test:run` (468 + 226 + 108 + 211 + 31 vitest tests, plus the node test scripts), `check:spec-coverage` (281/281, up from 262), `check:server-json`, and `check:isolated-runtime` all pass locally.

Specs updated in `email-write`, `provider-microsoft`, and `provider-gmail`. The `email-write` spec previously asserted outright that `ReplyOptions` has no `to` and that a caller-supplied `to` does not affect reply recipients; that sentence is now corrected.

## Review

Peer-reviewed by Codex (dynamic review with full repo access and command execution). Verdict was MERGE-WITH-CHANGES, blocking on the Microsoft reply-all recipient loss described above — caught and fixed in the second commit. Codex independently confirmed the no-allowlist-bypass finding, that Graph documents `toRecipients` as writable while `isDraft=true`, and that leaving `reply_to_email` alone was the right scope call.

One thing this change cannot verify locally: the Microsoft tests assert on the PATCH request body, not on a persisted draft read back from Graph. Graph documents recipient properties as writable on drafts, but an integration test that GETs the draft after the PATCH and asserts persisted To/Cc plus `conversationId` would close that gap.