### PR TITLE
fix(outlook): use immutable IDs for attachment round trips

### DIFF
--- a/packages/email-core/src/actions/attachments.test.ts
+++ b/packages/email-core/src/actions/attachments.test.ts
@@ -13,6 +13,24 @@ beforeEach(() => {
 });
 
 describe('email-attachments/Download Attachments', () => {
+  it('Scenario: List attachments uses the provider attachment collection when available', async () => {
+    const canonicalId = `attachment-${'A'.repeat(160)}`;
+    const listAttachments = vi.spyOn(provider, 'listAttachments').mockResolvedValue([{
+      id: canonicalId,
+      filename: 'canonical.pdf',
+      mimeType: 'application/pdf',
+      size: 123,
+      isInline: false,
+    }]);
+    const getMessage = vi.spyOn(provider, 'getMessage');
+
+    const result = await listAttachmentsAction.run(ctx, { message_id: 'message-id' });
+
+    expect(listAttachments).toHaveBeenCalledWith('message-id');
+    expect(getMessage).not.toHaveBeenCalled();
+    expect(result.attachments[0]!.id).toBe(canonicalId);
+  });
+
   it('Scenario: List attachments', async () => {
     provider.addMessage({
       id: 'msg1',

--- a/packages/email-core/src/actions/attachments.ts
+++ b/packages/email-core/src/actions/attachments.ts
@@ -113,8 +113,10 @@ export const listAttachmentsAction: EmailAction<
   output: ListAttachmentsOutput,
   annotations: { readOnlyHint: true, destructiveHint: false },
   run: async (ctx, input) => {
-    const msg = await ctx.provider.getMessage(input.message_id);
-    const attachments = (msg.attachments ?? []).map(a => ({
+    const listed = typeof ctx.provider.listAttachments === 'function'
+      ? await ctx.provider.listAttachments(input.message_id)
+      : (await ctx.provider.getMessage(input.message_id)).attachments ?? [];
+    const attachments = listed.map(a => ({
       id: a.id,
       filename: sanitizeFilename(a.filename),
       original_filename: a.filename,

--- a/packages/provider-microsoft/src/email-graph-provider.test.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.test.ts
@@ -2127,7 +2127,10 @@ describe('provider-microsoft/Graph API Client', () => {
       'https://graph.microsoft.com/v1.0/me/messages/msg-1/permanentDelete',
       {
         method: 'POST',
-        headers: { Authorization: 'Bearer token-123' },
+        headers: {
+          Authorization: 'Bearer token-123',
+          Prefer: 'IdType="ImmutableId"',
+        },
       },
     );
 
@@ -2159,6 +2162,7 @@ describe('provider-microsoft/Graph API Auth Retry', () => {
     // Retry should use fresh token
     const retryHeaders = fetchMock.mock.calls[1]![1]!.headers as Record<string, string>;
     expect(retryHeaders['Authorization']).toBe('Bearer token-v2');
+    expect(retryHeaders['Prefer']).toBe('IdType="ImmutableId"');
     expect(result.value).toHaveLength(1);
   });
 

--- a/packages/provider-microsoft/src/email-graph-provider.ts
+++ b/packages/provider-microsoft/src/email-graph-provider.ts
@@ -47,6 +47,13 @@ const SUBJECT_MAX_LENGTH = 255;
 // need the upload-session flow, which is intentionally out of scope here.
 const GRAPH_ENCODED_LIMIT = 3 * 1024 * 1024;
 
+// Ask Graph to return immutable Outlook resource IDs. They remain valid when a
+// message is moved and are materially shorter than the default REST IDs, which
+// also makes them safer to round-trip through MCP hosts that redact or shorten
+// long high-entropy strings. Graph continues to accept legacy/default IDs in
+// request paths, so existing callers do not need a migration.
+const IMMUTABLE_ID_PREFER = 'IdType="ImmutableId"';
+
 /** base64-encoded byte length of a buffer of `rawBytes` bytes. */
 function base64Size(rawBytes: number): number {
   return 4 * Math.ceil(rawBytes / 3);
@@ -305,7 +312,7 @@ export class RealGraphApiClient implements GraphApiClient {
     const token = await this.getToken();
     const fullUrl = url.startsWith('http') ? url : `https://graph.microsoft.com/v1.0${url}`;
     const resp = await this.fetchWithAuthRetry(fullUrl, {
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${token}`, Prefer: IMMUTABLE_ID_PREFER },
     });
     if (!resp.ok) {
       throw await this.errorFrom(resp);
@@ -316,7 +323,10 @@ export class RealGraphApiClient implements GraphApiClient {
   async post(url: string, body?: unknown): Promise<{ id?: string; [key: string]: unknown }> {
     const token = await this.getToken();
     const fullUrl = url.startsWith('http') ? url : `https://graph.microsoft.com/v1.0${url}`;
-    const headers: Record<string, string> = { Authorization: `Bearer ${token}` };
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Prefer: IMMUTABLE_ID_PREFER,
+    };
     const init: RequestInit = { method: 'POST', headers };
     if (body !== undefined) {
       headers['Content-Type'] = 'application/json';
@@ -339,6 +349,7 @@ export class RealGraphApiClient implements GraphApiClient {
       method: 'PATCH',
       headers: {
         Authorization: `Bearer ${token}`,
+        Prefer: IMMUTABLE_ID_PREFER,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
@@ -353,7 +364,7 @@ export class RealGraphApiClient implements GraphApiClient {
     const fullUrl = url.startsWith('http') ? url : `https://graph.microsoft.com/v1.0${url}`;
     const resp = await this.fetchWithAuthRetry(fullUrl, {
       method: 'DELETE',
-      headers: { Authorization: `Bearer ${token}` },
+      headers: { Authorization: `Bearer ${token}`, Prefer: IMMUTABLE_ID_PREFER },
     });
     if (!resp.ok) {
       throw await this.errorFrom(resp);


### PR DESCRIPTION
Closes #199.

## What changed

- Request Microsoft Graph immutable IDs on GET, POST, PATCH, and DELETE, including auth retries.
- Prefer the provider's dedicated attachment-list operation in `list_attachments`, with the existing message fallback for providers that lack it.
- Add regression coverage for immutable-ID headers and dedicated attachment listing.

## Verification

- 237 targeted tests passed across email-core, provider-microsoft, and email-mcp.
- Workspace TypeScript build passed.
- Live read-only Graph A/B: immutable message and attachment IDs matched across expanded and collection paths; attachment download succeeded; a legacy default ID remained accepted.
- Claude peer review: approve with changes. Its expanded-vs-collection and legacy-ID concerns were tested live and passed. Its claim that the host boundary was exonerated was declined because direct CLI output was 152 characters while the host-exposed result was 120.

No customer identifiers or message content are included in the branch, issue, or PR.
