### PR TITLE
fix(email-core): populate EMAIL_ACTIONS as an explicit canonical action registry

### DIFF
--- a/packages/email-core/src/actions/registry.test.ts
+++ b/packages/email-core/src/actions/registry.test.ts
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 // Spec: openspec/specs/mcp-transport/spec.md — "Action to Tool Mapping"
 // EMAIL_ACTIONS is the canonical registry consumed by adapters; it must be
 // non-empty, duplicate-free, and complete (issue #174: a previous mutable
@@ -61,6 +62,44 @@ describe('EMAIL_ACTIONS registry', () => {
     }
   });
 
+  it('matches an independent discovery of every action module export (no lockstep drift)', () => {
+    // EXPECTED_ACTION_NAMES above documents the published API, but it is
+    // manually maintained alongside the registry list — both could drift
+    // together. This test discovers action exports straight from the module
+    // files, so a new `*Action` export that is missing from EMAIL_ACTIONS
+    // fails here even if both manual lists were forgotten.
+    const modules = import.meta.glob(['./*.ts', '!./*.test.ts', '!./registry.ts'], {
+      eager: true,
+    }) as Record<string, Record<string, unknown>>;
+    const discovered: { source: string; action: { name: string } }[] = [];
+    for (const [file, mod] of Object.entries(modules)) {
+      for (const [exportName, value] of Object.entries(mod)) {
+        if (!exportName.endsWith('Action')) continue;
+        if (
+          typeof value !== 'object' ||
+          value === null ||
+          typeof (value as { name?: unknown }).name !== 'string' ||
+          typeof (value as { run?: unknown }).run !== 'function'
+        ) {
+          continue;
+        }
+        discovered.push({ source: `${file}#${exportName}`, action: value as { name: string } });
+      }
+    }
+    expect(discovered.length).toBeGreaterThan(0);
+    // Every discovered action object appears in EMAIL_ACTIONS exactly once (by identity).
+    for (const { source, action } of discovered) {
+      const occurrences = EMAIL_ACTIONS.filter((a) => a === action).length;
+      expect(occurrences, `${source} (${action.name}) must be registered exactly once`).toBe(1);
+    }
+    // Every registry entry corresponds to a discovered action export.
+    for (const entry of EMAIL_ACTIONS) {
+      const known = discovered.some(({ action }) => action === entry);
+      expect(known, `registry entry ${entry.name} must come from an action module`).toBe(true);
+    }
+    expect(EMAIL_ACTIONS.length).toBe(discovered.length);
+  });
+
   it('is exported (populated) from the package entry point', () => {
     expect(PUBLIC_EMAIL_ACTIONS).toBe(EMAIL_ACTIONS);
     expect(PUBLIC_EMAIL_ACTIONS.length).toBe(EXPECTED_ACTION_NAMES.length);
@@ -74,9 +113,10 @@ describe('EMAIL_ACTIONS registry', () => {
     let built: { EMAIL_ACTIONS: readonly { name: string }[] };
     try {
       built = await import('../../dist/index.js');
-    } catch {
+    } catch (err) {
       throw new Error(
         'dist/index.js not importable — run `npm run build -w @usejunior/email-core` before tests',
+        { cause: err },
       );
     }
     const names = built.EMAIL_ACTIONS.map((a) => a.name);

--- a/packages/email-core/src/actions/registry.test.ts
+++ b/packages/email-core/src/actions/registry.test.ts
@@ -1,0 +1,86 @@
+// Spec: openspec/specs/mcp-transport/spec.md — "Action to Tool Mapping"
+// EMAIL_ACTIONS is the canonical registry consumed by adapters; it must be
+// non-empty, duplicate-free, and complete (issue #174: a previous mutable
+// registration mechanism was never called, shipping a permanently empty
+// array as public API).
+import { describe, expect, it } from 'vitest';
+import { EMAIL_ACTIONS } from './registry.js';
+import { EMAIL_ACTIONS as PUBLIC_EMAIL_ACTIONS } from '../index.js';
+
+const EXPECTED_ACTION_NAMES = [
+  'list_emails',
+  'read_email',
+  'search_emails',
+  'get_thread',
+  'send_email',
+  'reply_to_email',
+  'create_draft',
+  'send_draft',
+  'update_draft',
+  'cancel_scheduled_send',
+  'list_scheduled_sends',
+  'list_attachments',
+  'download_attachment',
+  'label_email',
+  'flag_email',
+  'mark_read',
+  'delete_email',
+  'move_to_folder',
+  'list_folders',
+  'create_folder',
+  'delete_folder',
+  'list_inbox_rules',
+  'create_inbox_rule',
+  'delete_inbox_rule',
+  'configure_mailbox',
+  'remove_mailbox',
+  'list_mailboxes',
+  'get_mailbox_status',
+] as const;
+
+describe('EMAIL_ACTIONS registry', () => {
+  it('is non-empty and contains every defined action exactly once', () => {
+    const names = EMAIL_ACTIONS.map((a) => a.name);
+    expect(names.length).toBeGreaterThan(0);
+    expect(new Set(names).size).toBe(names.length);
+    expect([...names].sort()).toEqual([...EXPECTED_ACTION_NAMES].sort());
+  });
+
+  it('every entry is a well-formed EmailAction', () => {
+    for (const action of EMAIL_ACTIONS) {
+      expect(action.name, 'action name').toMatch(/^[a-z][a-z0-9_]*$/);
+      expect(typeof action.description, `${action.name} description`).toBe('string');
+      expect(action.description.length, `${action.name} description`).toBeGreaterThan(0);
+      expect(action.input, `${action.name} input schema`).toBeDefined();
+      expect(action.output, `${action.name} output schema`).toBeDefined();
+      expect(typeof action.annotations?.readOnlyHint, `${action.name} readOnlyHint`).toBe('boolean');
+      expect(typeof action.annotations?.destructiveHint, `${action.name} destructiveHint`).toBe(
+        'boolean',
+      );
+      expect(typeof action.run, `${action.name} run`).toBe('function');
+    }
+  });
+
+  it('is exported (populated) from the package entry point', () => {
+    expect(PUBLIC_EMAIL_ACTIONS).toBe(EMAIL_ACTIONS);
+    expect(PUBLIC_EMAIL_ACTIONS.length).toBe(EXPECTED_ACTION_NAMES.length);
+  });
+
+  it('is populated in the BUILT public entry point (dist/index.js)', async () => {
+    // The defect in issue #174 lived at the published-package surface:
+    // consumers of @usejunior/email-core imported a permanently empty array.
+    // Assert against the compiled entry point, exactly as a consumer would.
+    // CI and the repo workflow always run `npm run build` before tests.
+    let built: { EMAIL_ACTIONS: readonly { name: string }[] };
+    try {
+      built = await import('../../dist/index.js');
+    } catch {
+      throw new Error(
+        'dist/index.js not importable — run `npm run build -w @usejunior/email-core` before tests',
+      );
+    }
+    const names = built.EMAIL_ACTIONS.map((a) => a.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect([...names].sort()).toEqual([...EXPECTED_ACTION_NAMES].sort());
+  });
+});

--- a/packages/email-core/src/actions/registry.ts
+++ b/packages/email-core/src/actions/registry.ts
@@ -1,6 +1,21 @@
 // Action registry — single source of truth for all email actions
 import { z } from 'zod';
 import type { EmailProvider } from '../providers/provider.js';
+import { listAttachmentsAction, downloadAttachmentAction } from './attachments.js';
+import { configureMailboxAction, removeMailboxAction, listMailboxesAction } from './configure.js';
+import { getThreadAction } from './conversation.js';
+import { createDraftAction, sendDraftAction, updateDraftAction } from './draft.js';
+import { listFoldersAction, createFolderAction, deleteFolderAction } from './folders.js';
+import { labelEmailAction, flagEmailAction, markReadAction, deleteEmailAction } from './label.js';
+import { listEmailsAction } from './list.js';
+import { moveToFolderAction } from './move.js';
+import { readEmailAction } from './read.js';
+import { replyToEmailAction } from './reply.js';
+import { listInboxRulesAction, createInboxRuleAction, deleteInboxRuleAction } from './rules.js';
+import { cancelScheduledSendAction, listScheduledSendsAction } from './scheduling.js';
+import { searchEmailsAction } from './search.js';
+import { sendEmailAction } from './send.js';
+import { getMailboxStatusAction } from './status.js';
 
 export interface ActionContext {
   provider: EmailProvider;
@@ -41,16 +56,47 @@ export interface EmailAction<TInput = unknown, TOutput = unknown> {
   run: (ctx: ActionContext, input: TInput) => Promise<TOutput>;
 }
 
-// Mutable action list — actions register themselves on import
-const actions: EmailAction[] = [];
-
-export function registerAction(action: EmailAction): void {
-  actions.push(action);
-}
-
-export function getActions(): EmailAction[] {
-  return [...actions];
-}
-
-// For the main export — populated after all action modules are imported
-export const EMAIL_ACTIONS: EmailAction[] = actions;
+// Canonical, explicit list of every email action defined in this package.
+// Deliberately NOT side-effect registration (a previous mutable
+// `registerAction()` mechanism was never called, leaving this array
+// permanently empty — see issue #174): an explicit list is ordering-safe,
+// tree-shake-safe, and testable. Adding a new action module means adding it
+// here; `registry.test.ts` enforces that the list stays complete and
+// duplicate-free.
+export const EMAIL_ACTIONS: readonly EmailAction<any, any>[] = [
+  // Read / list / search
+  listEmailsAction,
+  readEmailAction,
+  searchEmailsAction,
+  getThreadAction,
+  // Compose / send
+  sendEmailAction,
+  replyToEmailAction,
+  createDraftAction,
+  sendDraftAction,
+  updateDraftAction,
+  cancelScheduledSendAction,
+  listScheduledSendsAction,
+  // Attachments
+  listAttachmentsAction,
+  downloadAttachmentAction,
+  // Triage
+  labelEmailAction,
+  flagEmailAction,
+  markReadAction,
+  deleteEmailAction,
+  moveToFolderAction,
+  // Folders
+  listFoldersAction,
+  createFolderAction,
+  deleteFolderAction,
+  // Inbox rules
+  listInboxRulesAction,
+  createInboxRuleAction,
+  deleteInboxRuleAction,
+  // Mailbox management / status
+  configureMailboxAction,
+  removeMailboxAction,
+  listMailboxesAction,
+  getMailboxStatusAction,
+];


### PR DESCRIPTION
## Summary

Closes #174.

`@usejunior/email-core` publicly exported `EMAIL_ACTIONS` from a mutable self-registration mechanism (`registerAction()`/`getActions()`) that **nothing ever called** — so the array was permanently empty at runtime (verified by importing the built entry point: `{"length":0,"names":[]}`), while the real MCP tool list is hand-maintained in `packages/email-mcp/src/server.ts`. This contradicted both `openspec/specs/mcp-transport/spec.md` ("Action to Tool Mapping" / Auto-registration scenario) and `AGENTS.md` ("actions in email-core are the single source of truth").

## What changed

- **`packages/email-core/src/actions/registry.ts`** — removed the dead `actions` array, `registerAction()`, and `getActions()` (neither was exported from the package index, so this is not a public-API removal). `EMAIL_ACTIONS` is now an explicit, readonly canonical list of all **28** action definitions in `packages/email-core/src/actions/`. Explicit list rather than import-time side-effect registration: ordering-safe, tree-shake-safe, testable. All exported types (`EmailAction`, `AllowlistConfig`, `ActionContext`, `MailboxEntry`, `RateLimiter`) are unchanged.
- **`packages/email-core/src/actions/registry.test.ts`** (new) — asserts the registry is non-empty, duplicate-free, and matches the expected 28 action names; every entry is a well-formed `EmailAction`; and the **built** public entry point (`dist/index.js`) — the surface that was actually broken for consumers — exposes the populated registry. CI builds before tests in all jobs, so the dist assertion is stable.

## Public API note

- `EMAIL_ACTIONS` is **retained and repaired**, not removed. Removal was considered and rejected per Codex peer review: removing a named export is a source- and runtime-breaking change for `^0.1.x` consumers despite the value being useless, and would contradict the OpenSpec requirement. No deprecation needed.
- The declared type tightened from `EmailAction[]` to `readonly EmailAction<any, any>[]`. Compat risk is negligible: the array was always empty before, and mutating it never did anything.

## Deliberately out of scope

- No changes to `packages/email-mcp/src/server.ts` (a concurrent change is rewriting its tool-list/mailbox region). Deriving `tools/list` from `EMAIL_ACTIONS` — with explicit name-based overrides for the server's five lazy/demo-aware tools and a parity test — is follow-up **#178**, to be done after that rewrite merges.

## Validation

- Finding validated pre-fix by an executed Codex peer review (runtime probes against the built package; verdict: real defect; fix by populating, not deleting).
- `npm run build` — clean.
- `npm run test:run` — all workspaces green (email-core 474/474 including 4 new tests; email-mcp 226; providers 108 + 212; apps 31; script tests 27 + 4). Watcher-test flakes seen only under parallel-load (EMFILE) and pass in isolation.
- Codex fix-review verdict will be posted as a PR comment.
