### PR TITLE
fix(oauth-broker): pin valid Vercel runtime version

### DIFF
--- a/apps/oauth-broker/vercel.json
+++ b/apps/oauth-broker/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "functions": {
     "api/**/*.ts": {
-      "runtime": "@vercel/node@5"
+      "runtime": "@vercel/node@5.7.15"
     }
   }
 }


### PR DESCRIPTION
Fixes Vercel deployment configuration: function runtimes require an exact version, so  was rejected before build.