### PR TITLE
feat(security): allow operator-configured attachment roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ white-on-white.
 
 **Body files** — `send_email`, `create_draft`, and `update_draft` also accept
 `body_file`: a path to a `.md`, `.html`, or `.txt` file (read relative to
-`EMAIL_MCP_SAFE_DIR`, default the process working directory) used as the body
+`EMAIL_MCP_SAFE_DIR`, default the process working directory, plus any
+`AGENT_EMAIL_ALLOWED_DIRS` roots) used as the body
 instead of `body`. A `.md` body file may
 open with a YAML frontmatter block:
 
@@ -355,7 +356,8 @@ unchanged.
 
 `send_email`, `reply_to_email`, `create_draft`, and `update_draft` accept an
 optional `attachments` array. Each entry takes a sandboxed file `path` (read
-relative to `EMAIL_MCP_SAFE_DIR`, default the process working directory) or
+relative to `EMAIL_MCP_SAFE_DIR`, default the process working directory, plus
+any `AGENT_EMAIL_ALLOWED_DIRS` roots — see below) or
 inline `base64`, plus optional `filename` / `mimeType` overrides:
 
 ```json
@@ -374,6 +376,32 @@ Files are capped at 25MB each; Microsoft Graph additionally caps inline sends
 at ~3MB total (larger files need an upload session — not yet supported). For
 `update_draft`, omitting `attachments` preserves the draft's existing files;
 passing an array (even empty) replaces them.
+
+**Attaching files from outside the working directory** — set
+`AGENT_EMAIL_ALLOWED_DIRS` to a delimiter-separated list of absolute
+directories (`:` on macOS/Linux, `;` on Windows; a leading `~` is expanded) that
+`attachments[].path` and `body_file` may also read from:
+
+```json
+{
+  "mcpServers": {
+    "email-agent-mcp": {
+      "command": "npx",
+      "args": ["-y", "@usejunior/email-agent-mcp"],
+      "env": { "AGENT_EMAIL_ALLOWED_DIRS": "~/Downloads:/Volumes/Shared/Contracts" }
+    }
+  }
+}
+```
+
+Paths are resolved against `EMAIL_MCP_SAFE_DIR` first, then each allowed
+directory in order, and the first match wins. Each root is canonicalised with
+`realpath` before the containment check, so an allowlisted root that is itself a
+symlink is resolved to its real location and a symlink escaping every root is
+still rejected. Unset (the default) keeps the working directory as the only
+root — which is why an agent that cannot reach a file should ask you to
+allowlist its directory rather than copy confidential documents into a git
+working tree.
 
 ## Provider Support
 

--- a/README.md
+++ b/README.md
@@ -394,14 +394,22 @@ directories (`:` on macOS/Linux, `;` on Windows; a leading `~` is expanded) that
 }
 ```
 
-Paths are resolved against `EMAIL_MCP_SAFE_DIR` first, then each allowed
-directory in order, and the first match wins. Each root is canonicalised with
-`realpath` before the containment check, so an allowlisted root that is itself a
-symlink is resolved to its real location and a symlink escaping every root is
-still rejected. Unset (the default) keeps the working directory as the only
-root — which is why an agent that cannot reach a file should ask you to
-allowlist its directory rather than copy confidential documents into a git
-working tree.
+A **relative** path resolves against `EMAIL_MCP_SAFE_DIR` only — allowed
+directories are reached by **absolute** path, so a bare `contract.pdf` can never
+silently pick up a different file from another root. Each root is canonicalised
+with `realpath` before the containment check: an allowlisted root that is itself
+a symlink resolves to its real location, a root that cannot be canonicalised
+authorises nothing, and a symlink escaping every root is still rejected. Unset
+(the default) keeps the working directory as the only root — which is why an
+agent that cannot reach a file should ask you to allowlist its directory rather
+than copy confidential documents into a git working tree.
+
+Allowlisting a directory trusts everyone who can write to it. Validation and
+open are separate operations on a path, so a principal who can replace a
+directory *inside* an allowed root between the two can still redirect the read;
+only allowlist roots whose ancestors are not writable by untrusted users. The
+final file is opened with `O_NOFOLLOW`, so the file itself cannot be swapped for
+a symlink after validation.
 
 ## Provider Support
 

--- a/openspec/changes/add-allowed-attachment-dirs/proposal.md
+++ b/openspec/changes/add-allowed-attachment-dirs/proposal.md
@@ -1,0 +1,36 @@
+# Add Operator-Allowlisted File Roots
+
+## Why
+
+`body_file` and `attachments[].path` resolve against a single root
+(`EMAIL_MCP_SAFE_DIR`, default the process working directory) with no way to
+declare additional trusted directories. Attaching a document that lives in
+`~/Downloads`, a cloud-storage mount, or a shared drive therefore forces one of
+two bad options: inline the file as `base64` (pushing hundreds of KB of encoded
+text through the agent's context) or copy it into the working directory, which
+routinely means staging a confidential document inside a git working tree.
+
+The sandbox itself is worth keeping as the default — without containment, an
+unrestricted `path` would let a restricted agent read files through the server
+that it could not read directly (a confused-deputy escalation). The missing
+piece is an opt-in escape hatch the operator, not the caller, controls.
+
+## What Changes
+
+- Accept `AGENT_EMAIL_ALLOWED_DIRS`: a delimiter-separated list of absolute
+  directories (leading `~` expanded) that `body_file` and `attachments[].path`
+  may also resolve within.
+- Resolve a caller path against the safe directory first, then each configured
+  root in order; the first containment match wins.
+- Canonicalize every root with `realpath` before containment, so an allowlisted
+  root that is itself a symlink is resolved to its real location and a symlink
+  escaping every root is still rejected.
+- Name the roots that were tried, and the env var that widens them, in the
+  rejection message.
+- Unset configuration preserves today's behavior exactly.
+
+## Impact
+
+- Affected specs: `email-write`, `email-attachments`
+- Affected code: `email-core` safe-path policy, body/attachment loaders,
+  compose helpers, action context; `email-mcp` server env wiring; README

--- a/openspec/changes/add-allowed-attachment-dirs/specs/email-attachments/spec.md
+++ b/openspec/changes/add-allowed-attachment-dirs/specs/email-attachments/spec.md
@@ -7,7 +7,7 @@ The system SHALL accept file attachments for outbound emails from a local file p
 A caller-supplied `attachments[].path` SHALL be read under the same sandbox as `body_file`: it resolves within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS`, with every root canonicalized before the containment check. A path outside every root SHALL be rejected with `PATH_TRAVERSAL`, and a symlink escaping every root with `SYMLINK_ESCAPE`.
 
 #### Scenario: Attach file to reply
-- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}` and `/tmp` is an allowed root
+- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}`
 - **THEN** the system base64-encodes the file and includes it as a Graph/Gmail attachment
 
 #### Scenario: Attach a file from an allowlisted directory

--- a/openspec/changes/add-allowed-attachment-dirs/specs/email-attachments/spec.md
+++ b/openspec/changes/add-allowed-attachment-dirs/specs/email-attachments/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: Attach Files to Outbound
+
+The system SHALL accept file attachments for outbound emails from a local file path or buffer. No CID embedding in v1 — email clients will show attachments inline if appropriate.
+
+A caller-supplied `attachments[].path` SHALL be read under the same sandbox as `body_file`: it resolves within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS`, with every root canonicalized before the containment check. A path outside every root SHALL be rejected with `PATH_TRAVERSAL`, and a symlink escaping every root with `SYMLINK_ESCAPE`.
+
+#### Scenario: Attach file to reply
+- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}` and `/tmp` is an allowed root
+- **THEN** the system base64-encodes the file and includes it as a Graph/Gmail attachment
+
+#### Scenario: Attach a file from an allowlisted directory
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Volumes/Shared/Contracts` and `send_email` is called with `{attachments: [{path: "/Volumes/Shared/Contracts/agreement.pdf"}]}`
+- **THEN** the file is attached without being copied into the working directory
+
+#### Scenario: Attachment outside every allowed root rejected
+- **WHEN** `attachments[].path` points outside the safe directory and outside every allowlisted root
+- **THEN** the system rejects with `PATH_TRAVERSAL` and an error naming the roots that were tried

--- a/openspec/changes/add-allowed-attachment-dirs/specs/email-write/spec.md
+++ b/openspec/changes/add-allowed-attachment-dirs/specs/email-write/spec.md
@@ -4,7 +4,7 @@
 
 The system SHALL accept an optional `body_file` parameter (local file path) as an alternative to the `body` string. File resolution and security validation SHALL occur in email-core action logic, not the MCP transport layer. When the file is markdown, the system SHALL render it to HTML before sending (see Body Rendering).
 
-Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any additional absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS` (a delimiter-separated list; a leading `~` is expanded, non-absolute entries are ignored with a warning). Roots SHALL be tried in order — safe directory first, then each allowlisted root — and the first containment match wins. Every root and the fully resolved target SHALL be canonicalized with `realpath` before the containment check. A rejection message SHALL name the roots that were tried and the env var that widens them.
+Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any additional absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS` (a delimiter-separated list; a leading `~` is expanded, non-absolute entries are ignored with a warning). A relative path SHALL resolve against the safe directory only; an absolute path SHALL be checked against each root in order — safe directory first — and the first containment match wins. Every root and the fully resolved target SHALL be canonicalized with `realpath` before the containment check, and a root that cannot be canonicalized SHALL authorize nothing. A rejection message SHALL name the roots that were tried and the env var that widens them.
 
 #### Scenario: Compose from markdown file
 - **WHEN** `send_email` is called with `{body_file: "draft.md", to: "..."}`
@@ -31,8 +31,12 @@ Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the
 - **THEN** `body_file` paths are resolved relative to that directory
 
 #### Scenario: Configured additional root
-- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Users/me/Downloads` and `body_file` is `/Users/me/Downloads/note.md`
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Users/me/Downloads` and `body_file` is the absolute path `/Users/me/Downloads/note.md`
 - **THEN** the system reads the file, even though it lies outside the safe directory
+
+#### Scenario: Relative path does not search allowlisted roots
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names a root holding `note.md` and `body_file` is the relative path `note.md`, absent from the safe directory
+- **THEN** the system rejects with `FILE_NOT_FOUND` rather than resolving the copy in the allowlisted root
 
 #### Scenario: Allowlisted root is itself a symlink
 - **WHEN** an `AGENT_EMAIL_ALLOWED_DIRS` entry is a symlink to another directory and `body_file` points inside it

--- a/openspec/changes/add-allowed-attachment-dirs/specs/email-write/spec.md
+++ b/openspec/changes/add-allowed-attachment-dirs/specs/email-write/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Body File Composition
+
+The system SHALL accept an optional `body_file` parameter (local file path) as an alternative to the `body` string. File resolution and security validation SHALL occur in email-core action logic, not the MCP transport layer. When the file is markdown, the system SHALL render it to HTML before sending (see Body Rendering).
+
+Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any additional absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS` (a delimiter-separated list; a leading `~` is expanded, non-absolute entries are ignored with a warning). Roots SHALL be tried in order — safe directory first, then each allowlisted root — and the first containment match wins. Every root and the fully resolved target SHALL be canonicalized with `realpath` before the containment check. A rejection message SHALL name the roots that were tried and the env var that widens them.
+
+#### Scenario: Compose from markdown file
+- **WHEN** `send_email` is called with `{body_file: "draft.md", to: "..."}`
+- **THEN** the system reads the file, renders the markdown to HTML, and ships both the raw source (as plain-text fallback) and the rendered HTML to the provider
+
+#### Scenario: Path traversal rejected
+- **WHEN** `body_file` contains `../` or an absolute path outside every allowed root
+- **THEN** the system rejects with `PATH_TRAVERSAL` and an error naming the roots that were tried, beginning "body_file must be within the working directory" when no extra roots are configured
+
+#### Scenario: Binary file rejected
+- **WHEN** `body_file` points to a binary file (image, PDF)
+- **THEN** the system rejects with an error: "body_file must be a text file (.md, .html, .txt)"
+
+#### Scenario: Symlink escape rejected
+- **WHEN** `body_file` is a symlink pointing outside every allowed root
+- **THEN** the system rejects with `SYMLINK_ESCAPE` and an error beginning "body_file symlink targets outside working directory" when no extra roots are configured
+
+#### Scenario: File not found
+- **WHEN** `body_file` points to a non-existent file
+- **THEN** the system rejects with an error: "body_file not found: draft.md"
+
+#### Scenario: Configured safe directory
+- **WHEN** a safe directory is configured via the `EMAIL_MCP_SAFE_DIR` env var
+- **THEN** `body_file` paths are resolved relative to that directory
+
+#### Scenario: Configured additional root
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Users/me/Downloads` and `body_file` is `/Users/me/Downloads/note.md`
+- **THEN** the system reads the file, even though it lies outside the safe directory
+
+#### Scenario: Allowlisted root is itself a symlink
+- **WHEN** an `AGENT_EMAIL_ALLOWED_DIRS` entry is a symlink to another directory and `body_file` points inside it
+- **THEN** the system canonicalizes the root before the containment check and resolves the file to its real path
+
+#### Scenario: Unset configuration preserves the single-root sandbox
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` is unset and `body_file` points outside the safe directory
+- **THEN** the system rejects with `PATH_TRAVERSAL`, exactly as before the setting existed
+
+#### Scenario: Frontmatter format override
+- **WHEN** `body_file` frontmatter declares `format: text`
+- **THEN** the system sends the body as plain text without rendering, preserving newlines verbatim

--- a/openspec/changes/add-allowed-attachment-dirs/tasks.md
+++ b/openspec/changes/add-allowed-attachment-dirs/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## 1. Sandbox policy
+- [x] 1.1 Accept a multi-root sandbox (`safeDir` plus extra allowed roots) in `assertPathInSafeDir`.
+- [x] 1.2 Canonicalize every root with `realpath` and keep the path-segment containment test.
+- [x] 1.3 Name the roots tried and the env var in `PATH_TRAVERSAL` / `SYMLINK_ESCAPE` messages.
+- [x] 1.4 Parse `AGENT_EMAIL_ALLOWED_DIRS` (delimiter split, `~` expansion, absolute-only, dedupe).
+
+## 2. Wiring
+- [x] 2.1 Thread the sandbox through body-loader, attachment-loader, and compose helpers.
+- [x] 2.2 Add `allowedDirs` to `ActionContext` and populate it in the MCP server from the env var.
+- [x] 2.3 Document the env var in the README body-file and attachment sections.
+
+## 3. Specification and verification
+- [x] 3.1 Update the body-file and outbound-attachment requirements and scenarios.
+- [x] 3.2 Cover allowed-root resolution, rejection, symlink escape, symlinked roots, and unset defaults with tests.
+- [ ] 3.3 Run tests, lint, build, strict OpenSpec validation, and spec coverage.

--- a/openspec/changes/add-allowed-attachment-dirs/tasks.md
+++ b/openspec/changes/add-allowed-attachment-dirs/tasks.md
@@ -5,13 +5,16 @@
 - [x] 1.2 Canonicalize every root with `realpath` and keep the path-segment containment test.
 - [x] 1.3 Name the roots tried and the env var in `PATH_TRAVERSAL` / `SYMLINK_ESCAPE` messages.
 - [x] 1.4 Parse `AGENT_EMAIL_ALLOWED_DIRS` (delimiter split, `~` expansion, absolute-only, dedupe).
+- [x] 1.5 Fail closed on a root that cannot be canonicalized; keep relative paths scoped to the safe directory.
+- [x] 1.6 Open validated files with `O_NOFOLLOW` on both read surfaces and document the residual TOCTOU contract.
 
 ## 2. Wiring
 - [x] 2.1 Thread the sandbox through body-loader, attachment-loader, and compose helpers.
 - [x] 2.2 Add `allowedDirs` to `ActionContext` and populate it in the MCP server from the env var.
-- [x] 2.3 Document the env var in the README body-file and attachment sections.
+- [x] 2.3 Warn on stderr for allowlisted roots that are missing or not directories.
+- [x] 2.4 Document the env var in the README body-file and attachment sections.
 
 ## 3. Specification and verification
 - [x] 3.1 Update the body-file and outbound-attachment requirements and scenarios.
 - [x] 3.2 Cover allowed-root resolution, rejection, symlink escape, symlinked roots, and unset defaults with tests.
-- [ ] 3.3 Run tests, lint, build, strict OpenSpec validation, and spec coverage.
+- [x] 3.3 Run tests, lint, build, strict OpenSpec validation, and spec coverage.

--- a/openspec/specs/email-attachments/spec.md
+++ b/openspec/specs/email-attachments/spec.md
@@ -28,9 +28,19 @@ The system SHALL preserve CID references (`<img src="cid:...">`) in HTML email b
 
 The system SHALL accept file attachments for outbound emails from a local file path or buffer. No CID embedding in v1 — email clients will show attachments inline if appropriate.
 
+A caller-supplied `attachments[].path` SHALL be read under the same sandbox as `body_file`: it resolves within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS`, with every root canonicalized before the containment check. A path outside every root SHALL be rejected with `PATH_TRAVERSAL`, and a symlink escaping every root with `SYMLINK_ESCAPE`.
+
 #### Scenario: Attach file to reply
-- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}`
+- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}` and `/tmp` is an allowed root
 - **THEN** the system base64-encodes the file and includes it as a Graph/Gmail attachment
+
+#### Scenario: Attach a file from an allowlisted directory
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Volumes/Shared/Contracts` and `send_email` is called with `{attachments: [{path: "/Volumes/Shared/Contracts/agreement.pdf"}]}`
+- **THEN** the file is attached without being copied into the working directory
+
+#### Scenario: Attachment outside every allowed root rejected
+- **WHEN** `attachments[].path` points outside the safe directory and outside every allowlisted root
+- **THEN** the system rejects with `PATH_TRAVERSAL` and an error naming the roots that were tried
 
 ### Requirement: Size and Type Validation
 

--- a/openspec/specs/email-attachments/spec.md
+++ b/openspec/specs/email-attachments/spec.md
@@ -31,7 +31,7 @@ The system SHALL accept file attachments for outbound emails from a local file p
 A caller-supplied `attachments[].path` SHALL be read under the same sandbox as `body_file`: it resolves within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS`, with every root canonicalized before the containment check. A path outside every root SHALL be rejected with `PATH_TRAVERSAL`, and a symlink escaping every root with `SYMLINK_ESCAPE`.
 
 #### Scenario: Attach file to reply
-- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}` and `/tmp` is an allowed root
+- **WHEN** `reply_to_email` is called with `{attachments: [{path: "/tmp/report.pdf"}]}`
 - **THEN** the system base64-encodes the file and includes it as a Graph/Gmail attachment
 
 #### Scenario: Attach a file from an allowlisted directory

--- a/openspec/specs/email-write/spec.md
+++ b/openspec/specs/email-write/spec.md
@@ -42,7 +42,7 @@ The system SHALL provide a `send_email` action that composes and sends a new ema
 
 The system SHALL accept an optional `body_file` parameter (local file path) as an alternative to the `body` string. File resolution and security validation SHALL occur in email-core action logic, not the MCP transport layer. When the file is markdown, the system SHALL render it to HTML before sending (see Body Rendering).
 
-Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any additional absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS` (a delimiter-separated list; a leading `~` is expanded, non-absolute entries are ignored with a warning). Roots SHALL be tried in order — safe directory first, then each allowlisted root — and the first containment match wins. Every root and the fully resolved target SHALL be canonicalized with `realpath` before the containment check. A rejection message SHALL name the roots that were tried and the env var that widens them.
+Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any additional absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS` (a delimiter-separated list; a leading `~` is expanded, non-absolute entries are ignored with a warning). A relative path SHALL resolve against the safe directory only; an absolute path SHALL be checked against each root in order — safe directory first — and the first containment match wins. Every root and the fully resolved target SHALL be canonicalized with `realpath` before the containment check, and a root that cannot be canonicalized SHALL authorize nothing. A rejection message SHALL name the roots that were tried and the env var that widens them.
 
 #### Scenario: Compose from markdown file
 - **WHEN** `send_email` is called with `{body_file: "draft.md", to: "..."}`
@@ -69,8 +69,12 @@ Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the
 - **THEN** `body_file` paths are resolved relative to that directory
 
 #### Scenario: Configured additional root
-- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Users/me/Downloads` and `body_file` is `/Users/me/Downloads/note.md`
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Users/me/Downloads` and `body_file` is the absolute path `/Users/me/Downloads/note.md`
 - **THEN** the system reads the file, even though it lies outside the safe directory
+
+#### Scenario: Relative path does not search allowlisted roots
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names a root holding `note.md` and `body_file` is the relative path `note.md`, absent from the safe directory
+- **THEN** the system rejects with `FILE_NOT_FOUND` rather than resolving the copy in the allowlisted root
 
 #### Scenario: Allowlisted root is itself a symlink
 - **WHEN** an `AGENT_EMAIL_ALLOWED_DIRS` entry is a symlink to another directory and `body_file` points inside it

--- a/openspec/specs/email-write/spec.md
+++ b/openspec/specs/email-write/spec.md
@@ -42,29 +42,43 @@ The system SHALL provide a `send_email` action that composes and sends a new ema
 
 The system SHALL accept an optional `body_file` parameter (local file path) as an alternative to the `body` string. File resolution and security validation SHALL occur in email-core action logic, not the MCP transport layer. When the file is markdown, the system SHALL render it to HTML before sending (see Body Rendering).
 
+Paths SHALL resolve within the safe directory (`EMAIL_MCP_SAFE_DIR`, default the process working directory) or within any additional absolute root the operator allowlists via `AGENT_EMAIL_ALLOWED_DIRS` (a delimiter-separated list; a leading `~` is expanded, non-absolute entries are ignored with a warning). Roots SHALL be tried in order — safe directory first, then each allowlisted root — and the first containment match wins. Every root and the fully resolved target SHALL be canonicalized with `realpath` before the containment check. A rejection message SHALL name the roots that were tried and the env var that widens them.
+
 #### Scenario: Compose from markdown file
 - **WHEN** `send_email` is called with `{body_file: "draft.md", to: "..."}`
 - **THEN** the system reads the file, renders the markdown to HTML, and ships both the raw source (as plain-text fallback) and the rendered HTML to the provider
 
 #### Scenario: Path traversal rejected
-- **WHEN** `body_file` contains `../` or an absolute path outside the working directory
-- **THEN** the system rejects with an error: "body_file must be within the working directory"
+- **WHEN** `body_file` contains `../` or an absolute path outside every allowed root
+- **THEN** the system rejects with `PATH_TRAVERSAL` and an error naming the roots that were tried, beginning "body_file must be within the working directory" when no extra roots are configured
 
 #### Scenario: Binary file rejected
 - **WHEN** `body_file` points to a binary file (image, PDF)
 - **THEN** the system rejects with an error: "body_file must be a text file (.md, .html, .txt)"
 
 #### Scenario: Symlink escape rejected
-- **WHEN** `body_file` is a symlink pointing outside the working directory
-- **THEN** the system rejects with an error: "body_file symlink targets outside working directory"
+- **WHEN** `body_file` is a symlink pointing outside every allowed root
+- **THEN** the system rejects with `SYMLINK_ESCAPE` and an error beginning "body_file symlink targets outside working directory" when no extra roots are configured
 
 #### Scenario: File not found
 - **WHEN** `body_file` points to a non-existent file
 - **THEN** the system rejects with an error: "body_file not found: draft.md"
 
 #### Scenario: Configured safe directory
-- **WHEN** a safe directory is configured via `AGENT_EMAIL_SAFE_DIR` env var
+- **WHEN** a safe directory is configured via the `EMAIL_MCP_SAFE_DIR` env var
 - **THEN** `body_file` paths are resolved relative to that directory
+
+#### Scenario: Configured additional root
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` names `/Users/me/Downloads` and `body_file` is `/Users/me/Downloads/note.md`
+- **THEN** the system reads the file, even though it lies outside the safe directory
+
+#### Scenario: Allowlisted root is itself a symlink
+- **WHEN** an `AGENT_EMAIL_ALLOWED_DIRS` entry is a symlink to another directory and `body_file` points inside it
+- **THEN** the system canonicalizes the root before the containment check and resolves the file to its real path
+
+#### Scenario: Unset configuration preserves the single-root sandbox
+- **WHEN** `AGENT_EMAIL_ALLOWED_DIRS` is unset and `body_file` points outside the safe directory
+- **THEN** the system rejects with `PATH_TRAVERSAL`, exactly as before the setting existed
 
 #### Scenario: Frontmatter format override
 - **WHEN** `body_file` frontmatter declares `format: text`

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -1,11 +1,12 @@
 // Shared helpers for compose actions — internal module, NOT exported from package root
 import { z } from 'zod';
 import { basename } from 'node:path';
-import type { RateLimiter, MailboxEntry } from './registry.js';
+import type { RateLimiter, MailboxEntry, ActionContext } from './registry.js';
 import { isProviderError } from '../providers/provider.js';
 import type { EmailReader } from '../providers/provider.js';
 import { resolveBodyFile } from '../content/body-loader.js';
 import { resolveAttachmentFile } from '../content/attachment-loader.js';
+import type { PathSandboxInput } from '../content/safe-path.js';
 import type { BodyFormat } from '../content/body-renderer.js';
 import { parseAddressList } from '../utils/address.js';
 import { validateAttachment, sanitizeFilename } from './attachments.js';
@@ -23,6 +24,14 @@ interface ActionError {
   // MCP wrapper), not necessarily every mailbox on disk.
   availableMailboxes?: string[];
   defaultMailbox?: string;
+}
+
+/**
+ * The filesystem sandbox for caller-supplied paths on this request: the safe
+ * base directory plus any operator-allowlisted extra roots.
+ */
+export function pathSandbox(ctx: ActionContext): PathSandboxInput {
+  return { safeDir: ctx.safeDir, allowedDirs: ctx.allowedDirs };
 }
 
 // --- checkMailboxRequired ---
@@ -77,7 +86,7 @@ export async function resolveComposeFields(
     format?: BodyFormat;
     force_black?: boolean;
   },
-  safeDir?: string,
+  sandbox?: PathSandboxInput,
   opts?: { bodyOptional?: boolean },
 ): Promise<ComposeFields> {
   let body: string | undefined;
@@ -90,7 +99,7 @@ export async function resolveComposeFields(
   let forceBlack = input.force_black;
 
   if (input.body_file) {
-    const bodyResult = await resolveBodyFile(input.body_file, safeDir);
+    const bodyResult = await resolveBodyFile(input.body_file, sandbox);
     if (bodyResult.error) {
       return { body: '', error: bodyResult.error };
     }
@@ -143,7 +152,7 @@ function isValidBase64(value: string): boolean {
 export const AttachmentInputSchema = z
   .object({
     path: z.string().optional()
-      .describe('Path to a file within the working directory (sandboxed, like body_file).'),
+      .describe('Path to a file within the working directory, or within a directory the server operator allowlisted via AGENT_EMAIL_ALLOWED_DIRS (sandboxed, like body_file).'),
     base64: z.string().optional()
       .describe('Inline standard-base64-encoded file content. Alternative to path.'),
     filename: z.string().optional()
@@ -171,14 +180,14 @@ export interface ResolveAttachmentsResult {
 
 /**
  * Resolve caller-supplied attachment inputs into validated OutboundAttachment
- * buffers. Path entries are read sandboxed to `safeDir`; base64 entries are
+ * buffers. Path entries are read sandboxed to `sandbox`; base64 entries are
  * decoded inline. Each file is run through validateAttachment (25MB cap +
  * magic-byte MIME). Returns a structured error on the first failure — never
  * throws. An undefined/empty input yields `{ files: [] }`.
  */
 export async function resolveAttachments(
   attachments: AttachmentInput[] | undefined,
-  safeDir: string | undefined,
+  sandbox: PathSandboxInput,
 ): Promise<ResolveAttachmentsResult> {
   if (!attachments || attachments.length === 0) {
     return { files: [] };
@@ -190,7 +199,7 @@ export async function resolveAttachments(
     let defaultName: string;
 
     if (hasNonEmpty(att.path)) {
-      const read = await resolveAttachmentFile(att.path!, safeDir);
+      const read = await resolveAttachmentFile(att.path!, sandbox);
       if (read.error) {
         return { error: { ...read.error, message: `attachments[${index}]: ${read.error.message}` } };
       }

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -23,6 +23,7 @@ import {
   AttachmentInputSchema,
   DraftPreviewSchema,
   PreviewErrorSchema,
+  pathSandbox,
 } from './compose-helpers.js';
 
 // --- Shared schemas ---
@@ -86,7 +87,7 @@ export const createDraftAction: EmailAction<
     }
 
     // Resolve body and frontmatter
-    const fields = await resolveComposeFields(input, ctx.safeDir);
+    const fields = await resolveComposeFields(input, pathSandbox(ctx));
     if (fields.error) {
       return { success: false, error: fields.error };
     }
@@ -95,7 +96,7 @@ export const createDraftAction: EmailAction<
     let { body } = fields;
 
     // Resolve attachments (sandboxed path reads + validation)
-    const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+    const attResult = await resolveAttachments(input.attachments, pathSandbox(ctx));
     if (attResult.error) {
       return { success: false, error: attResult.error };
     }
@@ -394,7 +395,7 @@ export const updateDraftAction: EmailAction<
     }
 
     // Resolve body from file if provided (body is optional for updates)
-    const fields = await resolveComposeFields(input, ctx.safeDir, { bodyOptional: true });
+    const fields = await resolveComposeFields(input, pathSandbox(ctx), { bodyOptional: true });
     if (fields.error) {
       return { success: false, error: fields.error };
     }
@@ -460,7 +461,7 @@ export const updateDraftAction: EmailAction<
     // Attachments: omitted → preserve existing (handled provider-side);
     // provided → replace entirely (an empty array removes all).
     if (input.attachments !== undefined) {
-      const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+      const attResult = await resolveAttachments(input.attachments, pathSandbox(ctx));
       if (attResult.error) {
         return { success: false, error: attResult.error };
       }

--- a/packages/email-core/src/actions/outbound-attachments.test.ts
+++ b/packages/email-core/src/actions/outbound-attachments.test.ts
@@ -1,7 +1,7 @@
 // Outbound attachment coverage for create_draft / update_draft / send_email /
 // reply_to_email — issue #89.
 import { describe, it, expect, beforeEach } from 'vitest';
-import { writeFile, mkdir } from 'node:fs/promises';
+import { writeFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { MockEmailProvider } from '../testing/mock-provider.js';
@@ -323,5 +323,58 @@ describe('outbound-attachments/reply_to_email', () => {
     expect(result.success).toBe(true);
     const draft = provider.getDrafts().get(result.draftId!);
     expect(draft!.attachments).toHaveLength(1);
+  });
+});
+
+describe('email-attachments/Attach Files to Outbound — allowlisted roots (#105)', () => {
+  // Issue #105 — an operator-declared root lets an agent attach a document that
+  // lives outside the working directory instead of staging it inside a repo.
+  it('Scenario: Attach a file from an allowlisted directory', async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), 'allowed-dir-test-'));
+    const contract = join(outsideDir, 'contract.pdf');
+    await writeFile(contract, PDF_BYTES);
+
+    const result = await sendEmailAction.run(
+      { ...ctx, allowedDirs: [outsideDir] },
+      {
+        to: 'alice@allowed.com',
+        subject: 'Outside',
+        body: 'body',
+        attachments: [{ path: contract }],
+      },
+    );
+
+    expect(result.success).toBe(true);
+    const sent = provider.getSentMessages();
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.attachments![0]!.filename).toBe('contract.pdf');
+    expect(sent[0]!.attachments![0]!.content.equals(PDF_BYTES)).toBe(true);
+
+    await rm(outsideDir, { recursive: true, force: true });
+  });
+
+  it('Scenario: Attachment outside every allowed root rejected', async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), 'denied-dir-test-'));
+    const allowedDir = await mkdtemp(join(tmpdir(), 'allowed-dir-test-'));
+    const contract = join(outsideDir, 'contract.pdf');
+    await writeFile(contract, PDF_BYTES);
+
+    const result = await sendEmailAction.run(
+      { ...ctx, allowedDirs: [allowedDir] },
+      {
+        to: 'alice@allowed.com',
+        subject: 'Outside',
+        body: 'body',
+        attachments: [{ path: contract }],
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('PATH_TRAVERSAL');
+    expect(result.error!.message).toContain(allowedDir);
+    expect(provider.getSentMessages()).toHaveLength(0);
+
+    await rm(outsideDir, { recursive: true, force: true });
+    await rm(allowedDir, { recursive: true, force: true });
   });
 });

--- a/packages/email-core/src/actions/registry.ts
+++ b/packages/email-core/src/actions/registry.ts
@@ -22,6 +22,11 @@ export interface ActionContext {
   sendAllowlist?: AllowlistConfig;
   receiveAllowlist?: AllowlistConfig;
   safeDir?: string;
+  /**
+   * Extra absolute roots that caller-supplied `body_file` / attachment paths
+   * may also resolve within, beyond `safeDir` (see AGENT_EMAIL_ALLOWED_DIRS).
+   */
+  allowedDirs?: string[];
   deleteEnabled?: boolean;
   hardDeleteAllowed?: boolean;
   rateLimiter?: RateLimiter;

--- a/packages/email-core/src/actions/registry.ts
+++ b/packages/email-core/src/actions/registry.ts
@@ -26,7 +26,7 @@ export interface ActionContext {
    * Extra absolute roots that caller-supplied `body_file` / attachment paths
    * may also resolve within, beyond `safeDir` (see AGENT_EMAIL_ALLOWED_DIRS).
    */
-  allowedDirs?: string[];
+  allowedDirs?: readonly string[];
   deleteEnabled?: boolean;
   hardDeleteAllowed?: boolean;
   rateLimiter?: RateLimiter;

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -15,6 +15,7 @@ import {
   AttachmentInputSchema,
   DraftPreviewSchema,
   PreviewErrorSchema,
+  pathSandbox,
 } from './compose-helpers.js';
 
 const ReplyToEmailInput = z.object({
@@ -147,7 +148,7 @@ export const replyToEmailAction: EmailAction<
     }
 
     // Resolve attachments (sandboxed path reads + validation)
-    const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+    const attResult = await resolveAttachments(input.attachments, pathSandbox(ctx));
     if (attResult.error) {
       return { success: false, error: attResult.error };
     }

--- a/packages/email-core/src/actions/send.test.ts
+++ b/packages/email-core/src/actions/send.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { writeFile, mkdir, symlink, rm } from 'node:fs/promises';
+import { writeFile, mkdir, mkdtemp, symlink, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { MockEmailProvider } from '../testing/mock-provider.js';
@@ -139,6 +139,71 @@ describe('email-write/Body File Composition', () => {
 
     expect(result.success).toBe(true);
     expect(provider.getSentMessages()[0]!.body).toBe('Safe body content');
+  });
+
+  // Issue #105 — operator-allowlisted roots, so a body file (or attachment)
+  // outside the working directory need not be copied into a git working tree.
+  it('Scenario: Configured additional root', async () => {
+    const extraDir = await mkdtemp(join(tmpdir(), 'allowed-root-'));
+    await writeFile(join(extraDir, 'outside-draft.md'), 'Body from an allowed root');
+
+    const result = await sendEmailAction.run(
+      { ...ctx, allowedDirs: [extraDir] },
+      {
+        to: 'alice@allowed.com',
+        subject: 'Test',
+        body_file: join(extraDir, 'outside-draft.md'),
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(provider.getSentMessages()[0]!.body).toBe('Body from an allowed root');
+
+    await rm(extraDir, { recursive: true, force: true });
+  });
+
+  it('Scenario: Allowlisted root is itself a symlink', async () => {
+    const realRoot = await mkdtemp(join(tmpdir(), 'real-root-'));
+    await writeFile(join(realRoot, 'linked-draft.md'), 'Body behind a symlinked root');
+    const linkedRoot = join(tmpdir(), `linked-root-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    try {
+      await symlink(realRoot, linkedRoot);
+    } catch {
+      return; // symlinks may not be supported
+    }
+
+    const result = await sendEmailAction.run(
+      { ...ctx, allowedDirs: [linkedRoot] },
+      {
+        to: 'alice@allowed.com',
+        subject: 'Test',
+        body_file: join(linkedRoot, 'linked-draft.md'),
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(provider.getSentMessages()[0]!.body).toBe('Body behind a symlinked root');
+
+    await rm(linkedRoot, { force: true });
+    await rm(realRoot, { recursive: true, force: true });
+  });
+
+  it('Scenario: Unset configuration preserves the single-root sandbox', async () => {
+    const extraDir = await mkdtemp(join(tmpdir(), 'unconfigured-root-'));
+    await writeFile(join(extraDir, 'outside-draft.md'), 'Body from an unconfigured root');
+
+    const result = await sendEmailAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Test',
+      body_file: join(extraDir, 'outside-draft.md'),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('PATH_TRAVERSAL');
+    expect(result.error!.message).toContain('body_file must be within the working directory');
+    expect(provider.getSentMessages()).toHaveLength(0);
+
+    await rm(extraDir, { recursive: true, force: true });
   });
 
   it('Scenario: Frontmatter format override', async () => {

--- a/packages/email-core/src/actions/send.test.ts
+++ b/packages/email-core/src/actions/send.test.ts
@@ -188,6 +188,26 @@ describe('email-write/Body File Composition', () => {
     await rm(realRoot, { recursive: true, force: true });
   });
 
+  it('Scenario: Relative path does not search allowlisted roots', async () => {
+    const extraDir = await mkdtemp(join(tmpdir(), 'allowed-root-'));
+    await writeFile(join(extraDir, 'roaming-draft.md'), 'Body that must not be found');
+
+    const result = await sendEmailAction.run(
+      { ...ctx, allowedDirs: [extraDir] },
+      {
+        to: 'alice@allowed.com',
+        subject: 'Test',
+        body_file: 'roaming-draft.md',
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error!.code).toBe('FILE_NOT_FOUND');
+    expect(provider.getSentMessages()).toHaveLength(0);
+
+    await rm(extraDir, { recursive: true, force: true });
+  });
+
   it('Scenario: Unset configuration preserves the single-root sandbox', async () => {
     const extraDir = await mkdtemp(join(tmpdir(), 'unconfigured-root-'));
     await writeFile(join(extraDir, 'outside-draft.md'), 'Body from an unconfigured root');

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -22,6 +22,7 @@ import {
   AttachmentInputSchema,
   DraftPreviewSchema,
   PreviewErrorSchema,
+  pathSandbox,
 } from './compose-helpers.js';
 
 const SendEmailInput = z.object({
@@ -92,7 +93,7 @@ export const sendEmailAction: EmailAction<
     }
 
     // Resolve body content and frontmatter
-    const fields = await resolveComposeFields(input, ctx.safeDir);
+    const fields = await resolveComposeFields(input, pathSandbox(ctx));
     if (fields.error) {
       return { success: false, error: fields.error };
     }
@@ -101,7 +102,7 @@ export const sendEmailAction: EmailAction<
     let { body } = fields;
 
     // Resolve attachments (sandboxed path reads + validation)
-    const attResult = await resolveAttachments(input.attachments, ctx.safeDir);
+    const attResult = await resolveAttachments(input.attachments, pathSandbox(ctx));
     if (attResult.error) {
       return { success: false, error: attResult.error };
     }

--- a/packages/email-core/src/content/attachment-loader.ts
+++ b/packages/email-core/src/content/attachment-loader.ts
@@ -3,7 +3,7 @@
 // assertPathInSafeDir, but reads raw bytes — no text-extension gate, no
 // null-byte rejection, no UTF-8 decode, no frontmatter parsing.
 import { open } from 'node:fs/promises';
-import { assertPathInSafeDir, type PathSandboxInput } from './safe-path.js';
+import { assertPathInSafeDir, SAFE_READ_FLAGS, type PathSandboxInput } from './safe-path.js';
 
 export const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024; // 25MB
 
@@ -20,6 +20,15 @@ function mapFsError(err: unknown, filePath: string): AttachmentFileResult {
   }
   if (code === 'EACCES' || code === 'EPERM') {
     return { error: { code: 'PERMISSION_DENIED', message: `attachment path is not readable: ${filePath}`, recoverable: false } };
+  }
+  if (code === 'ELOOP') {
+    return {
+      error: {
+        code: 'SYMLINK_ESCAPE',
+        message: `attachment path changed to a symlink during validation: ${filePath}`,
+        recoverable: false,
+      },
+    };
   }
   if (code === 'EISDIR') {
     return { error: { code: 'INVALID_FILE_TYPE', message: `attachment path is not a regular file: ${filePath}`, recoverable: false } };
@@ -53,7 +62,7 @@ export async function resolveAttachmentFile(
 
   let filehandle;
   try {
-    filehandle = await open(resolved, 'r');
+    filehandle = await open(resolved, SAFE_READ_FLAGS);
     const fileStat = await filehandle.stat();
 
     if (!fileStat.isFile()) {

--- a/packages/email-core/src/content/attachment-loader.ts
+++ b/packages/email-core/src/content/attachment-loader.ts
@@ -3,7 +3,7 @@
 // assertPathInSafeDir, but reads raw bytes — no text-extension gate, no
 // null-byte rejection, no UTF-8 decode, no frontmatter parsing.
 import { open } from 'node:fs/promises';
-import { assertPathInSafeDir } from './safe-path.js';
+import { assertPathInSafeDir, type PathSandboxInput } from './safe-path.js';
 
 export const MAX_ATTACHMENT_SIZE = 25 * 1024 * 1024; // 25MB
 
@@ -43,9 +43,9 @@ function mapFsError(err: unknown, filePath: string): AttachmentFileResult {
  */
 export async function resolveAttachmentFile(
   filePath: string,
-  safeDir?: string,
+  sandbox?: PathSandboxInput,
 ): Promise<AttachmentFileResult> {
-  const pathCheck = await assertPathInSafeDir(filePath, safeDir, 'attachment path');
+  const pathCheck = await assertPathInSafeDir(filePath, sandbox, 'attachment path');
   if (pathCheck.error) {
     return { error: pathCheck.error };
   }

--- a/packages/email-core/src/content/body-loader.ts
+++ b/packages/email-core/src/content/body-loader.ts
@@ -2,7 +2,7 @@
 import { readFile } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { parseFrontmatter, type FrontmatterFields } from './frontmatter.js';
-import { assertPathInSafeDir } from './safe-path.js';
+import { assertPathInSafeDir, type PathSandboxInput } from './safe-path.js';
 
 export const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 export const TEXT_EXTENSIONS = new Set(['.md', '.html', '.htm', '.txt', '.text']);
@@ -15,9 +15,9 @@ export interface BodyFileResult {
 
 export async function resolveBodyFile(
   bodyFile: string,
-  safeDir?: string,
+  sandbox?: PathSandboxInput,
 ): Promise<BodyFileResult> {
-  const pathCheck = await assertPathInSafeDir(bodyFile, safeDir, 'body_file');
+  const pathCheck = await assertPathInSafeDir(bodyFile, sandbox, 'body_file');
   if (pathCheck.error) {
     return { error: pathCheck.error };
   }

--- a/packages/email-core/src/content/body-loader.ts
+++ b/packages/email-core/src/content/body-loader.ts
@@ -1,8 +1,8 @@
 // Shared body-file resolution — safe file loading with frontmatter support
-import { readFile } from 'node:fs/promises';
+import { open } from 'node:fs/promises';
 import { extname } from 'node:path';
 import { parseFrontmatter, type FrontmatterFields } from './frontmatter.js';
-import { assertPathInSafeDir, type PathSandboxInput } from './safe-path.js';
+import { assertPathInSafeDir, SAFE_READ_FLAGS, type PathSandboxInput } from './safe-path.js';
 
 export const BODY_SIZE_LIMIT = 3.5 * 1024 * 1024; // 3.5MB
 export const TEXT_EXTENSIONS = new Set(['.md', '.html', '.htm', '.txt', '.text']);
@@ -35,8 +35,28 @@ export async function resolveBodyFile(
     };
   }
 
-  // Read file and check for binary content
-  const raw = await readFile(resolved);
+  // Read through an opened descriptor with O_NOFOLLOW, matching the
+  // attachment loader: the validated leaf cannot be swapped for a symlink
+  // between the containment check and the read.
+  let raw: Buffer;
+  let filehandle;
+  try {
+    filehandle = await open(resolved, SAFE_READ_FLAGS);
+    raw = await filehandle.readFile();
+  } catch (err) {
+    if ((err as { code?: string } | null)?.code === 'ELOOP') {
+      return {
+        error: {
+          code: 'SYMLINK_ESCAPE',
+          message: `body_file changed to a symlink during validation: ${bodyFile}`,
+          recoverable: false,
+        },
+      };
+    }
+    throw err;
+  } finally {
+    await filehandle?.close();
+  }
 
   // Binary file detection: check for null bytes
   if (raw.includes(0)) {

--- a/packages/email-core/src/content/safe-path.test.ts
+++ b/packages/email-core/src/content/safe-path.test.ts
@@ -221,7 +221,7 @@ describe('content/safe-path — parseAllowedDirs', () => {
   });
 
   it('splits on the platform delimiter, trims, and deduplicates', () => {
-    const raw = [` ${workDir} `, extraDir, workDir].join(delimiter);
+    const raw = [` ${workDir} `, extraDir, workDir, `${workDir}${sep}`].join(delimiter);
     expect(parseAllowedDirs(raw).dirs).toEqual([workDir, extraDir]);
   });
 

--- a/packages/email-core/src/content/safe-path.test.ts
+++ b/packages/email-core/src/content/safe-path.test.ts
@@ -189,18 +189,36 @@ describe('content/safe-path — configured extra roots', () => {
     expect(result.error!.code).toBe('FILE_NOT_FOUND');
   });
 
-  it('falls through to a later root when a relative path is missing in the first', async () => {
+  it('does not search extra roots for a relative path', async () => {
+    // Ambient basename lookup would make `contract.pdf` silently resolve to
+    // whichever root happened to hold a copy. Relative paths stay cwd-scoped.
     await writeFile(join(extraDir, 'contract.pdf'), 'data');
     const result = await assertPathInSafeDir(
       'contract.pdf',
       { safeDir: workDir, allowedDirs: [extraDir] },
       'attachment path',
     );
-    expect(result.error).toBeUndefined();
-    expect(result.resolved).toContain('extra');
+    expect(result.error!.code).toBe('FILE_NOT_FOUND');
   });
 
-  it('prefers the safe directory over a later root for the same relative path', async () => {
+  it('drops a configured root that cannot be canonicalized', async () => {
+    const missingRoot = join(root, 'not-created');
+    const result = await assertPathInSafeDir(
+      join(missingRoot, 'contract.pdf'),
+      { safeDir: workDir, allowedDirs: [missingRoot] },
+      'attachment path',
+    );
+    // The root is literally contained but unresolvable, so it authorizes
+    // nothing — no literal-path fallback.
+    expect(result.error!.code).toBe('FILE_NOT_FOUND');
+  });
+
+  it('expands a Windows-style ~\\ prefix', () => {
+    const { dirs } = parseAllowedDirs('~\\Downloads', { home: '/home/agent' });
+    expect(dirs).toEqual([join('/home/agent', 'Downloads')]);
+  });
+
+  it('resolves a relative path against the safe directory', async () => {
     await writeFile(join(workDir, 'contract.pdf'), 'work copy');
     await writeFile(join(extraDir, 'contract.pdf'), 'extra copy');
     const result = await assertPathInSafeDir(

--- a/packages/email-core/src/content/safe-path.test.ts
+++ b/packages/email-core/src/content/safe-path.test.ts
@@ -1,0 +1,240 @@
+// Sandbox policy coverage for body_file / attachment path reads, including the
+// operator-configured extra roots added for issue #105.
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, delimiter, sep } from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { assertPathInSafeDir, parseAllowedDirs, ALLOWED_DIRS_ENV } from './safe-path.js';
+
+let root: string;
+let workDir: string;
+let extraDir: string;
+let outsideDir: string;
+
+/** Skip a symlink assertion on platforms/filesystems that refuse symlinks. */
+async function trySymlink(target: string, link: string): Promise<boolean> {
+  try {
+    await symlink(target, link);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'safe-path-test-'));
+  workDir = join(root, 'work');
+  extraDir = join(root, 'extra');
+  outsideDir = join(root, 'outside');
+  await mkdir(workDir, { recursive: true });
+  await mkdir(extraDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe('content/safe-path — default single-root sandbox', () => {
+  it('resolves a file inside the safe directory', async () => {
+    await writeFile(join(workDir, 'draft.md'), 'body');
+    const result = await assertPathInSafeDir('draft.md', workDir, 'body_file');
+    expect(result.error).toBeUndefined();
+    expect(result.resolved!.endsWith(`${sep}draft.md`)).toBe(true);
+  });
+
+  it('rejects an outside path when no extra roots are configured', async () => {
+    await writeFile(join(extraDir, 'secret.pdf'), 'data');
+
+    const asString = await assertPathInSafeDir(join(extraDir, 'secret.pdf'), workDir, 'attachment path');
+    const asSandbox = await assertPathInSafeDir(
+      join(extraDir, 'secret.pdf'),
+      { safeDir: workDir },
+      'attachment path',
+    );
+
+    expect(asString.error!.code).toBe('PATH_TRAVERSAL');
+    expect(asSandbox.error!.code).toBe('PATH_TRAVERSAL');
+    // Legacy wording is preserved so existing callers keep matching on it.
+    expect(asString.error!.message).toContain('attachment path must be within the working directory');
+  });
+
+  it('names the working directory and the env var on rejection', async () => {
+    const result = await assertPathInSafeDir('/etc/passwd', workDir, 'attachment path');
+    expect(result.error!.message).toContain(workDir);
+    expect(result.error!.message).toContain(ALLOWED_DIRS_ENV);
+  });
+
+  it('rejects a symlink escape with the legacy message', async () => {
+    const target = join(outsideDir, 'secret.txt');
+    await writeFile(target, 'secret');
+    if (!(await trySymlink(target, join(workDir, 'escape.md')))) return;
+
+    const result = await assertPathInSafeDir('escape.md', workDir, 'body_file');
+    expect(result.error!.code).toBe('SYMLINK_ESCAPE');
+    expect(result.error!.message).toContain('body_file symlink targets outside working directory');
+  });
+});
+
+describe('content/safe-path — configured extra roots', () => {
+  it('resolves a path inside a configured extra root', async () => {
+    const file = join(extraDir, 'contract.pdf');
+    await writeFile(file, 'data');
+
+    const result = await assertPathInSafeDir(
+      file,
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.resolved!.endsWith(`${sep}contract.pdf`)).toBe(true);
+  });
+
+  it('rejects a path outside every root with PATH_TRAVERSAL', async () => {
+    const file = join(outsideDir, 'contract.pdf');
+    await writeFile(file, 'data');
+
+    const result = await assertPathInSafeDir(
+      file,
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+
+    expect(result.error!.code).toBe('PATH_TRAVERSAL');
+    expect(result.error!.message).toContain('must be within an allowed directory');
+    expect(result.error!.message).toContain(workDir);
+    expect(result.error!.message).toContain(extraDir);
+  });
+
+  it('rejects a symlink inside a configured root that targets outside every root', async () => {
+    const target = join(outsideDir, 'secret.txt');
+    await writeFile(target, 'secret');
+    const link = join(extraDir, 'escape.pdf');
+    if (!(await trySymlink(target, link))) return;
+
+    const result = await assertPathInSafeDir(
+      link,
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+
+    expect(result.error!.code).toBe('SYMLINK_ESCAPE');
+    expect(result.error!.message).toContain(extraDir);
+  });
+
+  it('accepts a symlink in one allowed root that targets another allowed root', async () => {
+    const target = join(extraDir, 'contract.pdf');
+    await writeFile(target, 'data');
+    const link = join(workDir, 'contract.pdf');
+    if (!(await trySymlink(target, link))) return;
+
+    const result = await assertPathInSafeDir(
+      'contract.pdf',
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.resolved!.endsWith(`${sep}contract.pdf`)).toBe(true);
+  });
+
+  it('canonicalizes an allowed root that is itself a symlink', async () => {
+    const realRoot = join(root, 'real-root');
+    await mkdir(realRoot, { recursive: true });
+    await writeFile(join(realRoot, 'contract.pdf'), 'data');
+    const linkedRoot = join(root, 'linked-root');
+    if (!(await trySymlink(realRoot, linkedRoot))) return;
+
+    const result = await assertPathInSafeDir(
+      join(linkedRoot, 'contract.pdf'),
+      { safeDir: workDir, allowedDirs: [linkedRoot] },
+      'attachment path',
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.resolved).toContain('real-root');
+  });
+
+  it('still rejects `..` traversal out of an allowed root', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret');
+    const result = await assertPathInSafeDir(
+      join(extraDir, '..', 'outside', 'secret.txt'),
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+    expect(result.error!.code).toBe('PATH_TRAVERSAL');
+  });
+
+  it('rejects a sibling directory whose name merely prefixes an allowed root', async () => {
+    const evil = `${extraDir}-evil`;
+    await mkdir(evil, { recursive: true });
+    await writeFile(join(evil, 'secret.txt'), 'secret');
+
+    const result = await assertPathInSafeDir(
+      join(evil, 'secret.txt'),
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+
+    expect(result.error!.code).toBe('PATH_TRAVERSAL');
+  });
+
+  it('reports FILE_NOT_FOUND when the path is allowed but absent', async () => {
+    const result = await assertPathInSafeDir(
+      join(extraDir, 'missing.pdf'),
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+    expect(result.error!.code).toBe('FILE_NOT_FOUND');
+  });
+
+  it('falls through to a later root when a relative path is missing in the first', async () => {
+    await writeFile(join(extraDir, 'contract.pdf'), 'data');
+    const result = await assertPathInSafeDir(
+      'contract.pdf',
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.resolved).toContain('extra');
+  });
+
+  it('prefers the safe directory over a later root for the same relative path', async () => {
+    await writeFile(join(workDir, 'contract.pdf'), 'work copy');
+    await writeFile(join(extraDir, 'contract.pdf'), 'extra copy');
+    const result = await assertPathInSafeDir(
+      'contract.pdf',
+      { safeDir: workDir, allowedDirs: [extraDir] },
+      'attachment path',
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.resolved).toContain('work');
+  });
+});
+
+describe('content/safe-path — parseAllowedDirs', () => {
+  it('returns no roots when unset or empty', () => {
+    expect(parseAllowedDirs(undefined).dirs).toEqual([]);
+    expect(parseAllowedDirs('').dirs).toEqual([]);
+    expect(parseAllowedDirs(delimiter + delimiter).dirs).toEqual([]);
+  });
+
+  it('splits on the platform delimiter, trims, and deduplicates', () => {
+    const raw = [` ${workDir} `, extraDir, workDir].join(delimiter);
+    expect(parseAllowedDirs(raw).dirs).toEqual([workDir, extraDir]);
+  });
+
+  it('expands a leading ~ against the home directory', () => {
+    const { dirs } = parseAllowedDirs(`~/Downloads${delimiter}~`, { home: '/home/agent' });
+    expect(dirs).toEqual([join('/home/agent', 'Downloads'), '/home/agent']);
+  });
+
+  it('drops non-absolute entries with a warning', () => {
+    const { dirs, warnings } = parseAllowedDirs(`relative/dir${delimiter}${extraDir}`);
+    expect(dirs).toEqual([extraDir]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('relative/dir');
+    expect(warnings[0]).toContain(ALLOWED_DIRS_ENV);
+  });
+});

--- a/packages/email-core/src/content/safe-path.ts
+++ b/packages/email-core/src/content/safe-path.ts
@@ -1,9 +1,14 @@
 // Shared sandbox policy for file reads (body_file, attachment paths).
-// Resolves a caller-supplied path against a safe base directory and rejects
-// path traversal and symlink escapes. Used by body-loader and
-// attachment-loader so both file-read surfaces share one policy.
+// Resolves a caller-supplied path against the safe base directory — plus any
+// operator-allowlisted extra roots — and rejects path traversal and symlink
+// escapes. Used by body-loader and attachment-loader so both file-read
+// surfaces share one policy.
 import { realpath } from 'node:fs/promises';
-import { resolve, relative, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
+import { resolve, relative, isAbsolute, delimiter, normalize } from 'node:path';
+
+/** Env var that adds trusted roots beyond the safe base directory. */
+export const ALLOWED_DIRS_ENV = 'AGENT_EMAIL_ALLOWED_DIRS';
 
 export interface SafePathError {
   code: string;
@@ -16,6 +21,18 @@ export interface SafePathResult {
   error?: SafePathError;
 }
 
+/**
+ * Filesystem sandbox for caller-supplied paths: the primary root that relative
+ * paths resolve against, plus extra operator-allowlisted roots. A bare string
+ * is accepted as shorthand for `{ safeDir }`.
+ */
+export interface PathSandbox {
+  safeDir?: string;
+  allowedDirs?: readonly string[];
+}
+
+export type PathSandboxInput = string | PathSandbox | undefined;
+
 /** True when `target` is `base` itself or a descendant of it. */
 function isWithin(base: string, target: string): boolean {
   if (target === base) return true;
@@ -23,70 +40,157 @@ function isWithin(base: string, target: string): boolean {
   return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
+/** Canonicalize a root, falling back to the literal path when it does not exist. */
+async function canonicalize(dir: string): Promise<string> {
+  try {
+    return await realpath(dir);
+  } catch {
+    return dir;
+  }
+}
+
 /**
- * Resolve `filePath` within `safeDir` and verify it does not escape that
- * directory via `..` segments, an absolute path, or a symlink (leaf OR an
- * ancestor directory). Both the base directory and the fully resolved target
- * are canonicalized with `realpath` before the containment check, so a
- * symlink anywhere in the chain that points outside the sandbox is caught —
- * and the comparison is a true path-segment containment test, not a string
- * prefix (so a sibling like `<safeDir>-evil` cannot pass).
+ * Parse a delimiter-separated list of extra allowed roots (the
+ * `AGENT_EMAIL_ALLOWED_DIRS` env var). Entries are split on the platform path
+ * delimiter (`:` on POSIX, `;` on Windows), trimmed, `~`-expanded, and
+ * deduplicated. Non-absolute entries are dropped with a warning rather than
+ * silently resolved against the process working directory, since an operator
+ * writing a relative root almost certainly means a different directory than
+ * whatever cwd the server happens to start in.
+ */
+export function parseAllowedDirs(
+  raw: string | undefined,
+  opts?: { home?: string },
+): { dirs: string[]; warnings: string[] } {
+  const home = opts?.home ?? homedir();
+  const dirs: string[] = [];
+  const warnings: string[] = [];
+
+  for (const entry of (raw ?? '').split(delimiter)) {
+    const trimmed = entry.trim();
+    if (trimmed === '') continue;
+
+    const expanded =
+      trimmed === '~' ? home
+      : trimmed.startsWith('~/') ? resolve(home, trimmed.slice(2))
+      : trimmed;
+
+    if (!isAbsolute(expanded)) {
+      warnings.push(`ignoring non-absolute ${ALLOWED_DIRS_ENV} entry: ${trimmed}`);
+      continue;
+    }
+
+    const normalized = normalize(expanded);
+    if (!dirs.includes(normalized)) dirs.push(normalized);
+  }
+
+  return { dirs, warnings };
+}
+
+/** Normalize the sandbox shorthand into an ordered, deduplicated root list. */
+function rootsOf(sandbox: PathSandboxInput): string[] {
+  const { safeDir, allowedDirs } =
+    typeof sandbox === 'string' ? { safeDir: sandbox, allowedDirs: undefined } : (sandbox ?? {});
+
+  const roots = [resolve(safeDir ?? process.cwd())];
+  for (const dir of allowedDirs ?? []) {
+    const resolved = resolve(dir);
+    if (!roots.includes(resolved)) roots.push(resolved);
+  }
+  return roots;
+}
+
+/**
+ * Resolve `filePath` within the sandbox and verify it does not escape via `..`
+ * segments, an absolute path outside every root, or a symlink (leaf OR an
+ * ancestor directory). Roots are tried in order — the safe base directory
+ * first, then each configured extra root — and the first containment match
+ * wins. Both every root and the fully resolved target are canonicalized with
+ * `realpath` before the containment check, so a symlink anywhere in the chain
+ * that points outside every root is caught — and the comparison is a true
+ * path-segment containment test, not a string prefix (so a sibling like
+ * `<safeDir>-evil` cannot pass).
+ *
+ * A symlink that lands inside *another* allowlisted root is accepted: the
+ * operator has already declared that directory trusted, so which root the
+ * caller entered through does not change what they are permitted to read.
  *
  * `fieldName` is interpolated into error messages (e.g. "body_file",
  * "attachment path") so callers get a field-specific message.
  */
 export async function assertPathInSafeDir(
   filePath: string,
-  safeDir: string | undefined,
+  sandbox: PathSandboxInput,
   fieldName: string,
 ): Promise<SafePathResult> {
-  const baseDir = resolve(safeDir ?? process.cwd());
-  const resolved = resolve(baseDir, filePath);
+  const roots = rootsOf(sandbox);
+  const scope =
+    roots.length === 1 ? 'the working directory' : 'an allowed directory';
+  const traversalError = (): SafePathResult => ({
+    error: {
+      code: 'PATH_TRAVERSAL',
+      message: `${fieldName} must be within ${scope}${rootsHint(roots)}`,
+      recoverable: false,
+    },
+  });
 
   // Cheap literal pre-check before touching the filesystem.
-  if (filePath.includes('..') || !isWithin(baseDir, resolved)) {
-    return {
-      error: {
-        code: 'PATH_TRAVERSAL',
-        message: `${fieldName} must be within the working directory`,
-        recoverable: false,
-      },
-    };
+  if (filePath.includes('..')) return traversalError();
+
+  const candidates = roots
+    .map(root => ({ root, target: resolve(root, filePath) }))
+    .filter(({ root, target }) => isWithin(root, target));
+  if (candidates.length === 0) return traversalError();
+
+  const realRoots = await Promise.all(roots.map(canonicalize));
+
+  let sawEscape = false;
+  for (const { target } of candidates) {
+    // Canonicalize the target — realpath resolves every symlink in the path,
+    // so a leaf or intermediate-directory symlink escape surfaces here.
+    let realTarget: string;
+    try {
+      realTarget = await realpath(target);
+    } catch {
+      continue; // Missing under this root; a later root may still hold it.
+    }
+
+    // Roots are canonicalized too — a sandbox root may itself live under a
+    // symlink (e.g. macOS /var → /private/var), so both sides must be real.
+    if (realRoots.some(realRoot => isWithin(realRoot, realTarget))) {
+      return { resolved: realTarget };
+    }
+    sawEscape = true;
   }
 
-  // Canonicalize the target — realpath resolves every symlink in the path,
-  // so a leaf or intermediate-directory symlink escape surfaces here.
-  let realResolved: string;
-  try {
-    realResolved = await realpath(resolved);
-  } catch {
-    return {
-      error: {
-        code: 'FILE_NOT_FOUND',
-        message: `${fieldName} not found: ${filePath}`,
-        recoverable: false,
-      },
-    };
-  }
-
-  // Canonicalize the base too — the sandbox root itself may live under a
-  // symlink (e.g. macOS /var → /private/var), so both sides must be real.
-  let realBase: string;
-  try {
-    realBase = await realpath(baseDir);
-  } catch {
-    realBase = baseDir;
-  }
-
-  if (!isWithin(realBase, realResolved)) {
+  if (sawEscape) {
+    const escaped =
+      roots.length === 1 ? 'working directory' : 'the allowed directories';
     return {
       error: {
         code: 'SYMLINK_ESCAPE',
-        message: `${fieldName} symlink targets outside working directory`,
+        message: `${fieldName} symlink targets outside ${escaped}${rootsHint(roots)}`,
         recoverable: false,
       },
     };
   }
 
-  return { resolved: realResolved };
+  return {
+    error: {
+      code: 'FILE_NOT_FOUND',
+      message: `${fieldName} not found: ${filePath}`,
+      recoverable: false,
+    },
+  };
+}
+
+/**
+ * Trailing hint naming every root the path was checked against, plus the env
+ * var that widens the sandbox. A bare "must be within the working directory"
+ * gave no indication that configuration could permit the path, leaving callers
+ * to guess (or to stage confidential files inside the working directory).
+ */
+function rootsHint(roots: string[]): string {
+  const tried = roots.length === 1 ? roots[0] : `tried: ${roots.join(', ')}`;
+  return ` (${tried}); set ${ALLOWED_DIRS_ENV} to allow other directories`;
 }

--- a/packages/email-core/src/content/safe-path.ts
+++ b/packages/email-core/src/content/safe-path.ts
@@ -5,7 +5,7 @@
 // surfaces share one policy.
 import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { resolve, relative, isAbsolute, delimiter, normalize } from 'node:path';
+import { resolve, relative, isAbsolute, delimiter } from 'node:path';
 
 /** Env var that adds trusted roots beyond the safe base directory. */
 export const ALLOWED_DIRS_ENV = 'AGENT_EMAIL_ALLOWED_DIRS';
@@ -80,7 +80,9 @@ export function parseAllowedDirs(
       continue;
     }
 
-    const normalized = normalize(expanded);
+    // `resolve` on an already-absolute path only normalizes it — collapsing
+    // `.` segments and a trailing slash — so `/a/b/` and `/a/b` dedupe.
+    const normalized = resolve(expanded);
     if (!dirs.includes(normalized)) dirs.push(normalized);
   }
 

--- a/packages/email-core/src/content/safe-path.ts
+++ b/packages/email-core/src/content/safe-path.ts
@@ -3,12 +3,22 @@
 // operator-allowlisted extra roots — and rejects path traversal and symlink
 // escapes. Used by body-loader and attachment-loader so both file-read
 // surfaces share one policy.
+import { constants as fsConstants } from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { resolve, relative, isAbsolute, delimiter } from 'node:path';
 
 /** Env var that adds trusted roots beyond the safe base directory. */
 export const ALLOWED_DIRS_ENV = 'AGENT_EMAIL_ALLOWED_DIRS';
+
+/**
+ * Open flags for a path already validated by `assertPathInSafeDir`. The
+ * returned path is canonical, so its leaf is not a symlink — `O_NOFOLLOW`
+ * therefore rejects nothing legitimate, and closes the window in which the
+ * leaf is swapped for a symlink between validation and open. Windows has no
+ * `O_NOFOLLOW`; there the flags degrade to a plain read.
+ */
+export const SAFE_READ_FLAGS = fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0);
 
 export interface SafePathError {
   code: string;
@@ -40,12 +50,17 @@ function isWithin(base: string, target: string): boolean {
   return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 }
 
-/** Canonicalize a root, falling back to the literal path when it does not exist. */
-async function canonicalize(dir: string): Promise<string> {
+/**
+ * Canonicalize a root, or `null` when it cannot be resolved (missing,
+ * unreadable, or an I/O error). Fails closed: a root we cannot canonicalize is
+ * dropped from the authorization set rather than falling back to its literal
+ * path, so an unresolvable root never authorizes a read.
+ */
+async function canonicalize(dir: string): Promise<string | null> {
   try {
     return await realpath(dir);
   } catch {
-    return dir;
+    return null;
   }
 }
 
@@ -72,7 +87,7 @@ export function parseAllowedDirs(
 
     const expanded =
       trimmed === '~' ? home
-      : trimmed.startsWith('~/') ? resolve(home, trimmed.slice(2))
+      : trimmed.startsWith('~/') || trimmed.startsWith('~\\') ? resolve(home, trimmed.slice(2))
       : trimmed;
 
     if (!isAbsolute(expanded)) {
@@ -105,13 +120,20 @@ function rootsOf(sandbox: PathSandboxInput): string[] {
 /**
  * Resolve `filePath` within the sandbox and verify it does not escape via `..`
  * segments, an absolute path outside every root, or a symlink (leaf OR an
- * ancestor directory). Roots are tried in order — the safe base directory
- * first, then each configured extra root — and the first containment match
- * wins. Both every root and the fully resolved target are canonicalized with
- * `realpath` before the containment check, so a symlink anywhere in the chain
- * that points outside every root is caught — and the comparison is a true
- * path-segment containment test, not a string prefix (so a sibling like
- * `<safeDir>-evil` cannot pass).
+ * ancestor directory). A RELATIVE path resolves against the safe base
+ * directory only; an ABSOLUTE path is checked against every root in order and
+ * the first containment match wins. Every root and the fully resolved target
+ * are canonicalized with `realpath` before the containment check, so a symlink
+ * anywhere in the chain that points outside every root is caught — and the
+ * comparison is a true path-segment containment test, not a string prefix (so
+ * a sibling like `<safeDir>-evil` cannot pass). A root that cannot be
+ * canonicalized authorizes nothing.
+ *
+ * Note the residual TOCTOU window: this returns a canonical *pathname* that
+ * the caller then opens. The leaf cannot be swapped for a symlink (callers
+ * open with `O_NOFOLLOW`), but an ancestor directory inside a root could be
+ * replaced between validation and open. Allowlisted roots and their ancestors
+ * must therefore not be writable by untrusted principals.
  *
  * A symlink that lands inside *another* allowlisted root is accepted: the
  * operator has already declared that directory trusted, so which root the
@@ -139,12 +161,20 @@ export async function assertPathInSafeDir(
   // Cheap literal pre-check before touching the filesystem.
   if (filePath.includes('..')) return traversalError();
 
-  const candidates = roots
+  // A relative path resolves against the safe directory ONLY. Searching every
+  // allowed root for a bare filename would make `contract.pdf` silently attach
+  // whichever copy happened to exist first — ambient basename lookup, not path
+  // resolution. Extra roots are reachable by absolute path.
+  const searchRoots = isAbsolute(filePath) ? roots : roots.slice(0, 1);
+
+  const candidates = searchRoots
     .map(root => ({ root, target: resolve(root, filePath) }))
     .filter(({ root, target }) => isWithin(root, target));
   if (candidates.length === 0) return traversalError();
 
-  const realRoots = await Promise.all(roots.map(canonicalize));
+  const realRoots = (await Promise.all(roots.map(canonicalize))).filter(
+    (real): real is string => real !== null,
+  );
 
   let sawEscape = false;
   for (const { target } of candidates) {
@@ -154,7 +184,7 @@ export async function assertPathInSafeDir(
     try {
       realTarget = await realpath(target);
     } catch {
-      continue; // Missing under this root; a later root may still hold it.
+      continue; // Missing under this root; another candidate may still hold it.
     }
 
     // Roots are canonicalized too — a sandbox root may itself live under a

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -107,6 +107,8 @@ export {
 export { parseFrontmatter } from './content/frontmatter.js';
 export type { FrontmatterFields } from './content/frontmatter.js';
 export { resolveBodyFile, truncateBody, BODY_SIZE_LIMIT } from './content/body-loader.js';
+export { parseAllowedDirs, ALLOWED_DIRS_ENV } from './content/safe-path.js';
+export type { PathSandbox, PathSandboxInput } from './content/safe-path.js';
 export {
   checkMailboxRequired,
   resolveComposeFields,

--- a/packages/email-mcp/src/server.test.ts
+++ b/packages/email-mcp/src/server.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
@@ -2549,5 +2552,94 @@ describe('mailbox-config/Mailbox Names Are Round-Trippable Selectors', () => {
     expect(retried.error?.code).not.toBe('MAILBOX_REQUIRED');
     expect(personalCreate).toHaveBeenCalledTimes(1);
     expect(workCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe('mcp-transport/Allowed attachment roots wiring', () => {
+  // Issue #105 — the sandbox widening is operator-configured, so the env var
+  // must actually reach ActionContext. A unit test of the parser alone would
+  // pass even if the server never wired it up.
+  const withAllowedDirs = async <T>(value: string, run: () => Promise<T>): Promise<T> => {
+    const previous = process.env['AGENT_EMAIL_ALLOWED_DIRS'];
+    process.env['AGENT_EMAIL_ALLOWED_DIRS'] = value;
+    try {
+      return await run();
+    } finally {
+      if (previous === undefined) delete process.env['AGENT_EMAIL_ALLOWED_DIRS'];
+      else process.env['AGENT_EMAIL_ALLOWED_DIRS'] = previous;
+    }
+  };
+
+  const connectedState = (sendMessage: (msg: unknown) => Promise<unknown>) => {
+    const state = createLazyProviderState();
+    state.status = 'connected';
+    state.initPromise = Promise.resolve();
+    state.mailboxes = [{
+      name: 'work',
+      emailAddress: 'me@company.com',
+      displayName: 'work',
+      providerType: 'microsoft',
+      provider: { sendMessage } as never,
+      auth: null,
+      isDefault: true,
+      status: 'connected',
+    }];
+    return state;
+  };
+
+  it('attaches a file from an AGENT_EMAIL_ALLOWED_DIRS root', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mcp-allowed-root-'));
+    const pdf = Buffer.from('%PDF-1.4\n1 0 obj<<>>endobj\n', 'utf-8');
+    await writeFile(join(dir, 'contract.pdf'), pdf);
+    const sendMessage = vi.fn(async () => ({ success: true, messageId: 'sent-1' }));
+
+    try {
+      const result = await withAllowedDirs(dir, async () => {
+        const actions = await buildLazyActions(connectedState(sendMessage), () => ({ entries: ['*'] }));
+        const send = actions.find(a => a.name === 'send_email')!;
+        return await send.run({}, {
+          to: 'alice@example.com',
+          subject: 'Contract',
+          body: 'Attached.',
+          attachments: [{ path: join(dir, 'contract.pdf') }],
+        }) as { success: boolean; error?: { code: string; message: string } };
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      const sent = sendMessage.mock.calls[0]![0] as { attachments?: { filename: string; content: Buffer }[] };
+      expect(sent.attachments![0]!.filename).toBe('contract.pdf');
+      expect(sent.attachments![0]!.content.equals(pdf)).toBe(true);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the same path when the env var is unset, and warns on relative entries', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mcp-unallowed-root-'));
+    await writeFile(join(dir, 'contract.pdf'), Buffer.from('%PDF-1.4\n', 'utf-8'));
+    const sendMessage = vi.fn(async () => ({ success: true, messageId: 'sent-1' }));
+    const stderr = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await withAllowedDirs('relative/dir', async () => {
+        const actions = await buildLazyActions(connectedState(sendMessage), () => ({ entries: ['*'] }));
+        const send = actions.find(a => a.name === 'send_email')!;
+        return await send.run({}, {
+          to: 'alice@example.com',
+          subject: 'Contract',
+          body: 'Attached.',
+          attachments: [{ path: join(dir, 'contract.pdf') }],
+        }) as { success: boolean; error?: { code: string; message: string } };
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error!.code).toBe('PATH_TRAVERSAL');
+      expect(sendMessage).not.toHaveBeenCalled();
+      expect(stderr.mock.calls.flat().join(' ')).toContain('ignoring non-absolute AGENT_EMAIL_ALLOWED_DIRS entry');
+    } finally {
+      stderr.mockRestore();
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -10,6 +10,8 @@ import {
   filterActionsForProfile,
   getEmailScopeProfile,
   profileBlockedActionError,
+  parseAllowedDirs,
+  ALLOWED_DIRS_ENV,
 } from '@usejunior/email-core';
 import { z } from 'zod';
 
@@ -713,6 +715,14 @@ export async function buildLazyActions(
   // the boundary is intentional and operator-overridable rather than an
   // implicit process.cwd() fallback inside the file loaders.
   const safeDir = process.env.EMAIL_MCP_SAFE_DIR || process.cwd();
+  // Extra trusted roots (e.g. ~/Downloads, a cloud-storage mount) so operators
+  // can attach files that live outside the working directory without staging
+  // confidential documents inside a git working tree. Unset means today's
+  // single-root behavior.
+  const { dirs: allowedDirs, warnings } = parseAllowedDirs(process.env[ALLOWED_DIRS_ENV]);
+  for (const warning of warnings) {
+    console.error(`[email-agent-mcp] ${warning}`);
+  }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const wrapAction = (action: EmailAction<any, any>): EmailActionDef => ({
@@ -737,6 +747,7 @@ export async function buildLazyActions(
           allMailboxes: resolved.allMailboxes,
           sendAllowlist: getSendAllowlist(),
           safeDir,
+          allowedDirs,
           deleteEnabled: deletePolicy?.enabled === true,
           hardDeleteAllowed: deletePolicy?.hardDeleteAllowed === true,
         };

--- a/packages/email-mcp/src/server.ts
+++ b/packages/email-mcp/src/server.ts
@@ -1,4 +1,5 @@
 // MCP server — thin transport adapter mapping action registry to MCP tools
+import { stat } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import type { DeletePolicy, EmailAction, EmailMessage, EmailProvider } from '@usejunior/email-core';
 import {
@@ -722,6 +723,20 @@ export async function buildLazyActions(
   const { dirs: allowedDirs, warnings } = parseAllowedDirs(process.env[ALLOWED_DIRS_ENV]);
   for (const warning of warnings) {
     console.error(`[email-agent-mcp] ${warning}`);
+  }
+  // Surface roots that cannot authorize anything at startup rather than only
+  // as a confusing per-call FILE_NOT_FOUND. Kept in the list either way — a
+  // mount may appear later — but the sandbox fails closed on any root it
+  // cannot canonicalize at read time.
+  for (const dir of allowedDirs) {
+    void stat(dir).then(
+      info => {
+        if (!info.isDirectory()) {
+          console.error(`[email-agent-mcp] ${ALLOWED_DIRS_ENV} entry is not a directory: ${dir}`);
+        }
+      },
+      () => console.error(`[email-agent-mcp] ${ALLOWED_DIRS_ENV} entry is not readable: ${dir}`),
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Closes #105.

## Problem

`body_file` and `attachments[].path` resolved against a single root (`EMAIL_MCP_SAFE_DIR`, default cwd) with no opt-in escape hatch. Attaching a document from `~/Downloads`, a cloud-storage mount, or a shared drive left two options: inline it as `base64` (pushing hundreds of KB of encoded text through the agent's context), or copy it into the working directory — which routinely means staging a confidential document inside a git working tree. The second failure mode is worse than the one the sandbox prevents.

The sandbox itself stays as the default: without containment, an unrestricted `path` would let a restricted agent read files through the server it could not read directly (confused deputy).

## Change

`AGENT_EMAIL_ALLOWED_DIRS` — a delimiter-separated list of absolute directories (`:` on POSIX, `;` on Windows, leading `~` expanded) that both file-read surfaces may also resolve within.

- **Relative paths resolve against the safe directory only.** Extra roots are reached by absolute path, so a bare `contract.pdf` can never silently pick up a different copy from another root.
- **Absolute paths** are checked against each root in order — safe directory first — first containment match wins.
- **Every root is canonicalized with `realpath`** before containment; a root that cannot be canonicalized authorizes nothing (no literal fallback). A symlink escaping every root is still `SYMLINK_ESCAPE`; a symlink landing inside another allowlisted root resolves, since the operator already trusts that directory.
- **Validated files are opened with `O_NOFOLLOW`** on both surfaces (`body_file` now reads through a descriptor, matching the attachment loader), closing the leaf-swap window between validation and open.
- **Rejections name the roots tried** and the env var that widens them — the old "must be within the working directory" gave no hint that configuration could permit the path.
- Unset configuration preserves today's behavior exactly.

Security contract, documented in the README: allowlisting a directory trusts everyone who can write to it. Validation and open are separate pathname operations, so a principal able to replace a directory *inside* an allowed root between the two can still redirect the read — only allowlist roots whose ancestors are not writable by untrusted users.

## Verification

`npm run build`, `npm run lint`, `npm run test:run` (all workspaces green), `npm run check:spec-coverage` (287/287), `npx openspec validate add-allowed-attachment-dirs --strict`.

New coverage: resolution inside an allowed root, rejection outside every root, symlink escape, symlinked roots, cross-root symlinks, sibling-prefix rejection, unresolvable roots, relative-path scoping, unset-config default, env parsing (delimiter/`~`/`~\`/absolute-only/dedupe), and MCP wiring proving the env var reaches `ActionContext`.

Peer-reviewed by Codex (dynamic review, ran the suite); its findings on relative-path fallthrough, the canonicalization fallback, the TOCTOU boundary, and a title-only spec-coverage match are addressed in the second commit.

## Note on naming

I used `AGENT_EMAIL_ALLOWED_DIRS` rather than the issue's suggested `EMAIL_AGENT_ATTACHMENT_DIRS`: the repo's dominant convention is `AGENT_EMAIL_*`, and the setting governs `body_file` as well as attachments. Easy to rename before release if you'd rather match the issue text — env var names are hard to migrate later.