### PR TITLE
fix(gmail): narrow default OAuth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,18 +458,26 @@ Other reasons to pick BYOK: dedicated API quota, your own privacy policy and
 verification status, and no dependency on the hosted broker at
 `https://oauth.usejunior.com`.
 
-### Scope requested
+### Scopes requested
 
-Agent Email requests exactly one Gmail scope:
+Agent Email requests exactly these two Gmail scopes by default:
 
 ```text
-https://www.googleapis.com/auth/gmail.modify
+https://www.googleapis.com/auth/gmail.readonly
+https://www.googleapis.com/auth/gmail.compose
 ```
 
-This is the narrowest Gmail scope that covers Agent Email's read, compose,
-send, label, and soft-delete-to-trash behavior. It does not permit immediate,
-permanent deletion. It is the single scope you add to your own OAuth consent
+`gmail.readonly` is required for reading messages and threads;
+`gmail.compose` manages drafts and sending but does not authorize
+`users.threads.get` or `users.messages.get`. The default grant does not include
+`gmail.modify`, so Gmail label changes, read-state changes, moves, trash, and
+delete operations are unavailable. Add both scopes to your OAuth consent
 screen.
+
+Deployments that explicitly set `GMAIL_OAUTH_SCOPES` must update it to the two
+space-separated scopes above. New authorizations and repeated authorizations
+must re-consent to the new scope pair. Existing mailbox files and their stored
+refresh-token metadata remain unchanged.
 
 ### BYOK: create your own Google OAuth client
 
@@ -479,7 +487,8 @@ screen.
 3. **Configure the OAuth consent screen** under *APIs & Services → OAuth consent screen*:
    - User type **External** for a personal `@gmail.com` account, or **Internal**
      if you are on Google Workspace and only your own org needs access.
-   - Add the scope `https://www.googleapis.com/auth/gmail.modify`.
+   - Add both `https://www.googleapis.com/auth/gmail.readonly` and
+     `https://www.googleapis.com/auth/gmail.compose`.
    - While the app is in *Testing*, add your own Gmail address under **Test users**,
      or consent will be refused.
 4. **Create the OAuth client** under *APIs & Services → Credentials → Create

--- a/apps/oauth-broker/README.md
+++ b/apps/oauth-broker/README.md
@@ -79,7 +79,7 @@ by `Map.delete` between awaits is effectively atomic.
 5. Optional:
 
    ```
-   GMAIL_OAUTH_SCOPES=https://www.googleapis.com/auth/gmail.modify    # default
+   GMAIL_OAUTH_SCOPES="https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose"    # default
    BROKER_TICKET_TTL_MS=300000                    # 5 min, default
    BROKER_REQUIRE_KV=true                         # force-fail without Redis even outside prod
    ```
@@ -96,15 +96,16 @@ by `Map.delete` between awaits is effectively atomic.
 ## Verification
 
 `https://<your-broker-domain>` must complete Google's OAuth verification
-flow for the restricted
-`https://www.googleapis.com/auth/gmail.modify` scope. Per Google's
+flow for the restricted `gmail.readonly` and `gmail.compose` scopes. Per Google's
 restricted-scope policy, transmitting restricted-scope data through a server
 requires a security assessment; running a server in the auth path does not
 remove that requirement.
 
 If an existing deployment explicitly sets `GMAIL_OAUTH_SCOPES`, update the
-environment value to `https://www.googleapis.com/auth/gmail.modify` before
-submitting the OAuth app for verification.
+environment value to the space-separated `https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose`
+pair before submitting the OAuth app for verification. Operators and users
+completing new or repeated authorizations must re-consent. Existing local
+refresh-token metadata is preserved.
 
 For the audited project values, pre-submission gates, scope justification,
 privacy-policy facts, and demo script, follow the

--- a/apps/oauth-broker/VERIFICATION.md
+++ b/apps/oauth-broker/VERIFICATION.md
@@ -17,7 +17,7 @@ Last audited: 2026-07-23.
 | Cloud billing | Enabled |
 | Hosted broker origin | `https://oauth.usejunior.com` |
 | OAuth callback | `https://oauth.usejunior.com/api/callback` |
-| Requested Gmail scope | `https://www.googleapis.com/auth/gmail.modify` |
+| Requested Gmail scopes | `https://www.googleapis.com/auth/gmail.readonly` and `https://www.googleapis.com/auth/gmail.compose` |
 | Product homepage | `https://usejunior.com/products/email-agent-mcp` |
 | Privacy policy | `https://usejunior.com/privacy_policy` |
 | Terms | `https://usejunior.com/terms` |
@@ -30,8 +30,11 @@ attached, so public broker routes still return `DEPLOYMENT_NOT_FOUND`. Complete
 those gates and a successful broker OAuth smoke before moving the OAuth app to
 production or recording the demo.
 
-The repository defaults to `gmail.modify`. A deployed broker with an explicit
-`GMAIL_OAUTH_SCOPES` value must set it to the same scope.
+The repository defaults to `gmail.readonly` plus `gmail.compose`. A deployed
+broker with an explicit `GMAIL_OAUTH_SCOPES` value must set it to those two
+space-separated scopes. Operators and users completing new or repeated
+authorizations must re-consent. Existing local refresh-token metadata is
+preserved.
 
 ## Pre-submission gates
 
@@ -40,7 +43,7 @@ The repository defaults to `gmail.modify`. A deployed broker with an explicit
 - [ ] Attach Redis and set `BROKER_REQUIRE_KV=true` in production.
 - [ ] Set `GMAIL_OAUTH_CLIENT_ID`, `GMAIL_OAUTH_CLIENT_SECRET`,
       `BROKER_PUBLIC_ORIGIN=https://oauth.usejunior.com`, and
-      `GMAIL_OAUTH_SCOPES=https://www.googleapis.com/auth/gmail.modify`.
+      `GMAIL_OAUTH_SCOPES="https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose"`.
 - [ ] Confirm `POST /api/sessions` reaches the application rather than a
       Vercel deployment error.
 - [ ] Complete an end-to-end hosted-broker Gmail authorization and refresh
@@ -77,7 +80,7 @@ Use these values in project `email-agent-mcp-gmail`:
 | Authorized domain | `usejunior.com` |
 | Developer contact | `steven@usejunior.com` |
 | Audience | External |
-| Data-access scope | `https://www.googleapis.com/auth/gmail.modify` |
+| Data-access scopes | `https://www.googleapis.com/auth/gmail.readonly` and `https://www.googleapis.com/auth/gmail.compose` |
 
 The app name, logo, homepage identity, consent screen, and demo recording must
 match. Keep a separate Google Cloud project for development/testing rather than
@@ -91,12 +94,12 @@ adding test-only clients or scopes to this production project.
 > updates, and sends drafts; sends new messages; and sends replies within
 > existing threads.
 >
-> `gmail.modify` is the narrowest single scope that supports this implemented
-> combination of reading existing Gmail content and composing and sending
-> messages. `gmail.readonly` cannot send messages, while `gmail.compose` and
-> `gmail.send` cannot read existing message content. The application does not
-> immediately or permanently delete Gmail messages and therefore does not
-> request `https://mail.google.com/`.
+> `gmail.readonly` authorizes reading existing Gmail messages and threads, and
+> `gmail.compose` authorizes managing drafts and sending messages. Both are
+> required: Gmail's `users.threads.get` and `users.messages.get` methods do not
+> accept `gmail.compose`. The default grant does not request `gmail.modify` or
+> `https://mail.google.com/`, and Gmail label, read-state, move, trash, and
+> delete mutations are unavailable under it.
 >
 > Gmail API calls and message content travel directly between the user's local
 > email-agent-mcp process and Google. UseJunior's hosted OAuth broker performs
@@ -108,13 +111,13 @@ ask for separate explanations of read and compose/send behavior.
 
 ## Demo video script
 
-Record against a dedicated test mailbox with the consent screen language set
-to English:
+Record against the personal Gmail account `steven.obiajulu@gmail.com` with the
+consent screen language set to English:
 
 1. Show the public product homepage and its privacy-policy link.
 2. Show Google Auth Platform > Clients with the single production Web client
-   and its client ID, then show Data Access with `gmail.modify`, `Email client`,
-   and `Email productivity`.
+   and its client ID, then show Data Access with `gmail.readonly`,
+   `gmail.compose`, `Email client`, and `Email productivity`.
 3. Start `email-agent-mcp configure --provider gmail --mailbox <test-account>`.
 4. Show the browser redirect to the same app name and branding configured in
    Google Auth Platform.
@@ -191,4 +194,6 @@ Current Google references:
 - [Verification requirements](https://support.google.com/cloud/answer/13464321)
 - [Submitting an app for verification](https://support.google.com/cloud/answer/13461325)
 - [Gmail API scopes](https://developers.google.com/workspace/gmail/api/auth/scopes)
+- [Gmail `users.threads.get` authorization scopes](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.threads/get)
+- [Gmail `users.messages.get` authorization scopes](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/get)
 - [Security assessment](https://support.google.com/cloud/answer/13465431)

--- a/apps/oauth-broker/api/routes.test.ts
+++ b/apps/oauth-broker/api/routes.test.ts
@@ -108,7 +108,7 @@ describe('provider-gmail/OAuth2 Authentication (broker routes)', () => {
       expect(captured.redirect).toContain('accounts.google.com');
       expect(captured.redirect).toContain(`state=${sessionId}`);
       expect(new URL(captured.redirect!).searchParams.get('scope')).toBe(
-        'https://www.googleapis.com/auth/gmail.modify',
+        'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose',
       );
     }
 
@@ -120,7 +120,7 @@ describe('provider-gmail/OAuth2 Authentication (broker routes)', () => {
           access_token: 'broker-access',
           refresh_token: 'broker-refresh',
           expires_in: 3600,
-          scope: 'https://www.googleapis.com/auth/gmail.modify',
+          scope: 'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose',
           token_type: 'Bearer',
         }),
         { status: 200, headers: { 'content-type': 'application/json' } },

--- a/apps/oauth-broker/lib/config.test.ts
+++ b/apps/oauth-broker/lib/config.test.ts
@@ -29,10 +29,12 @@ afterEach(() => {
 });
 
 describe('provider-gmail/OAuth2 Authentication (broker config)', () => {
-  it('defaults to the narrow Gmail modify scope', () => {
+  it('defaults to Gmail read and compose scopes without modify', () => {
     expect(getConfig().scopes).toEqual([
-      'https://www.googleapis.com/auth/gmail.modify',
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/gmail.compose',
     ]);
+    expect(getConfig().scopes).not.toContain('https://www.googleapis.com/auth/gmail.modify');
   });
 
   it('Scenario: Broker requires Redis in production', () => {

--- a/apps/oauth-broker/lib/config.ts
+++ b/apps/oauth-broker/lib/config.ts
@@ -44,7 +44,7 @@ export function getConfig(): BrokerConfig {
     redirectUri,
     scopes: (
       process.env['GMAIL_OAUTH_SCOPES'] ??
-      'https://www.googleapis.com/auth/gmail.modify'
+      'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose'
     ).split(/\s+/).filter(Boolean),
     ticketTtlMs: Number(process.env['BROKER_TICKET_TTL_MS'] ?? 5 * 60 * 1000),
     useKv,

--- a/packages/email-mcp/src/cli.test.ts
+++ b/packages/email-mcp/src/cli.test.ts
@@ -722,7 +722,10 @@ describe('cli/Gmail Configure', () => {
       redirectUri: 'http://127.0.0.1:62018/oauth2callback',
       codeChallenge: 'mock-code-challenge',
       loginHint: 'steven.obiajulu@gmail.com',
-      scopes: ['https://www.googleapis.com/auth/gmail.modify'],
+      scopes: [
+        'https://www.googleapis.com/auth/gmail.readonly',
+        'https://www.googleapis.com/auth/gmail.compose',
+      ],
     });
 
     const allowlistPath = await getEffectiveSendAllowlistPath();

--- a/packages/provider-gmail/README.md
+++ b/packages/provider-gmail/README.md
@@ -77,8 +77,11 @@ The simplest path is Google's OAuth 2.0 Playground using your own client credent
 1. Open `https://developers.google.com/oauthplayground/`.
 2. Click the gear icon and enable "Use your own OAuth credentials".
 3. Paste your Google `client_id` and `client_secret`.
-4. Authorize the Gmail scope
-   `https://www.googleapis.com/auth/gmail.modify`.
+4. Authorize both Gmail scopes:
+   `https://www.googleapis.com/auth/gmail.readonly` and
+   `https://www.googleapis.com/auth/gmail.compose`. Compose alone cannot read
+   messages or threads. The default grant does not support Gmail label,
+   read-state, move, trash, or delete mutations.
 5. Exchange the authorization code for tokens.
 6. Copy the returned `refresh_token`.
 

--- a/packages/provider-gmail/src/auth.test.ts
+++ b/packages/provider-gmail/src/auth.test.ts
@@ -74,7 +74,7 @@ describe('provider-gmail/OAuth2 Authentication', () => {
     await expect(auth.connect({})).rejects.toThrow('access_token or refresh_token');
   });
 
-  it('Scenario: Gmail OAuth requests the narrowest implemented scope', async () => {
+  it('Scenario: Gmail OAuth defaults to read and compose without modify', async () => {
     const auth = new GmailAuthManager({
       clientId: 'test-client',
       clientSecret: 'test-secret',
@@ -90,8 +90,10 @@ describe('provider-gmail/OAuth2 Authentication', () => {
 
     expect(url).toContain('accounts.google.com');
     expect(GMAIL_OAUTH_SCOPES).toEqual([
-      'https://www.googleapis.com/auth/gmail.modify',
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/gmail.compose',
     ]);
+    expect(GMAIL_OAUTH_SCOPES).not.toContain('https://www.googleapis.com/auth/gmail.modify');
     expect(url).not.toContain(encodeURIComponent('https://mail.google.com/'));
     expect(auth.getOAuth2Client().generateAuthUrl).toHaveBeenCalledWith({
       access_type: 'offline',

--- a/packages/provider-gmail/src/auth.ts
+++ b/packages/provider-gmail/src/auth.ts
@@ -69,7 +69,8 @@ export interface GmailProfile {
 }
 
 export const GMAIL_OAUTH_SCOPES = [
-  'https://www.googleapis.com/auth/gmail.modify',
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.compose',
 ];
 
 function collectAuthErrorStrings(err: unknown): string[] {


### PR DESCRIPTION
## Summary

- replace the Gmail provider and OAuth broker default `gmail.modify` grant with the mandatory `gmail.readonly` + `gmail.compose` pair
- add regressions that fail if either default omits a required scope or includes `gmail.modify`
- document deployment env updates, re-consent, preserved refresh-token metadata, and unavailable Gmail mutation operations

Google's [Gmail scope catalog](https://developers.google.com/workspace/gmail/api/auth/scopes) defines `gmail.readonly` for viewing messages/settings and `gmail.compose` for drafts/send. The [`users.threads.get` reference](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.threads/get) accepts `gmail.readonly` but not `gmail.compose`, so compose alone is insufficient.

## Verification

- `npm ci` — passed (397 packages installed; npm reported 28 pre-existing audit findings)
- `npm run build -w @usejunior/email-core` — passed (workspace prerequisite)
- `npm run test:run -w @usejunior/provider-gmail` — passed (7 files, 116 tests)
- `npm run test:run -w email-agent-mcp-oauth-broker` — passed (6 files, 31 tests)
- `npm run lint -w @usejunior/provider-gmail` — passed
- `npm run lint -w email-agent-mcp-oauth-broker` — passed
- `npm run build -w @usejunior/provider-gmail` — passed
- `npm run build -w email-agent-mcp-oauth-broker` — passed

Initial test attempts before bootstrapping are recorded in `/tmp/gmail-oauth-scope-cut-report.md`.

## Operational notes

- Deployments with explicit `GMAIL_OAUTH_SCOPES` must update it to `https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose`.
- New or repeated authorizations must re-consent.
- Existing mailbox files and refresh-token metadata are preserved.
- Gmail label/read-state/move/trash/delete operations are unavailable under the default grant; no such Gmail mutation action is currently exposed by the provider.

This PR does not change production broker environment state and must not be merged as part of this task.
