### PR TITLE
refactor(mailbox): make state.mailboxes the single source of truth (closes #176)

### DIFF
--- a/packages/email-core/src/providers/provider.test.ts
+++ b/packages/email-core/src/providers/provider.test.ts
@@ -6,6 +6,7 @@ import {
   withRetry,
   withAutoRefresh,
   discoverProviders,
+  createProvider,
   type AuthManager,
   type EmailProvider,
 } from './provider.js';
@@ -99,6 +100,16 @@ describe('provider-interface/Provider Registration', () => {
     const providers = await discoverProviders();
     expect(Array.isArray(providers)).toBe(true);
     // In test env, provider packages aren't installed as separate deps
+  });
+});
+
+describe('mailbox-config/Provider Discovery', () => {
+  it('Scenario: Provider not installed', async () => {
+    // WHEN a provider is requested that is not registered/installed
+    // THEN the error names the missing package and how to install it
+    await expect(createProvider('gmail')).rejects.toThrow(
+      "Provider 'gmail' not available. Install: npm install @usejunior/provider-gmail",
+    );
   });
 });
 

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -1501,6 +1501,50 @@ describe('cli/Call Subcommand Diagnostic Tools', () => {
       vi.doUnmock('./server.js');
     }
   });
+
+  it('Scenario: call list_mailboxes diagnoses an all-failed setup instead of exiting 3', async () => {
+    // Issue #176: list_mailboxes is a diagnostic like get_mailbox_status — it
+    // reports per-mailbox auth failures as its RESULT. Gating it behind the
+    // eager ensureProvider gate made the one-shot CLI exit 3 in exactly the
+    // broken-setup case the tool exists to explain.
+    const { z } = await import('zod');
+    let ranWithoutInit = false;
+    const listAction = {
+      name: 'list_mailboxes',
+      description: 'diagnostic stub',
+      input: z.object({}),
+      output: z.object({ mailboxes: z.array(z.object({})) }),
+      annotations: {},
+      run: async () => {
+        ranWithoutInit = true;
+        return { mailboxes: [{ name: 'work', emailAddress: null, provider: 'microsoft', isDefault: false, status: 'error', error: 'auth failed' }] };
+      },
+    };
+    const errorState = { status: 'error', error: 'all mailboxes failed', mailboxes: [] };
+
+    vi.doMock('./server.js', async () => {
+      const actual = await vi.importActual<typeof import('./server.js')>('./server.js');
+      return {
+        ...actual,
+        createLazyProviderState: () => errorState,
+        buildLazyActions: async () => [listAction],
+        // ensureProvider would normally throw here — verify we never call it
+        ensureProvider: async () => { throw new Error('should not be called for list_mailboxes'); },
+      };
+    });
+    try {
+      const { runCall } = await import('./cli.js');
+      const exitCode = await runCall({
+        command: 'call',
+        callTool: 'list_mailboxes',
+        callArgs: '{}',
+      });
+      expect(ranWithoutInit).toBe(true);
+      expect(exitCode).toBe(0);
+    } finally {
+      vi.doUnmock('./server.js');
+    }
+  });
 });
 
 describe('cli/Call Subcommand Output Formatting', () => {

--- a/packages/email-mcp/src/cli.ts
+++ b/packages/email-mcp/src/cli.ts
@@ -683,11 +683,14 @@ export async function runCall(opts: CliOptions): Promise<number> {
     args['mailbox'] = opts.mailbox;
   }
 
-  // `get_mailbox_status` is intentionally non-blocking: it inspects state.status
-  // (pending/connecting/not_configured/error) and reports it as the result. Skip
-  // the eager-init gate for this tool so it can serve as a diagnostic even when
-  // the provider isn't ready.
-  if (opts.callTool !== 'get_mailbox_status') {
+  // `get_mailbox_status` and `list_mailboxes` are diagnostics: they report
+  // state (including "nothing connected" / per-mailbox auth failures) as their
+  // RESULT rather than requiring a connected provider. Skip the eager-init gate
+  // for them so a broken setup can still be diagnosed from the one-shot CLI —
+  // gating them behind ensureProvider would make them exit 3 in exactly the
+  // misconfigured case they exist to explain.
+  const DIAGNOSTIC_TOOLS = new Set(['get_mailbox_status', 'list_mailboxes']);
+  if (!DIAGNOSTIC_TOOLS.has(opts.callTool)) {
     // Eagerly initialize the provider — no demo-mode fallback for one-shot CLI.
     // ensureProvider() awaits init internally, so no separate waitForInit() needed.
     try {

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -322,7 +322,7 @@ describe('mcp-transport/Lazy Provider State', () => {
     expect(actions.length).toBe(26);
     expect(state.status).toBe('pending');
     expect(state.initPromise).toBeNull();
-    expect(state.provider).toBeNull();
+    expect(state.mailboxes).toEqual([]);
 
     const tools = actionsToMcpTools(actions);
     expect(tools.map(t => t.name)).toContain('list_emails');
@@ -384,7 +384,18 @@ describe('mcp-transport/Lazy Provider State', () => {
     state.initPromise = new Promise<void>(resolve => {
       resolveInit = () => {
         initRuns++;
-        state.provider = {} as never; // pretend we connected
+        // Pretend we connected — install a complete mailbox entry, the same
+        // shape initProvider produces (mailboxes is the single source of truth).
+        state.mailboxes = [{
+          name: 'work',
+          emailAddress: 'work@example.com',
+          displayName: 'work@example.com',
+          providerType: 'microsoft',
+          provider: {} as never,
+          auth: null,
+          isDefault: true,
+          status: 'connected',
+        }];
         state.status = 'connected';
         resolve();
       };
@@ -560,9 +571,16 @@ describe('mcp-transport/Lazy Provider State', () => {
   it('Scenario: get_mailbox_status reports the connected Gmail provider', async () => {
     const state = createLazyProviderState();
     state.status = 'connected';
-    state.provider = {} as never;
-    state.connectedMailbox = 'steven.obiajulu@gmail.com';
-    state.connectedProvider = 'gmail';
+    state.mailboxes = [{
+      name: 'gmail',
+      emailAddress: 'steven.obiajulu@gmail.com',
+      displayName: 'steven.obiajulu@gmail.com',
+      providerType: 'gmail',
+      provider: {} as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
     state.initPromise = Promise.resolve();
 
     const actions = await buildLazyActions(state, noAllowlist);
@@ -604,9 +622,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = provider;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -675,9 +690,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { searchMessages: workSearch } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -751,9 +763,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { searchMessages: workSearch } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -833,9 +842,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'personal@example.com';
-    state.connectedProvider = 'gmail';
     state.mailboxes = [
       {
         name: 'personal',
@@ -887,8 +893,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [
       {
         name: 'alice',
@@ -930,8 +934,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [
       {
         name: 'alice',
@@ -957,8 +959,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage: vi.fn() } as never;
-    state.connectedMailbox = 'work@example.com';
     state.mailboxes = [];
 
     const actions = await buildLazyActions(state, noAllowlist);
@@ -976,8 +976,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage: vi.fn() } as never;
-    state.connectedMailbox = 'work@example.com';
     state.mailboxes = [];
 
     const actions = await buildLazyActions(state, noAllowlist);
@@ -1016,8 +1014,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [
       {
         name: 'alice',
@@ -1077,8 +1073,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [
       {
         name: 'alice',
@@ -1121,8 +1115,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [
       {
         name: 'alice',
@@ -1168,8 +1160,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [{
       name: 'alice',
       emailAddress: 'alice@corp.com',
@@ -1218,8 +1208,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage } as never;
-    state.connectedMailbox = 'alice@corp.com';
     state.mailboxes = [{
       name: 'alice',
       emailAddress: 'alice@corp.com',
@@ -1262,9 +1250,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = {} as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1307,9 +1292,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = {} as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1363,9 +1345,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { listMessages: workList } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1416,6 +1395,48 @@ describe('mcp-transport/Lazy Provider State', () => {
     ]);
   });
 
+  it('Scenario: canonical email address outranks another mailbox\'s colliding alias', async () => {
+    // mailbox-config/Mailbox Canonical Identity: the email address is the
+    // canonical ID. Here mailbox "b"'s logical alias equals mailbox "a"'s
+    // email address. The selector must resolve to the address's owner —
+    // never silently by array order (issue #176 follow-through).
+    const aliasOwnerList = vi.fn().mockResolvedValue([]);
+    const addressOwnerList = vi.fn().mockResolvedValue([]);
+
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.mailboxes = [
+      {
+        name: 'shared@corp.com', // alias that collides with the OTHER mailbox's address
+        emailAddress: 'personal@example.com',
+        displayName: 'personal@example.com',
+        providerType: 'gmail',
+        provider: { listMessages: aliasOwnerList } as never,
+        auth: null,
+        isDefault: true,
+        status: 'connected',
+      },
+      {
+        name: 'work',
+        emailAddress: 'shared@corp.com',
+        displayName: 'shared@corp.com',
+        providerType: 'microsoft',
+        provider: { listMessages: addressOwnerList } as never,
+        auth: null,
+        isDefault: false,
+        status: 'connected',
+      },
+    ];
+
+    const actions = await buildLazyActions(state, noAllowlist);
+    const listEmails = actions.find(a => a.name === 'list_emails')!;
+    await listEmails.run({}, { mailbox: 'shared@corp.com' });
+
+    expect(addressOwnerList).toHaveBeenCalledTimes(1);
+    expect(aliasOwnerList).not.toHaveBeenCalled();
+  });
+
   it('scheduled-send actions route to the requested mailbox provider', async () => {
     const workListScheduled = vi.fn().mockResolvedValue([]);
     const personalListScheduled = vi.fn().mockResolvedValue([{
@@ -1429,12 +1450,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = {
-      listScheduledSends: workListScheduled,
-      cancelScheduledSend: workCancel,
-    } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1499,9 +1514,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { listMessages: workList } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [{
       name: 'work',
       emailAddress: 'work@example.com',
@@ -1539,9 +1551,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { createReplyDraft } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1606,9 +1615,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { createDraft: workCreateDraft } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1665,9 +1671,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { getMessage: workGetMessage } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1730,9 +1733,6 @@ describe('mcp-transport/Lazy Provider State', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { listAttachments: workListAttachments, downloadAttachment: workDownloadAttachment } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -1805,10 +1805,10 @@ describe('mcp-transport/Lazy Provider State', () => {
   });
 });
 
-// Issue #93: list_mailboxes is a bespoke tool that enumerates state.mailboxes
-// directly. These tests drive the SHIPPED path (buildLazyActions → executeTool),
-// not the core listMailboxesAction, whose in-memory mailboxStore this server
-// never populates.
+// Issue #93: list_mailboxes is a bespoke tool that enumerates state.mailboxes —
+// the single source of truth for which mailboxes exist (#176; the unreachable
+// core listMailboxesAction is tracked separately in #175). These tests drive
+// the SHIPPED path (buildLazyActions → executeTool).
 describe('mcp-transport/List Mailboxes Tool', () => {
   const noAllowlist = () => undefined;
 
@@ -1930,9 +1930,9 @@ describe('mcp-transport/List Mailboxes Tool', () => {
 
 // The SHIPPED list_mailboxes path (buildLazyActions → executeTool) is the
 // canonical implementation of the mailbox-config/List Mailboxes requirement —
-// the core listMailboxesAction reads an in-memory store this server never fills
-// and is dead code (tracked for follow-up removal/reconciliation). This block is
-// the spec-traceable proof that the shipped output matches the canonical shape:
+// the core listMailboxesAction reads an in-memory store this server never
+// populates (removal/reconciliation tracked in #175). This block is the
+// spec-traceable proof that the shipped output matches the canonical shape:
 // distinct `name` + `emailAddress`, provider, isDefault, status.
 describe('mailbox-config/List Mailboxes', () => {
   it('Scenario: List all mailboxes', async () => {
@@ -1959,6 +1959,60 @@ describe('mailbox-config/List Mailboxes', () => {
       isDefault: true,
       status: 'connected',
     }]);
+  });
+});
+
+describe('mailbox-config/Default Mailbox', () => {
+  it('Scenario: Single mailbox auto-default', async () => {
+    // WHEN only one mailbox ("personal") is connected — even if nothing marked
+    // it default — THEN it is automatically the default for all actions
+    // (getDefaultMailbox falls back to the only connected member).
+    const personalList = vi.fn().mockResolvedValue([]);
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.mailboxes = [{
+      name: 'personal',
+      emailAddress: 'personal@example.com',
+      displayName: 'personal@example.com',
+      providerType: 'gmail',
+      provider: { listMessages: personalList } as never,
+      auth: null,
+      isDefault: false,
+      status: 'connected',
+    }];
+
+    const actions = await buildLazyActions(state, () => undefined);
+    const listEmails = actions.find(a => a.name === 'list_emails')!;
+    await listEmails.run({}, {}); // no mailbox arg — must route to "personal"
+    expect(personalList).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('mailbox-config/Mailbox Status', () => {
+  it('Scenario: Status with warning', async () => {
+    // WHEN get_mailbox_status is called and no send allowlist is configured
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.mailboxes = [{
+      name: 'work',
+      emailAddress: 'test-user@example.com',
+      displayName: 'test-user@example.com',
+      providerType: 'microsoft',
+      provider: {} as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+
+    const actions = await buildLazyActions(state, () => undefined);
+    const status = actions.find(a => a.name === 'get_mailbox_status')!;
+    const result = await status.run({}, {}) as { status: string; warnings: string[] };
+
+    // THEN the result reports the connected mailbox with an outbound-disabled warning
+    expect(result.status).toBe('connected');
+    expect(result.warnings.some(w => /send allowlist/i.test(w))).toBe(true);
   });
 });
 
@@ -2181,9 +2235,6 @@ describe('mcp-transport/Delete policy wiring', () => {
     state.status = 'connected';
     state.initPromise = Promise.resolve();
     const provider = { deleteMessage } as never;
-    state.provider = provider;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -2281,9 +2332,6 @@ describe('mcp-transport/Recoverable Mailbox-Required Error End-to-End', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = {} as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'work',
@@ -2345,9 +2393,6 @@ describe('mailbox-config/Mailbox Names Are Round-Trippable Selectors', () => {
     const state = createLazyProviderState();
     state.status = 'connected';
     state.initPromise = Promise.resolve();
-    state.provider = { createDraft: workCreate } as never;
-    state.connectedMailbox = 'work@example.com';
-    state.connectedProvider = 'microsoft';
     state.mailboxes = [
       {
         name: 'personal',

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -38,31 +38,29 @@ interface ConnectedLazyMailboxState extends LazyMailboxState {
   status: 'connected';
 }
 
+/**
+ * Lazy provider state. `mailboxes` is the SINGLE source of truth for which
+ * mailboxes exist: every configured mailbox is a member carrying its own
+ * `status` ('connected' | 'error'), and a failed mailbox is a member with an
+ * error — never an absence patched elsewhere. Init lifecycle is tracked
+ * separately via `status` / `initPromise` / `error` / `isDemo`.
+ */
 export interface LazyProviderState {
-  provider: EmailProvider | null;
-  auth: LazyProviderAuth | null;
   initPromise: Promise<void> | null;
   error: string | null;
   /** True when no mailboxes are configured OR all auth attempts failed. */
   isDemo: boolean;
   status: 'pending' | 'connecting' | 'connected' | 'not_configured' | 'error';
-  /** Human-readable display name of the connected mailbox, if any. */
-  connectedMailbox: string | null;
-  connectedProvider: 'microsoft' | 'gmail' | null;
   mailboxes: LazyMailboxState[];
 }
 
 /** Create a fresh lazy state. */
 export function createLazyProviderState(): LazyProviderState {
   return {
-    provider: null,
-    auth: null,
     initPromise: null,
     error: null,
     isDemo: false,
     status: 'pending',
-    connectedMailbox: null,
-    connectedProvider: null,
     mailboxes: [],
   };
 }
@@ -403,32 +401,12 @@ function normalizeMailboxKey(value: string): string {
   return value.trim().toLowerCase();
 }
 
-function fallbackConnectedMailbox(state: LazyProviderState): LazyMailboxState[] {
-  if (!state.provider) return [];
-  return [
-    {
-      name: state.connectedMailbox ?? 'default',
-      emailAddress: state.connectedMailbox ?? undefined,
-      displayName: state.connectedMailbox ?? 'default',
-      providerType: state.connectedProvider ?? 'microsoft',
-      provider: state.provider,
-      auth: state.auth,
-      isDefault: true,
-      status: 'connected',
-    },
-  ];
-}
-
-function getKnownMailboxes(state: LazyProviderState): LazyMailboxState[] {
-  return state.mailboxes.length > 0 ? state.mailboxes : fallbackConnectedMailbox(state);
-}
-
 function isConnectedMailbox(mailbox: LazyMailboxState): mailbox is ConnectedLazyMailboxState {
   return mailbox.status === 'connected' && mailbox.provider !== null;
 }
 
 function getConnectedMailboxes(state: LazyProviderState): ConnectedLazyMailboxState[] {
-  return getKnownMailboxes(state).filter(isConnectedMailbox);
+  return state.mailboxes.filter(isConnectedMailbox);
 }
 
 function getDefaultMailbox(state: LazyProviderState): ConnectedLazyMailboxState | null {
@@ -436,19 +414,31 @@ function getDefaultMailbox(state: LazyProviderState): ConnectedLazyMailboxState 
   return connected.find(mailbox => mailbox.isDefault) ?? connected[0] ?? null;
 }
 
+/**
+ * Resolve a caller-supplied mailbox selector against `state.mailboxes`.
+ *
+ * Canonical email address takes precedence over the logical config name
+ * (per the mailbox-config Mailbox Canonical Identity requirement), so one
+ * mailbox's alias colliding with another mailbox's email address resolves to
+ * the address's owner — never silently by array order. Multiple matches
+ * within the same tier (a misconfiguration) resolve to nothing rather than
+ * to an arbitrary winner; the caller then reports the available mailboxes.
+ * `displayName` is not matched: it is derived as `emailAddress ?? name`, so
+ * both tiers already cover it.
+ */
 function findKnownMailbox(state: LazyProviderState, mailboxName: string): LazyMailboxState | null {
   const target = normalizeMailboxKey(mailboxName);
-  return (
-    getKnownMailboxes(state).find(mailbox =>
-      normalizeMailboxKey(mailbox.name) === target ||
-      normalizeMailboxKey(mailbox.displayName) === target ||
-      (mailbox.emailAddress ? normalizeMailboxKey(mailbox.emailAddress) === target : false),
-    ) ?? null
+  const byEmail = state.mailboxes.filter(
+    mailbox => mailbox.emailAddress !== undefined && normalizeMailboxKey(mailbox.emailAddress) === target,
   );
+  if (byEmail.length === 1) return byEmail[0]!;
+  if (byEmail.length > 1) return null;
+  const byName = state.mailboxes.filter(mailbox => normalizeMailboxKey(mailbox.name) === target);
+  return byName.length === 1 ? byName[0]! : null;
 }
 
 function describeConfiguredMailboxes(state: LazyProviderState): string {
-  const names = getKnownMailboxes(state).map(mailbox => mailbox.emailAddress ?? mailbox.name);
+  const names = state.mailboxes.map(mailbox => mailbox.emailAddress ?? mailbox.name);
   return names.length > 0 ? names.join(', ') : 'none';
 }
 
@@ -633,10 +623,6 @@ export async function initProvider(state: LazyProviderState): Promise<void> {
     if (connectedMailboxes.length > 0) {
       connectedMailboxes[0]!.isDefault = true;
       state.mailboxes = [...connectedMailboxes, ...failedMailboxes];
-      state.provider = connectedMailboxes[0]!.provider;
-      state.auth = connectedMailboxes[0]!.auth;
-      state.connectedMailbox = connectedMailboxes[0]!.displayName;
-      state.connectedProvider = connectedMailboxes[0]!.providerType;
       state.isDemo = false;
       state.status = 'connected';
       return;
@@ -1031,20 +1017,21 @@ export async function buildLazyActions(
         ),
       }),
       annotations: { readOnlyHint: true, destructiveHint: false },
-      // Enumerates state.mailboxes directly — NOT via the generic action wrapper
-      // and NOT via the core listMailboxesAction, whose in-memory mailboxStore is
-      // never populated by this server (it loads mailboxes from disk metadata into
-      // state.mailboxes). Uses waitForInit rather than ensureProvider: ensureProvider
-      // throws when zero mailboxes are connected, which is exactly the misconfigured
-      // case an agent would call this tool to diagnose. waitForInit resolves once
-      // init settles (populating both connected and error mailboxes) without
-      // throwing on an all-failed state — it is provider-optional, not a latency
-      // guarantee (a never-settling auth promise would still block, as it does for
-      // every other tool that awaits init).
+      // Enumerates state.mailboxes — the single source of truth for which
+      // mailboxes exist — rather than going through the generic action wrapper
+      // or the core listMailboxesAction, whose in-memory mailboxStore this
+      // server never populates (reconciliation tracked in #175).
+      // Uses waitForInit rather than ensureProvider: ensureProvider throws when
+      // zero mailboxes are connected, which is exactly the misconfigured case an
+      // agent would call this tool to diagnose. waitForInit resolves once init
+      // settles (populating both connected and error mailboxes) without throwing
+      // on an all-failed state — it is provider-optional, not a latency guarantee
+      // (a never-settling auth promise would still block, as it does for every
+      // other tool that awaits init).
       run: async () => {
         await waitForInit(state);
         return {
-          mailboxes: getKnownMailboxes(state).map(mailbox => ({
+          mailboxes: state.mailboxes.map(mailbox => ({
             name: mailbox.name,
             emailAddress: mailbox.emailAddress ?? null,
             provider: mailbox.providerType,

--- a/packages/provider-microsoft/src/auth.test.ts
+++ b/packages/provider-microsoft/src/auth.test.ts
@@ -332,6 +332,58 @@ describe('mailbox-config/Mailbox Canonical Identity', () => {
   });
 });
 
+describe('provider-microsoft/Mailbox Metadata Discovery', () => {
+  let savedAgentEmailHome: string | undefined;
+  let configDir: string;
+
+  beforeEach(async () => {
+    savedAgentEmailHome = process.env['EMAIL_AGENT_MCP_HOME'];
+    const tempDir = join(tmpdir(), `email-agent-mcp-configure-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    process.env['EMAIL_AGENT_MCP_HOME'] = tempDir;
+    configDir = join(tempDir, 'tokens');
+    await mkdir(configDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    const tempDir = process.env['EMAIL_AGENT_MCP_HOME']!;
+    if (savedAgentEmailHome === undefined) {
+      delete process.env['EMAIL_AGENT_MCP_HOME'];
+    } else {
+      process.env['EMAIL_AGENT_MCP_HOME'] = savedAgentEmailHome;
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // NOT the mailbox-config "Add work mailbox" scenario — that canonical
+  // configure-flow scenario is covered by email-core's configure.test.ts.
+  // This test covers the discovery half the MCP server's initProvider relies
+  // on: metadata persisted in the shape the configure wizard writes must
+  // round-trip through listConfiguredMailboxesWithMetadata with its
+  // emailAddress intact (groundwork for #175, where the dead configure
+  // action's disposition is decided).
+  it('round-trips persisted mailbox metadata with emailAddress through startup discovery', async () => {
+    // GIVEN metadata on disk in the shape the configure workflow persists
+    // (fetched emailAddress included)
+    const metadata = {
+      authenticationRecord: { authority: 'test', homeAccountId: 'test', clientId: 'test', tenantId: 'test' },
+      lastInteractiveAuthAt: new Date().toISOString(),
+      clientId: 'test-client-id',
+      mailboxName: 'work',
+      emailAddress: 'test-user@example.com',
+    };
+    const safeKey = toFilesystemSafeKey('test-user@example.com');
+    await writeFile(join(configDir, `${safeKey}.json`), JSON.stringify(metadata), 'utf-8');
+
+    // THEN the stored metadata round-trips with `emailAddress`, and the
+    // discovery path the server's initProvider uses surfaces the mailbox
+    const { listConfiguredMailboxesWithMetadata } = await import('./auth.js');
+    const mailboxes = await listConfiguredMailboxesWithMetadata();
+    expect(mailboxes).toHaveLength(1);
+    expect(mailboxes[0]!.mailboxName).toBe('work');
+    expect(mailboxes[0]!.emailAddress).toBe('test-user@example.com');
+  });
+});
+
 describe('mailbox-config/Filesystem-Safe Storage Key', () => {
   it('Scenario: Derived filename from email', () => {
     // WHEN a mailbox is configured for test-user@example.com


### PR DESCRIPTION
Closes #176

`LazyProviderState.mailboxes` becomes the **single source of truth** for which mailboxes exist. Validated by an executed Codex peer review before implementation (verdict on #176: REAL — the fallback demonstrably fabricated `emailAddress` from a display name; probe output `{"name":"Friendly Work Name","emailAddress":"Friendly Work Name",...}`), and Codex-reviewed again after implementation (verdict: APPROVE, all four ship blockers confirmed with executed evidence — see review comment below).

## What changed

- **Deleted the second representation.** `LazyProviderState` loses the singular `provider` / `auth` / `connectedMailbox` / `connectedProvider` mirror fields; `fallbackConnectedMailbox()` and `getKnownMailboxes()` are gone. The fallback was unreachable through `initProvider` (no terminal path sets a provider while leaving `mailboxes` empty) and existed only to prop up hand-built test states — while being capable of fabricating an `emailAddress` from a display name, which the `list_mailboxes` wire contract forbids. A failed mailbox is now always an array member with `status: 'error'`, never an absence patched by a fallback.
- **Canonical-email selector precedence.** `findKnownMailbox` resolves the canonical email address before the logical alias and never silently resolves a collision by array order (mailbox-config "Mailbox Canonical Identity"). New regression test: one mailbox's alias colliding with another's email resolves to the address's owner.
- **CLI diagnostic gate.** One-shot `email-agent-mcp call list_mailboxes` is now exempt from the eager `ensureProvider` gate, like `get_mailbox_status`, so an all-failed setup exits 0 with the diagnosis instead of exiting 3 (new test).
- **Fixtures now test reality.** ~66 dead singular-field assignments removed from `server.test.ts`; the two fixtures that relied on the fallback install complete `LazyMailboxState` entries — the shape `initProvider` actually builds. Added shipped-path spec-scenario tests (Default Mailbox auto-default, Mailbox Status warning, Configure Mailbox metadata discovery, Provider Discovery).

## Preserved invariants (ship blockers — all confirmed by executed Codex review)

- MCP handshake never waits on OAuth (`void waitForInit(state)` fire-and-forget unchanged).
- Demo mode with nothing configured unchanged.
- `waitForInit` vs `ensureProvider` distinction unchanged — `list_mailboxes` / `get_mailbox_status` stay usable with zero connected mailboxes.
- `list_mailboxes` wire shape unchanged: logical `name`, SEPARATE nullable `emailAddress` (never fabricated), `provider`, `isDefault`, `status`, optional `error`.

## What deliberately did NOT change (scope note)

An earlier revision of this PR also deleted the unreachable in-memory `mailboxStore` actions in email-core (#175). That deletion was **pulled out**: #180 made `configure_mailbox` / `remove_mailbox` / `list_mailboxes` / `get_mailbox_status` members of the canonical `EMAIL_ACTIONS` registry, so their disposition is now a coordinated decision (registry + spec + this server) that needs ratification — the written OpenSpec proposal has been moved to #175. This PR closes **#176 only** and is rebased on post-#179/#180 `main`.

## Validation

- `npm run build`, `npm run check:spec-coverage`, and full `npm run test:run` green on the rebased branch (170 email-mcp tests, +4 new scenario tests elsewhere).
- Post-merge live-mailbox smoke to follow as a PR comment.
