### PR TITLE
fix(draft): derive reply subjects from parent messages

### DIFF
--- a/openspec/changes/fix-reply-draft-subject/proposal.md
+++ b/openspec/changes/fix-reply-draft-subject/proposal.md
@@ -1,0 +1,16 @@
+# Fix Reply Draft Subject Validation
+
+## Why
+
+`create_draft` requires `subject` when `reply_to` is supplied but never passes it to the provider. Callers must invent a subject even though providers correctly derive it from the parent message, risking broken threading.
+
+## What Changes
+
+- Require `subject` only for new drafts.
+- Preserve provider-derived subjects for reply drafts, including when callers supply an unused subject.
+- Keep the existing reply-draft recipient requirement unchanged.
+
+## Impact
+
+- Affected specs: `email-write`
+- Affected code: `email-core` draft validation and tests

--- a/openspec/changes/fix-reply-draft-subject/specs/email-write/spec.md
+++ b/openspec/changes/fix-reply-draft-subject/specs/email-write/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Reply-All Controls
+
+Every reply-producing surface SHALL let the caller choose between a reply-all and a sender-only reply through the same `reply_all` boolean parameter, defaulting to `true`.
+
+This applies to `reply_to_email` (both its send and `draft: true` paths) and to `create_draft` when `reply_to` is set. When `reply_all` is `false`, the system SHALL NOT populate recipients automatically derived from the original thread's To/Cc participants; the reply SHALL address the caller-supplied To (see Reply Recipient Override) plus any Cc recipients the caller supplied explicitly, falling back to the original sender when no To was supplied. Recipients supplied via `cc` SHALL still be honored — `reply_all: false` narrows the *derived* audience, not the caller's stated one.
+
+On `create_draft`, `reply_all` is meaningful only alongside `reply_to`; for a non-reply draft it SHALL have no effect on the composed recipients. New drafts SHALL require both `to` and `subject`. Reply drafts SHALL require `to` but SHALL NOT require or use a caller-supplied `subject`; the provider SHALL derive the subject from the parent message.
+
+#### Scenario: Draft reply narrowed to the original sender
+- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", body: "…", reply_all: false}` for a thread containing additional To/Cc participants
+- **THEN** the provider's reply-draft call receives `replyAll: false`
+
+#### Scenario: Draft reply defaults to reply-all
+- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", body: "…"}` and no `reply_all`
+- **THEN** the provider's reply-draft call receives `replyAll: true`, preserving existing behavior
+
+#### Scenario: Explicit cc survives a narrowed draft reply
+- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", body: "…", reply_all: false, cc: ["alice@example.com"]}`
+- **THEN** the provider's reply-draft call receives `replyAll: false` and still carries `alice@example.com` on Cc
+
+#### Scenario: Reply draft derives its subject
+- **WHEN** `create_draft` is called with `reply_to`, `to`, and a body but no `subject`
+- **THEN** the reply draft is created with the provider-derived parent-thread subject
+
+#### Scenario: Send-path reply honors the same toggle
+- **WHEN** `reply_to_email` is called with `{message_id: "msg123", body: "…", reply_all: false}`
+- **THEN** the reply is addressed only to the original sender, with the thread's other participants omitted

--- a/openspec/changes/fix-reply-draft-subject/tasks.md
+++ b/openspec/changes/fix-reply-draft-subject/tasks.md
@@ -1,0 +1,10 @@
+# Tasks
+
+## 1. Reply draft validation
+- [x] 1.1 Do not require a subject when `create_draft` uses `reply_to`.
+- [x] 1.2 Preserve the required subject validation for new drafts.
+- [x] 1.3 Add regression coverage for provider-derived reply subjects.
+
+## 2. Specification and verification
+- [x] 2.1 Update the reply-draft requirement and scenario.
+- [ ] 2.2 Run tests, lint, build, strict OpenSpec validation, and spec coverage.

--- a/openspec/specs/email-write/spec.md
+++ b/openspec/specs/email-write/spec.md
@@ -194,20 +194,24 @@ Every reply-producing surface SHALL let the caller choose between a reply-all an
 
 This applies to `reply_to_email` (both its send and `draft: true` paths) and to `create_draft` when `reply_to` is set. When `reply_all` is `false`, the system SHALL NOT populate recipients automatically derived from the original thread's To/Cc participants; the reply SHALL address the caller-supplied To (see Reply Recipient Override) plus any Cc recipients the caller supplied explicitly, falling back to the original sender when no To was supplied. Recipients supplied via `cc` SHALL still be honored — `reply_all: false` narrows the *derived* audience, not the caller's stated one.
 
-On `create_draft`, `reply_all` is meaningful only alongside `reply_to`; for a non-reply draft it SHALL have no effect on the composed recipients. This requirement does not alter `create_draft`'s existing required-field validation: `to` and `subject` remain required on every path, including reply drafts.
+On `create_draft`, `reply_all` is meaningful only alongside `reply_to`; for a non-reply draft it SHALL have no effect on the composed recipients. New drafts SHALL require both `to` and `subject`. Reply drafts SHALL require `to` but SHALL NOT require or use a caller-supplied `subject`; the provider SHALL derive the subject from the parent message.
 
 #### Scenario: Draft reply narrowed to the original sender
-- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", subject: "Re: Topic", body: "…", reply_all: false}` for a thread containing additional To/Cc participants
+- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", body: "…", reply_all: false}` for a thread containing additional To/Cc participants
 - **THEN** the provider's reply-draft call receives `replyAll: false`
 - **AND** the created draft addresses the original sender plus any caller-supplied Cc recipients, but omits automatically derived thread participants
 
 #### Scenario: Draft reply defaults to reply-all
-- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", subject: "Re: Topic", body: "…"}` and no `reply_all`
+- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", body: "…"}` and no `reply_all`
 - **THEN** the provider's reply-draft call receives `replyAll: true`, preserving existing behavior
 
 #### Scenario: Explicit cc survives a narrowed draft reply
-- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", subject: "Re: Topic", body: "…", reply_all: false, cc: ["alice@example.com"]}`
+- **WHEN** `create_draft` is called with `{reply_to: "msg123", to: "sender@example.com", body: "…", reply_all: false, cc: ["alice@example.com"]}`
 - **THEN** the provider's reply-draft call receives `replyAll: false` and still carries `alice@example.com` on Cc
+
+#### Scenario: Reply draft derives its subject
+- **WHEN** `create_draft` is called with `reply_to`, `to`, and a body but no `subject`
+- **THEN** the reply draft is created with the provider-derived parent-thread subject
 
 #### Scenario: Send-path reply honors the same toggle
 - **WHEN** `reply_to_email` is called with `{message_id: "msg123", body: "…", reply_all: false}`
@@ -277,4 +281,3 @@ This requirement governs the preview only. The body stored in the draft and the 
 #### Scenario: Gmail and fresh drafts are unaffected
 - **WHEN** a draft is created on Gmail, or a non-reply draft is created on any provider
 - **THEN** the preview is returned unchanged from current behavior with no extraction attempted and `quotedHistoryOmitted` unset
-

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -94,6 +94,27 @@ Body from file.`);
     expect(result.draftId).toBeDefined();
   });
 
+  it('Scenario: Reply draft derives its subject', async () => {
+    provider.addMessage({
+      id: 'subject-parent',
+      subject: 'Provider Derived Subject',
+      from: { email: 'partner@allowed.com' },
+      to: [{ email: 'me@company.com' }],
+      receivedAt: '2024-01-01T00:00:00Z',
+      isRead: true,
+      hasAttachments: false,
+    });
+
+    const result = await createDraftAction.run(ctx, {
+      to: 'partner@allowed.com',
+      body: 'Reply draft body',
+      reply_to: 'subject-parent',
+    });
+
+    expect(result.success).toBe(true);
+    expect([...provider.getDrafts().values()][0]!.subject).toBe('Re: Provider Derived Subject');
+  });
+
   it('Scenario: Reply draft to a self-sent message honors caller-supplied to (issue #164)', async () => {
     // The reported failure: replying to a message the mailbox owner sent makes
     // the provider derive To from the parent's sender — the owner. With

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -102,7 +102,7 @@ export const createDraftAction: EmailAction<
     const attachments = attResult.files!;
 
     // Validate required fields
-    const requiredError = validateRequiredFields(to, subject);
+    const requiredError = validateRequiredFields(to, replyTo ? 'reply' : subject);
     if (requiredError) {
       return { success: false, error: requiredError };
     }


### PR DESCRIPTION
Closes #172\n\nReply drafts no longer require an unused caller-supplied subject. Providers derive the subject from the parent message, preserving threading. The existing explicit reply-recipient contract is unchanged.