### PR TITLE
docs(security): spell out how caller paths resolve against allowed roots

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,15 +394,28 @@ directories (`:` on macOS/Linux, `;` on Windows; a leading `~` is expanded) that
 }
 ```
 
-A **relative** path resolves against `EMAIL_MCP_SAFE_DIR` only — allowed
-directories are reached by **absolute** path, so a bare `contract.pdf` can never
-silently pick up a different file from another root. Each root is canonicalised
-with `realpath` before the containment check: an allowlisted root that is itself
-a symlink resolves to its real location, a root that cannot be canonicalised
-authorises nothing, and a symlink escaping every root is still rejected. Unset
-(the default) keeps the working directory as the only root — which is why an
-agent that cannot reach a file should ask you to allowlist its directory rather
-than copy confidential documents into a git working tree.
+**How a caller's path is resolved** — the two rules below both surface as
+`FILE_NOT_FOUND`, which is easy to misread as a missing file:
+
+| Path you pass | Resolves against | Finds a file in an allowed root? |
+|---|---|---|
+| `contract.pdf` | `EMAIL_MCP_SAFE_DIR` (default: cwd) | ❌ relative paths never search the extra roots |
+| `~/Downloads/contract.pdf` | `EMAIL_MCP_SAFE_DIR` — the `~` is **not** expanded | ❌ |
+| `/Users/you/Downloads/contract.pdf` | each root in turn | ✅ |
+
+The `~` shorthand is expanded in `AGENT_EMAIL_ALLOWED_DIRS` (the operator's
+config) but **not** in `attachments[].path` or `body_file` (the caller's
+argument) — pass those as absolute paths. And a relative path is deliberately
+confined to the safe directory: searching every allowed root for a bare
+`contract.pdf` would silently attach whichever copy happened to exist first.
+
+Each root is canonicalised with `realpath` before the containment check: an
+allowlisted root that is itself a symlink resolves to its real location, a root
+that cannot be canonicalised authorises nothing, and a symlink escaping every
+root is still rejected. Unset (the default) keeps the working directory as the
+only root — which is why an agent that cannot reach a file should ask you to
+allowlist its directory rather than copy confidential documents into a git
+working tree.
 
 Allowlisting a directory trusts everyone who can write to it. Validation and
 open are separate operations on a path, so a principal who can replace a

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -152,7 +152,7 @@ function isValidBase64(value: string): boolean {
 export const AttachmentInputSchema = z
   .object({
     path: z.string().optional()
-      .describe('Path to a file within the working directory, or within a directory the server operator allowlisted via AGENT_EMAIL_ALLOWED_DIRS (sandboxed, like body_file).'),
+      .describe('Path to a file, sandboxed like body_file. Relative paths resolve against the working directory only; files in a directory the operator allowlisted via AGENT_EMAIL_ALLOWED_DIRS must be given as an ABSOLUTE path (a leading ~ is not expanded here).'),
     base64: z.string().optional()
       .describe('Inline standard-base64-encoded file content. Alternative to path.'),
     filename: z.string().optional()

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -55,7 +55,8 @@ const CreateDraftInput = z.object({
   cc: z.array(z.string()).optional(),
   subject: z.string().optional(),
   body: z.string().optional(),
-  body_file: z.string().optional(),
+  body_file: z.string().optional()
+    .describe('Path to a .md/.html/.txt file to use as the body. Sandboxed like attachment paths: relative paths resolve against the working directory only; files in an AGENT_EMAIL_ALLOWED_DIRS root must be given as an ABSOLUTE path (a leading ~ is not expanded here).'),
   reply_to: z.string().optional(),
   reply_all: z.boolean().optional().default(true)
     .describe('Only relevant when reply_to is set. When false, the draft replies only to the original sender. Default true preserves reply-all behavior (cc the original thread).'),
@@ -361,7 +362,8 @@ const UpdateDraftInput = z.object({
   cc: z.array(z.string()).optional(),
   subject: z.string().optional(),
   body: z.string().optional(),
-  body_file: z.string().optional(),
+  body_file: z.string().optional()
+    .describe('Path to a .md/.html/.txt file to use as the body. Sandboxed like attachment paths: relative paths resolve against the working directory only; files in an AGENT_EMAIL_ALLOWED_DIRS root must be given as an ABSOLUTE path (a leading ~ is not expanded here).'),
   replace_body: z.boolean().optional()
     .describe('Required as true to replace the body of a non-reply draft wholesale. Reply draft bodies cannot be edited; create a new draft instead.'),
   include_quoted: z.boolean().optional().default(false)

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -30,7 +30,8 @@ const SendEmailInput = z.object({
   cc: z.array(z.string()).optional(),
   subject: z.string().optional(),
   body: z.string().optional(),
-  body_file: z.string().optional(),
+  body_file: z.string().optional()
+    .describe('Path to a .md/.html/.txt file to use as the body. Sandboxed like attachment paths: relative paths resolve against the working directory only; files in an AGENT_EMAIL_ALLOWED_DIRS root must be given as an ABSOLUTE path (a leading ~ is not expanded here).'),
   mailbox: z.string().optional(),
   draft: z.boolean().optional(),
   format: z.enum(['markdown', 'html', 'text']).optional()


### PR DESCRIPTION
Follow-up to #193. The allowlist works, but two path-form mistakes both surface as `FILE_NOT_FOUND` — which reads as "the file isn't there" rather than "you addressed it wrong":

1. A **relative** path never searches the extra roots (deliberate — searching every root for a bare `contract.pdf` would silently attach whichever copy existed first).
2. A leading `~` is expanded in `AGENT_EMAIL_ALLOWED_DIRS` (operator config) but **not** in `attachments[].path` / `body_file` (caller argument), so `~/Downloads/x.pdf` resolves under the working directory and misses.

Hit both while configuring a real install, hence the docs.

## Changes

- **README** — a table of the three path forms against what each resolves to, plus a sentence naming which side of the config boundary expands `~`.
- **Tool schema descriptions** — the same rule where an agent actually reads it, in `tools/list`. `attachments[].path` gets the absolute-path requirement stated explicitly; `body_file` had **no description at all** on `send_email`, `create_draft`, or `update_draft` and now carries it too.

No behavior change — description strings and prose only.

## Verification

`npm run build`, `npm run lint`, `npm run test:run`, `check:spec-coverage` (290/290), `check:server-json` — all clean.