### PR TITLE
fix(auth): stop observe-profile serve path from hanging on an unconsented scope set

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ compatibility.
 
 | Profile | Microsoft delegated scopes | Exposed tools |
 |---------|-----------------------------|---------------|
-| `observe` | `Mail.Read`, `MailboxSettings.Read`, `User.Read`, `offline_access` | Read-only email tools plus local mailbox configuration/authentication tools |
+| `observe` | `Mail.Read`, `User.Read`, `offline_access` | Read-only email tools, minus `list_inbox_rules` (see below) |
 | `full` (default) | `Mail.Read`, `Mail.ReadWrite`, `Mail.Send`, `MailboxSettings.ReadWrite`, `User.Read`, `offline_access` | All tools |
 
 For an observation-only deployment, set the profile for both configuration and
@@ -162,11 +162,42 @@ npx email-agent-mcp configure
 npx email-agent-mcp serve
 ```
 
-Changing profiles changes the Microsoft OAuth scope set. MSAL caches tokens by
-scope, so restart the server and run `email-agent-mcp configure` again to grant
-the new scopes. In particular, switching from `observe` to `full` requires a new
-interactive consent before write tools can be used. An invalid profile value
-stops startup instead of silently granting broader access.
+`observe`'s scopes are a deliberate **strict subset** of `full`'s. That is what
+makes the profile adoptable: a tenant that has already consented to the full set
+grants `observe` silently, so switching `full` → `observe` needs no new consent.
+Switching `observe` → `full` does require a new interactive consent, because it
+asks for scopes that were never granted.
+
+For the same reason `observe` does **not** expose `list_inbox_rules`. Graph gates
+`/mailFolders/inbox/messageRules` behind `MailboxSettings`, and Entra treats
+`MailboxSettings.Read` as a distinct scope from `full`'s
+`MailboxSettings.ReadWrite` rather than implied by it. Requesting it would break
+the subset property and force a fresh consent on every `observe` deployment — an
+admin-approval request in tenants that restrict user consent. Use `full` if you
+need inbox-rule visibility.
+
+An invalid profile value stops startup instead of silently granting broader
+access. If cached credentials do not cover the profile's scopes, the server
+fails fast with an actionable error rather than blocking on an interactive
+sign-in.
+
+#### What `observe` does and does not guarantee
+
+`observe` always removes the write tools from the MCP tool surface, so an agent
+cannot invoke them. That part holds everywhere.
+
+It only narrows the **OAuth token** on a mailbox that has not already consented
+to the write scopes. Entra issues an access token carrying every scope the user
+or tenant has already consented to for that application — not just the subset
+requested at token-acquisition time. So if you point `observe` at a mailbox
+previously configured as `full`, the underlying token still carries
+`Mail.ReadWrite` and `Mail.Send`; only the tool surface is reduced.
+
+For a genuine least-privilege token, consent to `observe` from a mailbox that
+has never been granted the write scopes — a fresh `configure` against an app
+registration whose delegated permissions stop at `Mail.Read`/`User.Read`. Treat
+the tool-surface reduction as defense in depth, not as an OAuth boundary, unless
+you control the grant.
 
 ### Tools
 

--- a/packages/email-core/src/scope-profile.test.ts
+++ b/packages/email-core/src/scope-profile.test.ts
@@ -4,6 +4,7 @@ import {
   EMAIL_SCOPE_PROFILE_ENV,
   filterActionsForProfile,
   getEmailScopeProfile,
+  profileBlockedActionError,
 } from './scope-profile.js';
 
 const action = (name: string, readOnlyHint: boolean) => ({
@@ -37,6 +38,29 @@ describe('email scope profiles', () => {
       'configure_mailbox',
       'remove_mailbox',
     ]);
+  });
+
+  it('Scenario: observe hides read-only tools its scopes cannot satisfy', () => {
+    // list_inbox_rules is readOnlyHint, but Graph gates messageRules behind
+    // MailboxSettings, which observe does not request. Advertising it would
+    // hand an agent a tool that always 403s.
+    const actions = [action('read_email', true), action('list_inbox_rules', true)];
+
+    expect(filterActionsForProfile(actions, 'observe').map(item => item.name)).toEqual(['read_email']);
+    expect(filterActionsForProfile(actions, 'full').map(item => item.name)).toEqual([
+      'read_email',
+      'list_inbox_rules',
+    ]);
+  });
+
+  it('Scenario: blocked-tool errors name the right reason', () => {
+    // A read-only tool withheld for scope reasons must not be described as a
+    // write tool — that points an agent at the wrong recovery path.
+    expect(profileBlockedActionError('send_email').message).toContain('can modify mailbox data');
+    expect(profileBlockedActionError('list_inbox_rules').message)
+      .toContain('does not request the Microsoft Graph scope it requires');
+    expect(profileBlockedActionError('list_inbox_rules').message)
+      .not.toContain('can modify mailbox data');
   });
 
   it('Scenario: invalid profile fails closed with an actionable error', () => {

--- a/packages/email-core/src/scope-profile.ts
+++ b/packages/email-core/src/scope-profile.ts
@@ -24,12 +24,22 @@ export function getEmailScopeProfile(
   );
 }
 
+// Read-only actions that observe must still hide, because the Graph scopes the
+// observe profile requests cannot satisfy them. list_inbox_rules reads
+// /mailFolders/inbox/messageRules, which Graph gates behind MailboxSettings —
+// a scope observe deliberately does not request (see GRAPH_SCOPES_BY_PROFILE).
+// Exposing it anyway would advertise a tool that always 403s.
+const OBSERVE_EXCLUDED_ACTIONS = new Set([
+  'list_inbox_rules',
+]);
+
 export function isActionAllowedForProfile(
   action: Pick<EmailAction, 'name' | 'annotations'>,
   profile: EmailScopeProfile,
 ): boolean {
-  return profile === 'full'
-    || action.annotations.readOnlyHint
+  if (profile === 'full') return true;
+  if (OBSERVE_EXCLUDED_ACTIONS.has(action.name)) return false;
+  return action.annotations.readOnlyHint
     || OBSERVE_CONFIGURATION_ACTIONS.has(action.name);
 }
 
@@ -41,7 +51,14 @@ export function filterActionsForProfile<T extends Pick<EmailAction, 'name' | 'an
 }
 
 export function profileBlockedActionError(actionName: string): Error {
+  // Two different reasons a tool can be missing under observe, and telling an
+  // agent the wrong one sends it down the wrong recovery path. A read-only tool
+  // excluded for scope reasons is not "a write tool".
+  const reason = OBSERVE_EXCLUDED_ACTIONS.has(actionName)
+    ? 'because the "observe" profile does not request the Microsoft Graph scope it requires'
+    : 'because it can modify mailbox data';
   return new Error(
-    `Tool "${actionName}" is unavailable under the "observe" scope profile because it can modify mailbox data. Set ${EMAIL_SCOPE_PROFILE_ENV}=full and re-authenticate to enable write tools.`,
+    `Tool "${actionName}" is unavailable under the "observe" scope profile ${reason}. `
+    + `Set ${EMAIL_SCOPE_PROFILE_ENV}=full and re-authenticate to enable it.`,
   );
 }

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -72,10 +72,9 @@ describe('provider-interface/Microsoft Mailbox Settings Consent', () => {
   });
 
   it('Scenario: Observe profile requests only read and identity scopes', () => {
-    expect(GRAPH_SCOPES_BY_PROFILE.observe).toEqual(['Mail.Read', 'MailboxSettings.Read', 'User.Read', 'offline_access']);
+    expect(GRAPH_SCOPES_BY_PROFILE.observe).toEqual(['Mail.Read', 'User.Read', 'offline_access']);
     expect(GRAPH_SCOPES_FULL_BY_PROFILE.observe).toEqual([
       'https://graph.microsoft.com/Mail.Read',
-      'https://graph.microsoft.com/MailboxSettings.Read',
       'https://graph.microsoft.com/User.Read',
       'offline_access',
     ]);
@@ -84,6 +83,19 @@ describe('provider-interface/Microsoft Mailbox Settings Consent', () => {
     expect(GRAPH_SCOPES_FULL_BY_PROFILE.observe.some(scope => /ReadWrite|\.Send/.test(scope))).toBe(false);
     expect(GRAPH_SCOPES_BY_PROFILE.full).toBe(GRAPH_SCOPES);
     expect(GRAPH_SCOPES_FULL_BY_PROFILE.full).toBe(GRAPH_SCOPES_FULL);
+  });
+
+  it('Scenario: Observe scopes are a strict subset of full, so no new consent is needed', () => {
+    // The subset property is the whole adoption story: a tenant that already
+    // consented to (or admin-consented) the full set grants observe silently.
+    // Adding any scope outside the full set turns every observe deployment into
+    // a fresh consent, and an admin-approval request in a restricted tenant.
+    for (const scope of GRAPH_SCOPES_BY_PROFILE.observe) {
+      expect(GRAPH_SCOPES).toContain(scope);
+    }
+    for (const scope of GRAPH_SCOPES_FULL_BY_PROFILE.observe) {
+      expect(GRAPH_SCOPES_FULL).toContain(scope);
+    }
   });
 });
 
@@ -176,8 +188,12 @@ describe('provider-microsoft/Delegated OAuth Authentication', () => {
 
     const [credentialOptions] = mockDeviceCodeState.constructorOptions;
     const persistenceOptions = credentialOptions?.tokenCachePersistenceOptions as { enabled?: boolean; name?: string } | undefined;
-    // reconnect uses disableAutomaticAuthentication: false to allow silent token refresh via MSAL cache
-    expect(credentialOptions?.disableAutomaticAuthentication).toBe(false);
+    // reconnect must set disableAutomaticAuthentication: true. The flag only gates the
+    // *interactive* fallback — MSAL's silent path (cache hit and refresh-token redemption)
+    // still works. Left false, a cache that cannot satisfy the requested scopes makes
+    // getToken start a device flow that blocks for the whole polling window and writes its
+    // prompt to stdout, which is the JSON-RPC channel on an stdio MCP server.
+    expect(credentialOptions?.disableAutomaticAuthentication).toBe(true);
     expect(persistenceOptions?.name).toBe('email-agent-mcp-work-cache-id');
     expect(auth.needsReauth).toBe(false);
   });

--- a/packages/provider-microsoft/src/auth.ts
+++ b/packages/provider-microsoft/src/auth.ts
@@ -22,20 +22,26 @@ export const GRAPH_SCOPES_FULL = [
   'offline_access',
 ];
 
-// MailboxSettings.Read is the read-only half of the full profile's
-// MailboxSettings.ReadWrite. list_inbox_rules is a read-only tool that stays
-// exposed under observe, and Graph gates /mailFolders/inbox/messageRules behind
-// MailboxSettings — without it that tool is guaranteed to 403.
+// Observe deliberately requests a STRICT SUBSET of the full profile's scopes.
+// That subset property is what makes the profile adoptable: a tenant that has
+// already consented to the full set (or admin-consented it once for everyone)
+// grants observe silently, so switching profiles needs no new consent.
+//
+// This is why MailboxSettings.Read is NOT here even though it would let
+// list_inbox_rules work. Entra treats it as a distinct scope from the full
+// profile's MailboxSettings.ReadWrite, not as implied by it, so adding it turns
+// every observe deployment into a fresh consent — and in a tenant that restricts
+// user consent, an admin-approval request. The tool surface is trimmed to match
+// these scopes instead; see OBSERVE_EXCLUDED_ACTIONS in email-core.
 export const GRAPH_SCOPES_BY_PROFILE: Record<EmailScopeProfile, string[]> = {
   full: GRAPH_SCOPES,
-  observe: ['Mail.Read', 'MailboxSettings.Read', 'User.Read', 'offline_access'],
+  observe: ['Mail.Read', 'User.Read', 'offline_access'],
 };
 
 export const GRAPH_SCOPES_FULL_BY_PROFILE: Record<EmailScopeProfile, string[]> = {
   full: GRAPH_SCOPES_FULL,
   observe: [
     'https://graph.microsoft.com/Mail.Read',
-    'https://graph.microsoft.com/MailboxSettings.Read',
     'https://graph.microsoft.com/User.Read',
     'offline_access',
   ],
@@ -175,6 +181,16 @@ export class DelegatedAuthManager implements AuthManager {
       tenantId: metadata.tenantId,
       authenticationRecord: this.authRecord,
       cacheName: this.cacheName,
+      // This is the `serve` path. Without this, a cache that does not cover the
+      // requested scopes makes DeviceCodeCredential silently start an interactive
+      // device flow: it blocks for the whole polling window while the server sits
+      // in `connecting`, and its default prompt callback writes to stdout — which
+      // on an stdio MCP server is the JSON-RPC channel. Fail fast instead.
+      disableAutomaticAuthentication: true,
+      // Belt-and-braces: if a device prompt is ever reached here, keep it off stdout.
+      userPromptCallback: (info: DeviceCodeInfo) => {
+        console.error(`[email-agent-mcp] Interactive sign-in required: ${info.verificationUri} code ${info.userCode}`);
+      },
     });
 
     // Verify the token still works
@@ -184,9 +200,19 @@ export class DelegatedAuthManager implements AuthManager {
       this._needsReauth = false;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('interaction_required') || message.includes('invalid_grant')) {
+      const name = err instanceof Error ? err.name : '';
+      // AuthenticationRequiredError is what disableAutomaticAuthentication raises
+      // when the cached token cannot satisfy `this.scopes` — the normal signal for
+      // "this profile's scopes were never consented", not just an expired token.
+      if (name === 'AuthenticationRequiredError'
+        || message.includes('interaction_required')
+        || message.includes('invalid_grant')) {
         this._needsReauth = true;
-        throw new Error(`Token expired. Run: email-agent-mcp configure --mailbox ${this.mailboxName}`);
+        throw new Error(
+          `Cached credentials do not cover the scopes required by mailbox "${this.mailboxName}" `
+          + `(scope profile "${this.config.scopeProfile ?? getEmailScopeProfile()}"). `
+          + `Run: email-agent-mcp configure --mailbox ${this.mailboxName}`,
+        );
       }
       throw err;
     }


### PR DESCRIPTION
Follow-up fixes to the scope profiles shipped in #163, all found by exercising `observe` against a live Microsoft Graph mailbox.

## 1. The serve path could hang indefinitely (the real bug)

`reconnect()` — the path the MCP server takes on startup — did not set `disableAutomaticAuthentication`. When the cached token could not satisfy the requested scopes, `DeviceCodeCredential` silently started an **interactive device flow**: it blocked for the whole polling window while the server sat in `connecting`, and its default prompt callback wrote to **stdout**, which is the JSON-RPC channel on an stdio MCP server.

`connect()` (the `configure` path) already had the flag; `reconnect()` did not.

Fixed by setting `disableAutomaticAuthentication: true`, mapping `AuthenticationRequiredError` to an actionable "run `email-agent-mcp configure`" message, and adding a `userPromptCallback` that writes to stderr as belt-and-braces.

- Before: indefinite hang. After: fails in **228ms** with a message naming the mailbox and profile.
- This is not observe-specific — any scope mismatch (including a future scope addition to `full`) would have hit it.

An existing test asserted `disableAutomaticAuthentication: false` "to allow silent token refresh". That premise was wrong: the flag gates only the *interactive* fallback, not MSAL's silent cache-hit/refresh-token path. Verified live — the `full` profile still gets a silent token in **16ms**. Test and comment corrected.

## 2. Reverted `observe` to a strict subset of `full`'s scopes

Review flagged that `list_inbox_rules` (read-only) would 403 under observe, since Graph gates `/mailFolders/inbox/messageRules` behind `MailboxSettings`. My first fix added `MailboxSettings.Read` — **that was wrong**, and the live test proved it: Entra treats it as a scope distinct from `full`'s `MailboxSettings.ReadWrite`, not implied by it, so the consent screen demanded **admin approval**.

Reverted. Observe now requests `Mail.Read`, `User.Read`, `offline_access` — a strict subset of `full`. That subset property is what makes the profile adoptable: a mailbox already consented to `full` switches to observe with **no new consent** (verified: silent token in 11ms). `list_inbox_rules` is excluded from the observe tool surface via `OBSERVE_EXCLUDED_ACTIONS` instead of advertising a tool that always 403s. A new test locks the subset invariant so it can't regress.

## 3. Blocked-tool errors named the wrong reason

`list_inbox_rules` under observe reported "because it can modify mailbox data … enable write tools" — it's read-only, and withheld for scope reasons. That sends an agent down the wrong recovery path. `profileBlockedActionError` now branches on why the tool is hidden.

## 4. README: observe is not an OAuth boundary

Both profiles' tokens come back carrying the **same** `scp` claim:

```
Calendars.Read Files.Read.All Mail.Read Mail.ReadWrite Mail.Send
MailboxSettings.ReadWrite openid profile Sites.Read.All User.Read email
```

Entra issues a token with every scope consented for the resource, not the subset requested. So on a mailbox that has already consented to write scopes, observe trims the **MCP tool surface** but does **not** narrow the token. Documented under "What `observe` does and does not guarantee" — treat it as defense in depth, not an OAuth boundary. On a fresh mailbox that only ever consents to observe, the token genuinely is read-only.

## Verification

- Build, lint clean. **1047 tests pass** (470 + 226 + 108 + 212 + 31).
- Live `observe` against the real mailbox: 10 tools; real `list_emails` / `read_email` / `list_folders` / `search_emails` returning actual messages; `send_email` and `list_inbox_rules` both correctly refused with distinct, correct reasons.
- Live `full` re-verified after: 26 tools, 15/15 write tools, banner reads `26 tools, full scope profile`.
- No email was ever sent — write verification was tool-surface only.

## Known follow-up (not in this PR)

`OBSERVE_CONFIGURATION_ACTIONS` lists `configure_mailbox` and `remove_mailbox`, but those are CLI-only and never registered as MCP tools, so both entries are inert at the MCP layer. Harmless, worth a cleanup.