### PR TITLE
fix(mcp): preserve opaque IDs in structured output

### DIFF
--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -38,6 +38,48 @@ const testActions: EmailActionDef[] = [
 ];
 
 describe('mcp-transport/executeTool primitive', () => {
+  it('Scenario: opaque IDs longer than display previews round-trip through structured MCP output', async () => {
+    const opaqueId = `opaque-${'A'.repeat(145)}`;
+    const actions: EmailActionDef[] = [
+      {
+        name: 'search_emails',
+        description: 'Search',
+        input: z.object({ query: z.string() }),
+        output: z.object({ emails: z.array(z.object({ id: z.string(), subject: z.string() })) }),
+        annotations: { readOnlyHint: true, destructiveHint: false },
+        run: async () => ({ emails: [{ id: opaqueId, subject: 'Synthetic result' }] }),
+      },
+      {
+        name: 'create_draft',
+        description: 'Create reply draft',
+        input: z.object({ reply_to: z.string() }),
+        output: z.object({ success: z.boolean(), draftId: z.string() }),
+        annotations: { readOnlyHint: false, destructiveHint: false },
+        run: async (_ctx, input) => ({
+          success: true,
+          draftId: (input as { reply_to: string }).reply_to,
+        }),
+      },
+    ];
+
+    const search = await handleToolCall(actions, {}, 'search_emails', { query: 'synthetic' });
+    const structuredSearch = search.structuredContent as { emails: Array<{ id: string }> };
+    expect(structuredSearch.emails[0]!.id).toBe(opaqueId);
+    expect(structuredSearch.emails[0]!.id).toHaveLength(152);
+    expect(JSON.parse((search.content[0] as { text: string }).text).emails[0].id).toBe(opaqueId);
+
+    const draft = await handleToolCall(actions, {}, 'create_draft', {
+      reply_to: structuredSearch.emails[0]!.id,
+    });
+    expect((draft.structuredContent as { draftId: string }).draftId).toBe(opaqueId);
+
+    const tools = actionsToMcpTools(actions);
+    expect(tools.find(tool => tool.name === 'search_emails')!.outputSchema).toMatchObject({
+      type: 'object',
+      properties: { emails: { type: 'array' } },
+    });
+  });
+
   it('Scenario: executeTool returns raw action result without MCP envelope', async () => {
     // Both `serve` (via handleToolCall) and `call` (via the CLI) dispatch through
     // executeTool. The raw shape MUST be free of MCP transport formatting so the
@@ -105,6 +147,7 @@ describe('mcp-transport/Action to Tool Mapping', () => {
     expect(tools).toHaveLength(2);
     expect(tools.map(t => t.name)).toContain('list_emails');
     expect(tools.map(t => t.name)).toContain('send_email');
+    expect(tools.every(tool => tool.outputSchema.type === 'object')).toBe(true);
   });
 });
 
@@ -164,6 +207,7 @@ describe('mcp-transport/stdio Transport', () => {
     expect(metadata).not.toHaveProperty('base64');
     expect(metadata.filename).toBe('note.pdf');
     expect(metadata.mimeType).toBe('application/pdf');
+    expect(result.structuredContent).toEqual(metadata);
 
     expect(result.content[1]!.type).toBe('resource');
     const resourceContent = result.content[1] as { resource: { uri: string; mimeType?: string; blob?: string } };

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { deleteEmailAction, EMAIL_ACTIONS, sendEmailAction } from '@usejunior/email-core';
 import {
   actionsToMcpTools,
@@ -11,6 +13,7 @@ import {
   waitForInit,
   ensureProvider,
   buildLazyActions,
+  createMcpProtocolServer,
   coerceArgsForZod,
   type EmailActionDef,
   type LazyProviderState,
@@ -38,7 +41,7 @@ const testActions: EmailActionDef[] = [
 ];
 
 describe('mcp-transport/executeTool primitive', () => {
-  it('Scenario: opaque IDs longer than display previews round-trip through structured MCP output', async () => {
+  it('Scenario: opaque IDs round-trip through real MCP JSON-RPC search, reply draft, and update calls', async () => {
     const opaqueId = `opaque-${'A'.repeat(145)}`;
     const actions: EmailActionDef[] = [
       {
@@ -60,24 +63,85 @@ describe('mcp-transport/executeTool primitive', () => {
           draftId: (input as { reply_to: string }).reply_to,
         }),
       },
+      {
+        name: 'update_draft',
+        description: 'Update draft',
+        input: z.object({ draft_id: z.string() }),
+        output: z.object({ success: z.boolean(), draftId: z.string() }),
+        annotations: { readOnlyHint: false, destructiveHint: false },
+        run: async (_ctx, input) => ({
+          success: true,
+          draftId: (input as { draft_id: string }).draft_id,
+        }),
+      },
     ];
+    const server = await createMcpProtocolServer(actions);
+    const client = new Client({ name: 'opaque-id-regression', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
 
-    const search = await handleToolCall(actions, {}, 'search_emails', { query: 'synthetic' });
-    const structuredSearch = search.structuredContent as { emails: Array<{ id: string }> };
-    expect(structuredSearch.emails[0]!.id).toBe(opaqueId);
-    expect(structuredSearch.emails[0]!.id).toHaveLength(152);
-    expect(JSON.parse((search.content[0] as { text: string }).text).emails[0].id).toBe(opaqueId);
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const listed = await client.listTools();
+      expect(listed.tools.find(tool => tool.name === 'search_emails')!.outputSchema).toMatchObject({
+        type: 'object',
+        properties: { emails: { type: 'array' } },
+      });
 
-    const draft = await handleToolCall(actions, {}, 'create_draft', {
-      reply_to: structuredSearch.emails[0]!.id,
-    });
-    expect((draft.structuredContent as { draftId: string }).draftId).toBe(opaqueId);
+      const search = await client.callTool({ name: 'search_emails', arguments: { query: 'synthetic' } });
+      const searchResult = search.structuredContent as { emails: Array<{ id: string }> };
+      expect(searchResult.emails[0]!.id).toBe(opaqueId);
+      expect(searchResult.emails[0]!.id).toHaveLength(152);
 
-    const tools = actionsToMcpTools(actions);
-    expect(tools.find(tool => tool.name === 'search_emails')!.outputSchema).toMatchObject({
-      type: 'object',
-      properties: { emails: { type: 'array' } },
-    });
+      const draft = await client.callTool({
+        name: 'create_draft',
+        arguments: { reply_to: searchResult.emails[0]!.id },
+      });
+      const draftId = (draft.structuredContent as { draftId: string }).draftId;
+      expect(draftId).toBe(opaqueId);
+
+      const update = await client.callTool({
+        name: 'update_draft',
+        arguments: { draft_id: draftId },
+      });
+      expect((update.structuredContent as { draftId: string }).draftId).toBe(opaqueId);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('Scenario: lazy provider failure is a protocol error, not schema-invalid ordinary data', async () => {
+    const state = createLazyProviderState();
+    state.status = 'error';
+    state.isDemo = true;
+    state.error = 'Synthetic mailbox authentication failure';
+    state.initPromise = Promise.resolve();
+    const actions = await buildLazyActions(state, () => undefined);
+    const server = await createMcpProtocolServer(actions);
+    const client = new Client({ name: 'error-regression', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      await client.listTools();
+      // list_attachments advertises `{attachments: [...]}`. Before the fix the
+      // lazy wrapper returned `{success:false,error:...}` as ordinary structured
+      // content and the SDK rejected it against that schema before the caller
+      // could inspect the provider error.
+      const result = await client.callTool({
+        name: 'list_attachments',
+        arguments: { message_id: 'synthetic-message-id' },
+      });
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.content).toEqual([{
+        type: 'text',
+        text: 'Error: PROVIDER_UNAVAILABLE: Synthetic mailbox authentication failure',
+      }]);
+    } finally {
+      await client.close();
+    }
   });
 
   it('Scenario: executeTool returns raw action result without MCP envelope', async () => {
@@ -485,7 +549,7 @@ describe('mcp-transport/Lazy Provider State', () => {
     await expect(ensureProvider(state)).rejects.toThrow(/All configured mailboxes/);
   });
 
-  it('Scenario: email-core wrapped action returns structured error on init failure', async () => {
+  it('Scenario: email-core wrapped action throws a coded provider error on init failure', async () => {
     const state = createLazyProviderState();
     // Simulate: init has run, all mailboxes failed.
     state.status = 'error';
@@ -496,17 +560,11 @@ describe('mcp-transport/Lazy Provider State', () => {
     const actions = await buildLazyActions(state, noAllowlist);
     const sendEmail = actions.find(a => a.name === 'send_email')!;
 
-    // Must NOT throw — must return the structured error shape.
-    const result = await sendEmail.run({}, {
+    await expect(sendEmail.run({}, {
       to: ['x@example.com'],
       subject: 'test',
       body: 'test',
-    }) as { success: boolean; error?: { code: string; message: string; recoverable: boolean } };
-
-    expect(result.success).toBe(false);
-    expect(result.error?.code).toBe('PROVIDER_UNAVAILABLE');
-    expect(result.error?.message).toMatch(/All configured mailboxes/);
-    expect(result.error?.recoverable).toBe(false);
+    })).rejects.toThrow(/PROVIDER_UNAVAILABLE: All configured mailboxes/);
   });
 
   it('Scenario: custom tools fall back to demo responses in demo mode', async () => {
@@ -1826,7 +1884,7 @@ describe('mcp-transport/Lazy Provider State', () => {
     expect(Buffer.from(result.base64!, 'base64').equals(PAYLOAD)).toBe(true);
   });
 
-  it('Scenario: download_attachment returns PROVIDER_UNAVAILABLE when init failed', async () => {
+  it('Scenario: download_attachment throws PROVIDER_UNAVAILABLE when init failed', async () => {
     const state = createLazyProviderState();
     state.status = 'error';
     state.isDemo = true;
@@ -1835,15 +1893,11 @@ describe('mcp-transport/Lazy Provider State', () => {
 
     const actions = await buildLazyActions(state, noAllowlist);
     const downloadAttachment = actions.find(a => a.name === 'download_attachment')!;
-    const result = await downloadAttachment.run({}, {
+    await expect(downloadAttachment.run({}, {
       message_id: 'msg-1',
       attachment_id: 'att-1',
       max_size_mb: 5,
-    }) as { success: boolean; error?: { code: string; message: string; recoverable: boolean } };
-
-    expect(result.success).toBe(false);
-    expect(result.error?.code).toBe('PROVIDER_UNAVAILABLE');
-    expect(result.error?.message).toMatch(/All configured mailboxes/);
+    })).rejects.toThrow(/PROVIDER_UNAVAILABLE: All configured mailboxes/);
   });
 
   it('Scenario: waitForInit returns immediately once a terminal state is reached', async () => {

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -129,6 +129,41 @@ export function actionsToMcpTools(actions: EmailActionDef[]): McpTool[] {
   }));
 }
 
+/**
+ * Build the protocol server shared by stdio production startup and transport
+ * integration tests. MCP SDK/spec error semantics exempt `isError` results
+ * from an advertised output schema, so thrown actions return text-only error
+ * content; successful object results carry schema-validated `structuredContent`.
+ */
+export async function createMcpProtocolServer(
+  actions: EmailActionDef[],
+  ctx: unknown = {},
+): Promise<import('@modelcontextprotocol/sdk/server/index.js').Server> {
+  const { Server } = await import('@modelcontextprotocol/sdk/server/index.js');
+  const { ListToolsRequestSchema, CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
+  const server = new Server(
+    { name: 'email-agent-mcp', version: PACKAGE_VERSION },
+    { capabilities: { tools: {} } },
+  );
+  const tools = actionsToMcpTools(actions);
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server.setRequestHandler(CallToolRequestSchema, (async (request: any) => {
+    const { name, arguments: args } = request.params;
+    try {
+      return await handleToolCall(actions, ctx, name, (args ?? {}) as Record<string, unknown>);
+    } catch (err) {
+      return {
+        content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
+        isError: true,
+      };
+    }
+  }) as never);
+
+  return server;
+}
+
 // Strict decimal/float regex for coercing numeric strings. Rejects hex
 // (`0x10`), scientific notation (`1e3`), `Infinity`, whitespace, and other
 // shapes that `Number()` silently accepts but which are unlikely to be
@@ -679,16 +714,6 @@ export async function buildLazyActions(
   // implicit process.cwd() fallback inside the file loaders.
   const safeDir = process.env.EMAIL_MCP_SAFE_DIR || process.cwd();
 
-  // Structured "provider unavailable" error — matches the shape of email-core errors.
-  const providerUnavailableError = (err: unknown) => ({
-    success: false,
-    error: {
-      code: 'PROVIDER_UNAVAILABLE',
-      message: err instanceof Error ? err.message : String(err),
-      recoverable: false,
-    },
-  });
-
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const wrapAction = (action: EmailAction<any, any>): EmailActionDef => ({
     name: action.name,
@@ -717,7 +742,15 @@ export async function buildLazyActions(
         };
         return action.run(actionCtx as never, input as never);
       } catch (err) {
-        return providerUnavailableError(err);
+        // Do not return a generic `{success,error}` object here: many wrapped
+        // actions advertise narrower output schemas (for example,
+        // list_attachments requires `{attachments}`), so treating an exception
+        // as ordinary success data makes MCP clients reject the response during
+        // structured-output validation. Throw into createMcpProtocolServer's
+        // protocol-level `isError` path instead; the code remains visible in the
+        // text error for both MCP and direct CLI callers.
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new Error(`PROVIDER_UNAVAILABLE: ${detail}`, { cause: err });
       }
     },
   });
@@ -1055,9 +1088,7 @@ export async function buildLazyActions(
  * off provider init in the background so the MCP handshake never waits on OAuth.
  */
 export async function runServer(): Promise<void> {
-  const { Server } = await import('@modelcontextprotocol/sdk/server/index.js');
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
-  const { ListToolsRequestSchema, CallToolRequestSchema } = await import('@modelcontextprotocol/sdk/types.js');
 
   // Load send allowlist with hot-reload (convention: ~/.email-agent-mcp/send-allowlist.json)
   const { loadSendAllowlist, getSendAllowlistPath, WatchedAllowlist, getDeletePolicyFromEnv } = await import('@usejunior/email-core');
@@ -1086,26 +1117,8 @@ export async function runServer(): Promise<void> {
   const actions = await buildLazyActions(state, getSendAllowlist, getDeletePolicy);
   const scopeProfile = getEmailScopeProfile();
 
-  const server = new Server(
-    { name: 'email-agent-mcp', version: PACKAGE_VERSION },
-    { capabilities: { tools: {} } },
-  );
-
+  const server = await createMcpProtocolServer(actions);
   const tools = actionsToMcpTools(actions);
-
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  server.setRequestHandler(CallToolRequestSchema, (async (request: any) => {
-    const { name, arguments: args } = request.params;
-    try {
-      return await handleToolCall(actions, {}, name, (args ?? {}) as Record<string, unknown>);
-    } catch (err) {
-      return {
-        content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }],
-        isError: true,
-      };
-    }
-  }) as never);
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -79,6 +79,7 @@ export interface McpTool {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
   annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean };
 }
 
@@ -91,6 +92,8 @@ export type McpContent =
 
 export interface McpToolCallResult {
   content: McpContent[];
+  /** Machine-readable action output; opaque provider IDs remain exact here. */
+  structuredContent?: Record<string, unknown>;
 }
 
 export interface EmailActionDef {
@@ -118,6 +121,7 @@ export function actionsToMcpTools(actions: EmailActionDef[]): McpTool[] {
     name: action.name,
     description: action.description,
     inputSchema: zodToJsonSchema(action.input),
+    outputSchema: zodToJsonSchema(action.output, 'output'),
     annotations: {
       readOnlyHint: action.annotations.readOnlyHint,
       destructiveHint: action.annotations.destructiveHint,
@@ -307,13 +311,19 @@ export async function handleToolCall(
             },
           },
         ],
+        structuredContent: metadata,
       };
     }
   }
 
   return {
     content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    ...(isStructuredResult(result) ? { structuredContent: result } : {}),
   };
+}
+
+function isStructuredResult(result: unknown): result is Record<string, unknown> {
+  return result !== null && typeof result === 'object' && !Array.isArray(result);
 }
 
 /**
@@ -327,11 +337,11 @@ export function getActionInputJsonSchema(action: EmailActionDef): Record<string,
 /**
  * Convert a Zod schema to JSON Schema for MCP `tools/list`.
  *
- * Uses Zod v4's first-party `z.toJSONSchema` with `io: 'input'`. Input mode
- * is the semantically correct one for tool input schemas: fields with
- * defaults are not marked required (because the client may omit them), and
- * the emitted shape describes what the client sends, not what the parser
- * produces.
+ * Uses Zod v4's first-party `z.toJSONSchema`. Input mode is the semantically
+ * correct default for tool arguments: fields with defaults are not marked
+ * required (because the client may omit them), and the emitted shape describes
+ * what the client sends, not what the parser produces. Tool result schemas use
+ * output mode so fields populated by defaults are described as present.
  *
  * Historical note: this used to feature-detect a misspelled `toJsonSchema`
  * (lowercase `s`), which never existed in Zod v4. The primary path
@@ -348,8 +358,8 @@ export function getActionInputJsonSchema(action: EmailActionDef): Record<string,
  * `$schema` marker so OpenClaw can compile the tool schema while we keep the
  * richer generated shape.
  */
-function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
-  const jsonSchema = z.toJSONSchema(schema, { io: 'input' }) as Record<string, unknown>;
+function zodToJsonSchema(schema: z.ZodType, io: 'input' | 'output' = 'input'): Record<string, unknown> {
+  const jsonSchema = z.toJSONSchema(schema, { io }) as Record<string, unknown>;
   delete jsonSchema.$schema;
   return jsonSchema;
 }

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -2305,6 +2305,27 @@ describe('provider-microsoft/NemoClaw Compatibility', () => {
 });
 
 describe('provider-microsoft/Search Hardening', () => {
+  it('Scenario: Search preserves a long opaque Graph message ID byte-for-byte', async () => {
+    const opaqueId = `opaque-${'B'.repeat(145)}`;
+    const client = createMockClient({
+      get: vi.fn().mockResolvedValue({
+        value: [{
+          id: opaqueId,
+          subject: 'Synthetic result',
+          from: { emailAddress: { address: 'sender@example.test' } },
+          toRecipients: [],
+          receivedDateTime: '2026-01-01T00:00:00Z',
+        }],
+      }),
+    });
+    const provider = new GraphEmailProvider(client);
+
+    const [message] = await provider.searchMessages('synthetic');
+
+    expect(message!.id).toBe(opaqueId);
+    expect(message!.id).toHaveLength(152);
+  });
+
   it('Scenario: Empty query returns empty array', async () => {
     const client = createMockClient();
     const provider = new GraphEmailProvider(client);

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -410,9 +410,10 @@ function classifyGraphDelivery(err: unknown): {
 /**
  * Build the EmailError for a failed delivery.
  *
- * The message string carries the guidance, because it is the only channel that
- * reaches an LLM caller — no outputSchema is published over MCP. So the
- * ambiguous wording must name a concrete artifact the caller can go and
+ * The message string carries the guidance because the structured action result
+ * has no separate guidance field. Publishing an MCP output schema makes the
+ * existing fields machine-readable; it does not create a new place for recovery
+ * advice. So the ambiguous wording must name a concrete artifact the caller can
  * inspect, and must say plainly not to resend. Wording mirrors the
  * scheduled-send path so the two families read alike.
  */


### PR DESCRIPTION
## Summary

Preserve provider identifiers in protocol-native MCP structured output so long Microsoft Graph IDs round-trip unchanged into threaded reply and draft operations. Keep the existing text JSON representation for compatibility.

## Implementation

- publish Zod-derived output schemas for MCP tools
- return exact action objects through `structuredContent`
- keep attachment bytes in MCP resources while returning attachment metadata structurally
- add synthetic 152-character ID regression coverage at the Graph provider and MCP boundaries

## Verification

- [x] `npm run build`
- [x] `npm run lint --workspaces --if-present`
- [x] `npm run test:run` (1,103 checks/tests passed)
- [ ] Independent peer review pending before automerge

Closes #187