### PR TITLE
chore(release): bump workspace versions to 0.3.0

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -5927,10 +5927,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.2.0"
+        "@usejunior/email-mcp": "^0.3.0"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -5941,10 +5941,10 @@
     },
     "packages/email-agent-mcp-scoped": {
       "name": "@usejunior/email-agent-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "email-agent-mcp": "0.2.0"
+        "email-agent-mcp": "0.3.0"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -5955,7 +5955,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "^18.0.0",
@@ -5974,14 +5974,14 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.2.0",
-        "@usejunior/provider-gmail": "^0.2.0",
-        "@usejunior/provider-microsoft": "^0.2.0"
+        "@usejunior/email-core": "^0.3.0",
+        "@usejunior/provider-gmail": "^0.3.0",
+        "@usejunior/provider-microsoft": "^0.3.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5995,11 +5995,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.2.0",
+        "@usejunior/email-core": "^0.3.0",
         "google-auth-library": "^8.9.0"
       },
       "devDependencies": {
@@ -6014,13 +6014,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.2.0"
+        "@usejunior/email-core": "^0.3.0"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 and manual-token Gmail setup",
   "type": "module",

--- a/packages/email-agent-mcp-scoped/package.json
+++ b/packages/email-agent-mcp-scoped/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-agent-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Compatibility package for email-agent-mcp — use the unscoped package for new installations",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "email-agent-mcp": "0.2.0"
+    "email-agent-mcp": "0.3.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook and manual-token Gmail setup",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.2.0"
+    "@usejunior/email-mcp": "^0.3.0"
   },
   "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -21,9 +21,9 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.2.0",
-    "@usejunior/provider-gmail": "^0.2.0",
-    "@usejunior/provider-microsoft": "^0.2.0"
+    "@usejunior/email-core": "^0.3.0",
+    "@usejunior/provider-gmail": "^0.3.0",
+    "@usejunior/provider-microsoft": "^0.3.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.2.0",
+    "@usejunior/email-core": "^0.3.0",
     "google-auth-library": "^8.9.0"
   },
   "devDependencies": {

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.2.0"
+    "@usejunior/email-core": "^0.3.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
Version bump for the 0.3.0 release. Minor, not patch: #193 adds a new operator-configured capability (`AGENT_EMAIL_ALLOWED_DIRS`), with existing behavior unchanged when the variable is unset.

## Shipping in 0.3.0

- **#193** — `feat(security)`: opt-in escape hatch for the attachment / `body_file` path sandbox. Operators can allowlist extra absolute roots so agents attach documents from `~/Downloads` or a shared mount instead of staging confidential files inside a git working tree. Closes #105.
- **#194** — `fix(draft)`: derive reply recipients when `to` is omitted. Closes #192.

Both merged with passing post-merge smokes.

## Bumped

All six published packages (`email-core`, `provider-microsoft`, `provider-gmail`, `email-mcp`, `email-agent-mcp`, `@usejunior/email-agent-mcp`), the root `package.json`, `gemini-extension.json`, `packages/email-agent-mcp/server.json` (both the top-level and `packages[0]` version), the scoped compat package's exact `email-agent-mcp` pin, and the lockfile.

Lockfile diff is version-only (15 lines) — the scoped package pins the unscoped one by exact version, so missing that pin would have dragged published 0.2.0 tarballs into a nested `node_modules`.

## Preflight run locally

`npm run build`, `npm run lint`, `npm run test:run`, `check:spec-coverage` (290/290), `check:server-json` (`PASS … match canonical package.json (0.3.0)`), `check:gemini-extension-manifest` — all clean, mirroring the gates in `release.yml`.

Tag `v0.3.0` goes up once this lands.