### PR TITLE
docs(skills): scope the one-ask rule to cold outreach, and repair rule-guardrail citations

### DIFF
--- a/skills/email-cleanup/SKILL.md
+++ b/skills/email-cleanup/SKILL.md
@@ -50,7 +50,7 @@ requires:
       - permanentDelete
 metadata:
   author: UseJunior
-  version: "0.1.4"
+  version: "0.1.5"
 ---
 
 # Inbox Cleanup & Rules (Outlook)
@@ -71,7 +71,7 @@ Before you install or grant OAuth consent, understand where the safety boundary 
 
 ### What that means in practice
 
-- The blocked-actions list (`forwardTo`, `redirectTo`, `delete`, etc.) describes what a trusted runtime SHOULD reject. Whether those actions are actually rejected depends on the runtime. If you use [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), rejection is built into the action handler ([`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39)). If you use a raw Graph API client or a custom MCP without equivalent guards, the protections do not automatically apply.
+- The blocked-actions list (`forwardTo`, `redirectTo`, `delete`, etc.) describes what a trusted runtime SHOULD reject. Whether those actions are actually rejected depends on the runtime. If you use [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), rejection is built into the action handler ([`createInboxRuleAction` in `rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts)). If you use a raw Graph API client or a custom MCP without equivalent guards, the protections do not automatically apply.
 - `MailboxSettings.ReadWrite` is a high-risk scope because it controls inbox rules — and inbox rules can be configured to forward or redirect mail externally. Granting the scope without a runtime that enforces the blocked-actions list gives up the primary mitigation.
 - Autonomous invocation (where the agent runs this skill without per-call approval) is a platform-level setting, not something the skill controls. Combined with write scopes, it increases the surface area of any runtime weakness.
 
@@ -79,9 +79,9 @@ Before you install or grant OAuth consent, understand where the safety boundary 
 
 This skill requests a high-risk mailbox-rule permission (`MailboxSettings.ReadWrite`). Review the five items below before you grant consent. They are the exact things to check; the skill cannot enforce any of them for you.
 
-1. **Only grant `MailboxSettings.ReadWrite` if you trust the runtime** that will execute these instructions. The skill itself cannot enforce the blocked-actions list (`forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete`). Verify your runtime does.
+1. **Only grant `MailboxSettings.ReadWrite` if you trust the runtime** that will execute these instructions. The skill itself cannot refuse these actions — `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete` (refused against the runtime's `BLOCKED_ACTIONS` denylist) or `permanentDelete` (refused as an action outside the `SAFE_ACTIONS` allowlist). Verify your runtime does.
 2. **Prefer audit-only scopes** (`MailboxSettings.Read`) — or omit rule creation entirely — if you do not need automated rule management. Folder operations and batch moves work with just `Mail.ReadWrite`.
-3. **If you must grant full scopes, use a vetted runtime** that enforces blocking of forward/redirect/delete actions at the action handler. The reference runtime `email-agent-mcp` does this at [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39) — inspect the code yourself. Alternatively, add network-level protections (for example, NemoClaw) to block Graph endpoints that create dangerous rules.
+3. **If you must grant full scopes, use a vetted runtime** that enforces blocking of forward/redirect/delete actions at the action handler. The reference runtime `email-agent-mcp` does this in [`createInboxRuleAction` in `rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts) — inspect the code yourself. Alternatively, add network-level protections (for example, NemoClaw) to block Graph endpoints that create dangerous rules.
 4. **Test on a non-production account first.** Be prepared to revoke OAuth consent and invalidate refresh tokens at https://myaccount.microsoft.com/consent if anything looks wrong or misconfigured.
 5. **Avoid enabling autonomous invocation** for this skill unless you understand and trust the runtime's guardrails. Autonomous invocation combined with `MailboxSettings.ReadWrite` gives the agent the ability to create inbox rules without per-call user approval — only safe if the runtime enforces the blocked-actions list.
 
@@ -118,7 +118,7 @@ The reference runtime stores OAuth tokens in the OS keychain (macOS Keychain / W
 
 This skill is instruction-only — it cannot enforce any guardrails by itself. The protections below are provided by the **runtime** that actually executes the Graph API calls, not by this skill.
 
-If you use [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp) as the runtime, it blocks dangerous inbox rule actions at the action handler level — `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete` — and rejects any rule creation attempt that includes them. Source: [`packages/email-core/src/actions/rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39).
+If you use [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp) as the runtime, it refuses dangerous inbox rule actions at the action handler level. `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete` are matched against a `BLOCKED_ACTIONS` denylist and rejected with `UNSAFE_RULE_ACTION`; anything outside the `SAFE_ACTIONS` allowlist — `permanentDelete` among them — is rejected with `UNSUPPORTED_RULE_ACTION`. Either way the rule is not created. Source: [`createInboxRuleAction` in `rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts).
 
 If you use a different runtime (raw Graph API client, custom MCP server), these protections are NOT automatically present. You should either layer NemoClaw network policy, restrict OAuth scopes, or use a runtime that provides equivalent guardrails.
 
@@ -238,7 +238,7 @@ Always set `stopProcessingRules: true` on each rule to prevent cascade.
 
 Not all rule actions are safe. Agents should never create rules with the actions listed below. This skill is instruction-only — it cannot enforce these restrictions itself. The agent's runtime is what actually makes (or blocks) the API calls.
 
-If your runtime is [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), it rejects rule creation attempts that include any of these actions and returns a `BLOCKED_ACTION` error. Source: [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39). If you use a different runtime, you should verify it provides equivalent enforcement, or layer network-level controls (e.g. NemoClaw).
+If your runtime is [`email-agent-mcp`](https://github.com/UseJunior/email-agent-mcp), it rejects rule creation attempts that include any of these actions — `UNSAFE_RULE_ACTION` for the four on the `BLOCKED_ACTIONS` denylist, `UNSUPPORTED_RULE_ACTION` for `permanentDelete`, which is refused as an action outside the `SAFE_ACTIONS` allowlist rather than named on the denylist. Source: [`createInboxRuleAction` in `rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts). If you use a different runtime, you should verify it provides equivalent enforcement, or layer network-level controls (e.g. NemoClaw).
 
 **Block these actions:**
 

--- a/skills/email-drafting/SKILL.md
+++ b/skills/email-drafting/SKILL.md
@@ -13,7 +13,7 @@ compatibility: >-
   and thread detection.
 metadata:
   author: UseJunior
-  version: "0.1.1"
+  version: "0.1.2"
 ---
 
 # Email Response Drafting
@@ -73,12 +73,21 @@ If the original message cannot be found, tell the user rather than silently crea
 
 **MCP**: `reply_to_email` handles threading automatically.
 
-## Structure: One Ask Per Email
+## Structure: How Many Asks?
 
-Every email should have exactly one clear action item. If you need multiple things, either:
+**Unsolicited cold outreach: one primary ask.** You have no relationship, the recipient owes you no reply, and every additional ask lowers the odds of getting one. If you need more than one thing, either:
 
 - Pick the most important one and save the rest for a follow-up
 - Use a numbered list where the first item is the ask and the rest are context
+
+**Transactional mail, and mail to anyone you already have a relationship with: every ask that is independently necessary.** The one-ask rule is a cold-outreach heuristic, not a general law. Applied to mail the recipient is already expecting, it causes the worse failure — a necessary question gets deferred to a follow-up, or pushed below the fold into supporting detail, where the recipient skims past the one thing that needed an answer. Trimming to hit a lower number costs a round trip and buys nothing.
+
+An ask belongs in the message when both of these hold:
+
+- **It is independently necessary** — you cannot proceed without the answer, and no other ask in the message already covers it.
+- **It is readily answerable** — the recipient can answer from what they already know, in a word or a sentence. If answering it means doing work you could have done yourself, it is not a question yet.
+
+Anything that fails those tests is not an ask. It is either an assumption you state and invite them to correct, or work you do before you write.
 
 **Structure template for action-needed replies:**
 

--- a/skills/outlook-email/SKILL.md
+++ b/skills/outlook-email/SKILL.md
@@ -63,7 +63,7 @@ requires:
     - calendar_integration
 metadata:
   author: UseJunior
-  version: "0.1.7"
+  version: "0.1.8"
 ---
 
 # Outlook Email Management
@@ -89,8 +89,8 @@ Why this matters: a single wrong send — wrong recipient, wrong attachment, con
 **email-agent-mcp** enforces this via concrete runtime guardrails:
 
 - **Empty send allowlist by default** — agents cannot send email until the user explicitly configures allowed recipients
-- **Action-level blocks** on dangerous inbox rule actions: `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete` ([rules.ts:39](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39))
-- **`delete_email` disabled by default** unless the caller explicitly opts in with `user_explicitly_requested_deletion: true` ([label.ts](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts))
+- **Action-level rejection of dangerous inbox rule actions** — `createInboxRuleAction` refuses `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete` against its `BLOCKED_ACTIONS` denylist, and refuses anything outside its `SAFE_ACTIONS` allowlist — `permanentDelete` among them — as an unsupported action ([`createInboxRuleAction` in `rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts))
+- **`delete_email` disabled by default** — `deleteEmailAction` requires *both* an operator-enabled delete policy (`AGENT_EMAIL_DELETE_ENABLED=true`) *and* a caller-supplied `user_explicitly_requested_deletion: true` ([`deleteEmailAction` in `label.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts))
 
 **NemoClaw** can enforce it at the network policy level — see the [NemoClaw Email Policy skill](#related-skills).
 
@@ -112,7 +112,7 @@ Before you install or grant OAuth consent, understand where the safety boundary 
 This skill requests high-impact Microsoft Graph scopes (`Mail.ReadWrite`, `MailboxSettings.ReadWrite`, optionally `Mail.Send`). Review the items below before you grant consent. They are the exact things to check; the skill cannot enforce any of them for you.
 
 1. **Only grant `Mail.Send` if you trust the runtime** to honor draft-first. The skill itself cannot enforce "draft first, send second" — that's a runtime property. Verify your runtime either (a) blocks direct send by default, or (b) is `email-agent-mcp` which ships with an empty send allowlist by default.
-2. **Only grant `MailboxSettings.ReadWrite` if you trust the runtime** to block dangerous rule actions (`forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete`). The reference runtime does this at [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39) — inspect the code yourself. Alternatively, prefer `MailboxSettings.Read` if rule auditing is all you need.
+2. **Only grant `MailboxSettings.ReadWrite` if you trust the runtime** to reject dangerous rule actions. The reference runtime does this in `createInboxRuleAction`: `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, and `delete` are refused against a `BLOCKED_ACTIONS` denylist, and any action outside the `SAFE_ACTIONS` allowlist — `permanentDelete` included — is refused as unsupported ([`createInboxRuleAction` in `rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts)) — inspect the code yourself. Alternatively, prefer `MailboxSettings.Read` if rule auditing is all you need.
 3. **Prefer least-privilege consent.** Start with `Mail.Read` + `offline_access` for read-only triage. Escalate to write scopes only as specific workflows require them. Skip `Mail.Send` entirely if draft-first (user sends manually from Outlook) is acceptable.
 4. **Review the client app identity.** Whatever `AGENT_EMAIL_CLIENT_ID` resolves to is the Azure AD application you are consenting to. Check the consent screen, verify the app name and publisher, and make sure the requested scopes match what you see in this document.
 5. **Test on a non-production account first.** Be prepared to revoke OAuth consent and invalidate refresh tokens at https://myaccount.microsoft.com/consent if anything looks wrong or misconfigured.
@@ -149,7 +149,7 @@ offline_access
 
 `User.Read` is requested by the reference runtime only — it is used by the CLI to fetch `/me` and persist the authenticated mailbox address to config. A generic Graph client does not need `User.Read` unless it performs the same profile lookup.
 
-Source: [`packages/provider-microsoft/src/auth.ts:14`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/provider-microsoft/src/auth.ts#L14)
+Source: the `GRAPH_SCOPES` constant in [`packages/provider-microsoft/src/auth.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/provider-microsoft/src/auth.ts)
 
 ### Token storage
 
@@ -176,7 +176,7 @@ Draft-first is the recommended workflow for all runtimes. Enforcement is layered
 
 | Layer | Enforcement mechanism |
 |-------|----------------------|
-| **Reference runtime (email-agent-mcp)** | Send allowlist empty by default. Action-level blocks on `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete`, `permanentDelete` in [`rules.ts:39`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts#L39). `delete_email` disabled by default in [`label.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts). |
+| **Reference runtime (email-agent-mcp)** | Send allowlist empty by default. `createInboxRuleAction` refuses `forwardTo`, `forwardAsAttachmentTo`, `redirectTo`, `delete` (`BLOCKED_ACTIONS` denylist) and `permanentDelete` (outside the `SAFE_ACTIONS` allowlist) in [`rules.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/rules.ts). `deleteEmailAction` has `delete_email` disabled by default in [`label.ts`](https://github.com/UseJunior/email-agent-mcp/blob/main/packages/email-core/src/actions/label.ts). |
 | **Network policy (NemoClaw)** | Can block `graph.microsoft.com/v1.0/me/sendMail` at the network layer via custom policy, eliminating send capability entirely |
 | **Raw Graph API client** | Instruction-level only. Relies on the agent honoring the draft-first instructions. **Not recommended for safety-critical use** — pair with one of the runtime layers above |
 
@@ -219,7 +219,7 @@ When drafting replies:
 
 - **Match the sender's tone** — if they wrote "Dear Steven," reply with "Dear [Name]," not "Hey!"
 - **State the outcome, not the journey** — "The document is ready for your review" beats "I processed the document through our pipeline and..."
-- **One clear ask per message** — don't bury the action item in paragraph three
+- **One primary ask on cold outreach** — don't bury the action item in paragraph three. In transactional or ongoing-relationship mail, keep every ask that is independently necessary and readily answerable (see `email-drafting`)
 - **Check threading** — if the subject has "Re:" or "RE:", find the original message and create a threaded reply, not a standalone draft
 
 **Formatting gotchas** agents get wrong:


### PR DESCRIPTION
# PR description (DRAFT — not opened, awaiting Steven's approval)

**Repo:** `UseJunior/email-agent-mcp` (public)
**Branch:** `docs/one-ask-cold-outbound-v2` (local only — not pushed)
**Commit:** `03e7204` · **Base:** `main` @ `058987b`
**Worktree:** `~/Projects/email-agent-mcp/.worktrees/one-ask-scope`

---

## Title

`docs(skills): scope the one-ask rule, and repair the rule-guardrail citations`

## What the rule was

`email-drafting` stated, without qualification:

> Every email should have exactly one clear action item.

`outlook-email` repeated it as a checklist line: *"One clear ask per message —
don't bury the action item in paragraph three."* Both were published that way to
ClawHub, so every consumer of these skills inherited it as a general law of
email.

## Why it was wrong

It is a **cold-outreach heuristic** presented as a universal rule. In cold
outbound the logic holds: you have no relationship, the recipient owes you no
reply, and each additional ask lowers the odds of getting one. Nothing about
that reasoning transfers to mail the recipient is already expecting.

## The operational failure that motivated the change

Applied to transactional and ongoing-relationship mail, the rule causes the
*worse* failure. An agent holding several necessary questions and one permitted
ask does one of two things: it defers the rest to a follow-up email that costs a
round trip, or it keeps them but demotes them below the fold into supporting
detail — which is precisely where a recipient skims past the one thing that
needed an answer. Cutting a necessary question to hit a lower number buys
nothing and costs a cycle.

This was found in production drafting, corrected in the drafting practice, and
copied into a downstream mirror — but the published rule kept teaching the
mistake to everyone else.

## This change was already made upstream, and stranded

The correction is not new. It was written on **2026-08-10** as commit
`85923e4` on branch `docs/one-ask-cold-outbound`. It was pushed to origin,
never merged, has **no PR and no issue**, and there is **no recorded reason it
was abandoned**. It predates the downstream mirror copy by one day: the local
edits in `foam-notes` were copied *from* this intended upstream fix, not
invented separately.

This PR re-lands that commit on current `main`. It cherry-picked cleanly — a
genuine rebase, not a rewrite. `email-drafting` 0.1.1's publication fix and
`outlook-email` 0.1.7's Trust Boundary section and
`references/outlook-graph-patterns.md` are all preserved and verified present.

## What changed relative to the stranded commit

The original wording was shaped by a law practice: it tested an ask on whether
"money, obligation, or meaning moves on the answer" and whether the reply
"*selects* rather than *commissions*." That test is good, but it is opinionated
in a way a published, general-purpose skill should not be. It has been
generalised here and **stays, unchanged, in the private `client-email-questions`
skill** where it belongs.

The published rule is now:

- **Unsolicited cold outreach:** one primary ask.
- **Transactional mail, and mail to anyone you already have a relationship
  with:** every ask that is *independently necessary* (you cannot proceed
  without the answer, and no other ask covers it) and *readily answerable* (the
  recipient can answer from what they already know, in a word or a sentence).

## Bundled: three citation defects in the Trust Boundary sections

Each verified against the tree before changing, not taken on report:

1. **`rules.ts:39` had rotted.** Line 39 now resolves to `listInboxRulesAction`,
   which is read-only and enforces nothing. The actual guardrails are
   `BLOCKED_ACTIONS` (line 81) and the checks inside `createInboxRuleAction`
   (lines 125–139). Citations now name the **symbol** and link the file, so they
   cannot rot the same way again.

2. **The prose overstated the mechanism.** It listed `permanentDelete` as
   explicitly blocked. `BLOCKED_ACTIONS` contains only `forwardTo`,
   `forwardAsAttachmentTo`, `redirectTo`, `delete`. `permanentDelete` *is* still
   refused — as an action outside the `SAFE_ACTIONS` allowlist
   (`UNSUPPORTED_RULE_ACTION`), not as a denylisted one (`UNSAFE_RULE_ACTION`).
   Same outcome, different mechanism; the docs now say which.
   `email-cleanup` additionally named a `BLOCKED_ACTION` error code that does
   not exist anywhere in the codebase.

3. **`label.ts` was cited with no anchor.** It now names `deleteEmailAction` and
   states the gate correctly: deletion requires *both* an operator-enabled
   policy (`AGENT_EMAIL_DELETE_ENABLED=true`) *and* the caller's
   `user_explicitly_requested_deletion` — not the caller flag alone, as the old
   prose implied.

`auth.ts:14` (`GRAPH_SCOPES`) was verified still accurate but is line-pinned; it
now names the symbol too.

**Scope note for review:** the same defective `rules.ts:39` citation appears
five times in `email-cleanup`, which the peer review did not name. It is the
same defect, added by the same ClawHub sync commit (`77d7af5`), so it is fixed
here. Say the word and I will split it into its own PR.

## Versions

`email-drafting` 0.1.1 → 0.1.2 · `email-cleanup` 0.1.4 → 0.1.5 ·
`outlook-email` 0.1.7 → 0.1.8

There is no manifest or lockfile for skill versions in this repo. The
`metadata.version` field in each `SKILL.md` frontmatter is the only record, and
per `77d7af5` the convention is that it mirrors the **ClawHub** published
version. **ClawHub must be bumped to match at publish time** or the frontmatter
becomes a claim about a version that was never published.

## Verification

- Diffed the branch against `main`: contains both the scoping change and the
  newer upstream content. Nothing outside `skills/` is touched.
- `npm run lint` — clean across all five workspaces (`tsc --noEmit`).
- `npm run test:run` — 1,111 workspace tests + 4 launch-prep + 27 oauth-video,
  all passing, 0 failures.

## Not in this PR

The two `foam-notes` mirrors are deliberately left alone. Once this merges they
get replaced by byte-for-byte directory copies, and the mirror lockfile
(`.agents/skills/mirrors.lock.json`, now enforced by a pre-commit hook) is
regenerated.
