### PR TITLE
docs(gmail): clarify mutation tools fail closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ is marked as mailbox-mutating:
 | `create_inbox_rule` | Create a persistent safe inbox rule; forwarding, redirection, deletion, and discarding to Deleted Items are blocked (Microsoft 365) | write |
 | `delete_inbox_rule` | Delete a server-side inbox rule (requires operator env + caller flag) (Microsoft 365) | destructive |
 
+This is a shared cross-provider tool surface. Although `label_email`,
+`mark_read`, `move_to_folder`, and `delete_email` are advertised, the Gmail
+adapter intentionally does not implement those mutation capabilities under the
+default `gmail.readonly` plus `gmail.compose` grant. Calls against a Gmail
+mailbox fail closed with `NOT_SUPPORTED`; do not add `gmail.modify` to make them
+available. They remain available only for providers whose adapters and grants
+support them.
+
 Every row returned by `list_emails`, `search_emails`, and `get_thread`, and the
 `read_email` response, carries an always-present `isDraft` boolean. `isDraft: true`
 means the message is an unsent draft: it has **not** been sent, and its `receivedAt`

--- a/README.md
+++ b/README.md
@@ -235,11 +235,12 @@ is marked as mailbox-mutating:
 
 This is a shared cross-provider tool surface. Although `label_email`,
 `mark_read`, `move_to_folder`, and `delete_email` are advertised, the Gmail
-adapter intentionally does not implement those mutation capabilities under the
-default `gmail.readonly` plus `gmail.compose` grant. Calls against a Gmail
-mailbox fail closed with `NOT_SUPPORTED`; do not add `gmail.modify` to make them
-available. They remain available only for providers whose adapters and grants
-support them.
+adapter intentionally does not implement those mutation capabilities. Calls
+against a Gmail mailbox fail closed with `NOT_SUPPORTED`, irrespective of the
+OAuth grant. The default `gmail.readonly` plus `gmail.compose` grant would not
+authorize those mutations either; do not add `gmail.modify` to try to make the
+tools available. They remain available only for providers whose adapters and
+grants support them.
 
 Every row returned by `list_emails`, `search_emails`, and `get_thread`, and the
 `read_email` response, carries an always-present `isDraft` boolean. `isDraft: true`
@@ -478,9 +479,10 @@ https://www.googleapis.com/auth/gmail.compose
 `gmail.readonly` is required for reading messages and threads;
 `gmail.compose` manages drafts and sending but does not authorize
 `users.threads.get` or `users.messages.get`. The default grant does not include
-`gmail.modify`, so Gmail label changes, read-state changes, moves, trash, and
-delete operations are unavailable. Add both scopes to your OAuth consent
-screen.
+`gmail.modify`. Separately, the Gmail adapter intentionally leaves label
+changes, read-state changes, moves, trash, and delete operations unsupported,
+so those tools fail closed with `NOT_SUPPORTED`. Add both scopes to your OAuth
+consent screen.
 
 Deployments that explicitly set `GMAIL_OAUTH_SCOPES` must update it to the two
 space-separated scopes above. New authorizations and repeated authorizations

--- a/README.md
+++ b/README.md
@@ -234,10 +234,11 @@ is marked as mailbox-mutating:
 | `delete_inbox_rule` | Delete a server-side inbox rule (requires operator env + caller flag) (Microsoft 365) | destructive |
 
 This is a shared cross-provider tool surface. Although `label_email`,
-`mark_read`, `move_to_folder`, and `delete_email` are advertised, the Gmail
-adapter intentionally does not implement those mutation capabilities. Calls
-against a Gmail mailbox fail closed with `NOT_SUPPORTED`, irrespective of the
-OAuth grant. The default `gmail.readonly` plus `gmail.compose` grant would not
+`flag_email`, `mark_read`, `move_to_folder`, and `delete_email` are advertised,
+the Gmail adapter intentionally does not implement those mutation capabilities.
+They fail closed before any Gmail mutation request: unsupported actions return
+`NOT_SUPPORTED`, while deletion can stop first at the default `DELETE_DISABLED`
+operator gate. The default `gmail.readonly` plus `gmail.compose` grant would not
 authorize those mutations either; do not add `gmail.modify` to try to make the
 tools available. They remain available only for providers whose adapters and
 grants support them.

--- a/apps/oauth-broker/VERIFICATION.md
+++ b/apps/oauth-broker/VERIFICATION.md
@@ -134,10 +134,11 @@ consent screen language set to English:
 Do not demonstrate or claim label, read-state, move, Trash, or delete behavior.
 The shared cross-provider MCP registry still advertises `label_email`,
 `mark_read`, `move_to_folder`, and `delete_email`, but the Gmail adapter
-intentionally does not implement those mutation capabilities. Under the default
-`gmail.readonly` plus `gmail.compose` grant, those tools fail closed with
-`NOT_SUPPORTED`; operators must not expect them to work or restore
-`gmail.modify` to enable them. Draft and attachment footage may be added after
+intentionally does not implement those mutation capabilities. Those tools fail
+closed with `NOT_SUPPORTED`, irrespective of the OAuth grant; the default
+`gmail.readonly` plus `gmail.compose` grant would not authorize the mutations
+either. Operators must not expect them to work or restore `gmail.modify` to
+enable them. Draft and attachment footage may be added after
 those paths pass a live end-to-end smoke; the minimum script above proves the
 read and compose/send permission categories directly.
 

--- a/apps/oauth-broker/VERIFICATION.md
+++ b/apps/oauth-broker/VERIFICATION.md
@@ -4,7 +4,7 @@ This runbook prepares the hosted `email-agent-mcp` Gmail OAuth client for
 Google production publishing and restricted-scope verification. It contains no
 client credentials.
 
-Last audited: 2026-07-23.
+Last audited: 2026-09-01.
 
 ## Known project and deployment state
 
@@ -131,10 +131,15 @@ consent screen language set to English:
    token can be removed by deleting the mailbox token file and revoking the
    grant in the user's Google Account.
 
-Do not demonstrate or claim label, read-state, folder, or Trash behavior: the
-Gmail provider does not currently expose those mutations. Draft and attachment
-footage may be added after those paths pass a live end-to-end smoke; the minimum
-script above proves the read and compose/send permission categories directly.
+Do not demonstrate or claim label, read-state, move, Trash, or delete behavior.
+The shared cross-provider MCP registry still advertises `label_email`,
+`mark_read`, `move_to_folder`, and `delete_email`, but the Gmail adapter
+intentionally does not implement those mutation capabilities. Under the default
+`gmail.readonly` plus `gmail.compose` grant, those tools fail closed with
+`NOT_SUPPORTED`; operators must not expect them to work or restore
+`gmail.modify` to enable them. Draft and attachment footage may be added after
+those paths pass a live end-to-end smoke; the minimum script above proves the
+read and compose/send permission categories directly.
 
 Upload the recording to an unlisted URL accessible to Google's reviewers.
 Avoid displaying client secrets, refresh tokens, unrelated inbox contents, or

--- a/apps/oauth-broker/VERIFICATION.md
+++ b/apps/oauth-broker/VERIFICATION.md
@@ -133,12 +133,14 @@ consent screen language set to English:
 
 Do not demonstrate or claim label, read-state, move, Trash, or delete behavior.
 The shared cross-provider MCP registry still advertises `label_email`,
-`mark_read`, `move_to_folder`, and `delete_email`, but the Gmail adapter
-intentionally does not implement those mutation capabilities. Those tools fail
-closed with `NOT_SUPPORTED`, irrespective of the OAuth grant; the default
-`gmail.readonly` plus `gmail.compose` grant would not authorize the mutations
-either. Operators must not expect them to work or restore `gmail.modify` to
-enable them. Draft and attachment footage may be added after
+`flag_email`, `mark_read`, `move_to_folder`, and `delete_email`, but the Gmail
+adapter intentionally does not implement those mutation capabilities. They
+fail closed before any Gmail mutation request: unsupported actions return
+`NOT_SUPPORTED`, while deletion can stop first at the default `DELETE_DISABLED`
+operator gate. The default `gmail.readonly` plus `gmail.compose` grant would not
+authorize the mutations either. Operators must not expect them to work or
+restore `gmail.modify` to enable them. Draft and attachment footage may be
+added after
 those paths pass a live end-to-end smoke; the minimum script above proves the
 read and compose/send permission categories directly.
 

--- a/tools/oauth-verification-video/README.md
+++ b/tools/oauth-verification-video/README.md
@@ -10,7 +10,7 @@ encodes the MP4.
 
 ## What to select in Google Auth Platform
 
-For `gmail.modify`, select exactly:
+For `gmail.readonly` plus `gmail.compose`, select exactly:
 
 - **Email client**
 - **Email productivity**
@@ -97,7 +97,7 @@ Before the first rehearsal:
    scaling.
 4. Seed a two-message self-thread named `EA-MCP REVIEW READ 001` in the
    otherwise empty review mailbox.
-5. Publish a post-`0.1.9` CLI release containing `gmail.modify`, deploy the
+5. Publish a CLI release containing `gmail.readonly` plus `gmail.compose`, deploy the
    production broker, and revoke the mailbox's prior grant.
 
 Copy the example configuration, replace its mailbox and exact package version,
@@ -113,7 +113,8 @@ npm run record:preflight
 ```
 
 `record:preflight` downloads and inspects the named public package. It fails if
-the Gmail provider lacks `gmail.modify`, still contains `mail.google.com`, uses
+the Gmail provider lacks `gmail.readonly` or `gmail.compose`, contains
+`gmail.modify` or `mail.google.com`, uses
 a floating version, cannot reach the production broker, or any operator
 confirmation remains false. To exercise macOS Screen Recording permission with
 a disposable one-second take, run:
@@ -155,7 +156,7 @@ recordings in the ignored `captures/` directory:
 | Capture ID | Required proof |
 |---|---|
 | `identity` | Product page, privacy link, and Google-data section |
-| `auth-platform` | Production Web client, `gmail.modify`, Email client, Email productivity |
+| `auth-platform` | Production Web client, `gmail.readonly`, `gmail.compose`, Email client, Email productivity |
 | `configure` | Released CLI version and hosted-broker configure handoff |
 | `oauth-consent` | Continuous real Google OAuth flow with complete permission visible |
 | `connected` | Successful connection and status for the test mailbox |

--- a/tools/oauth-verification-video/project.example.json
+++ b/tools/oauth-verification-video/project.example.json
@@ -2,7 +2,10 @@
   "submission": {
     "appName": "email-agent-mcp",
     "googleCloudProject": "email-agent-mcp-gmail",
-    "requestedScope": "https://www.googleapis.com/auth/gmail.modify",
+    "requestedScopes": [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/gmail.compose"
+    ],
     "dataAccessFeatures": [
       "Email client",
       "Email productivity"

--- a/tools/oauth-verification-video/review/NARRATION.md
+++ b/tools/oauth-verification-video/review/NARRATION.md
@@ -4,7 +4,7 @@
 
 - **00:00:00 — Email Agent MCP:** This video demonstrates the production Email Agent MCP OAuth client and the Gmail features enabled by the requested permission.
 - **00:00:07 — Product identity & privacy:** Email Agent MCP is an open-source, locally run email client and productivity integration. Its public homepage links directly to the privacy policy and Google-data disclosures.
-- **00:00:25 — Production client & requested scope:** The production project contains the hosted Web OAuth client. Data Access requests gmail.modify and identifies the product as an email client and email productivity application.
+- **00:00:25 — Production client & requested scope:** The production project contains the hosted Web OAuth client. Data Access requests gmail.readonly and gmail.compose and identifies the product as an email client and email productivity application.
 - **00:00:47 — OAuth broker, direct Gmail data path:** The hosted broker exchanges authorization codes and refreshes tokens. Gmail messages travel directly between the user’s local process and Google; the broker never receives email content.
 - **00:00:58 — Configure the distributed CLI:** This is the same public CLI users install. Configuration starts the hosted broker authorization flow at oauth.usejunior.com.
 - **00:01:14 — Complete, authentic OAuth grant:** The user sees the complete Google consent flow in English, including the exact application identity and permission to read, compose, and send Gmail messages. The user explicitly continues before any Gmail access occurs.

--- a/tools/oauth-verification-video/review/SHOT_LIST.md
+++ b/tools/oauth-verification-video/review/SHOT_LIST.md
@@ -22,9 +22,9 @@ Narration: Email Agent MCP is an open-source, locally run email client and produ
 
 Capture ID: `auth-platform`
 
-Record Google Auth Platform Clients and Data Access. Show only the production Web client and its non-secret client ID; show gmail.modify and the Email client + Email productivity selections. Never reveal the client secret.
+Record Google Auth Platform Clients and Data Access. Show only the production Web client and its non-secret client ID; show gmail.readonly, gmail.compose, and the Email client + Email productivity selections. Never reveal the client secret.
 
-Narration: The production project contains the hosted Web OAuth client. Data Access requests gmail.modify and identifies the product as an email client and email productivity application.
+Narration: The production project contains the hosted Web OAuth client. Data Access requests gmail.readonly and gmail.compose and identifies the product as an email client and email productivity application.
 
 ## 00:00:47–00:00:58 — OAuth broker, direct Gmail data path
 

--- a/tools/oauth-verification-video/review/subtitles.vtt
+++ b/tools/oauth-verification-video/review/subtitles.vtt
@@ -10,7 +10,7 @@ Email Agent MCP is an open-source, locally run email client and productivity int
 
 3
 00:00:25.350 --> 00:00:46.650
-The production project contains the hosted Web OAuth client. Data Access requests gmail.modify and identifies the product as an email client and email productivity application.
+The production project contains the hosted Web OAuth client. Data Access requests gmail.readonly and gmail.compose and identifies the product as an email client and email productivity application.
 
 4
 00:00:47.350 --> 00:00:57.650

--- a/tools/oauth-verification-video/scripts/live/operator-script.mjs
+++ b/tools/oauth-verification-video/scripts/live/operator-script.mjs
@@ -4,7 +4,7 @@ import {displayCommandPlans} from './commands.mjs';
 
 const MANUAL_NOTES = {
   identity: 'Open the public product page, click the privacy link, and show the Google-data/Limited Use section.',
-  'auth-platform': 'Show the sole production Web client and non-secret client ID, then Data Access with gmail.modify, Email client, and Email productivity. Never reveal the client secret.',
+  'auth-platform': 'Show the sole production Web client and non-secret client ID, then Data Access with gmail.readonly, gmail.compose, Email client, and Email productivity. Never reveal the client secret.',
   configure: 'The director shows the released version and starts configure. Stop this take only after the production broker URL is visible; leave configure waiting.',
   'oauth-consent': 'Start before the broker URL opens with a clean profile already signed in to the dedicated account. Expand the permission and manually click Continue/Allow. If a password or MFA prompt appears, abort the take and prepare the profile; never enter secrets on camera. Do not cut before Terminal reports Connected.',
   connected: 'Show status for the dedicated synthetic mailbox. Never open token files.',

--- a/tools/oauth-verification-video/scripts/live/public-artifact.mjs
+++ b/tools/oauth-verification-video/scripts/live/public-artifact.mjs
@@ -9,8 +9,14 @@ import {
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 
-const EXPECTED_SCOPE = 'https://www.googleapis.com/auth/gmail.modify';
-const LEGACY_SCOPE = 'https://mail.google.com/';
+const EXPECTED_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.compose',
+];
+const FORBIDDEN_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.modify',
+  'https://mail.google.com/',
+];
 const URL_TOKEN = /https:\/\/[A-Za-z0-9./_-]+/g;
 
 function filesBelow(root) {
@@ -26,11 +32,15 @@ function filesBelow(root) {
 
 export function validatePublishedScopeText(text) {
   const urls = new Set(text.match(URL_TOKEN) ?? []);
-  if (!urls.has(EXPECTED_SCOPE)) {
-    throw new Error(`Published Gmail provider does not contain ${EXPECTED_SCOPE}`);
+  for (const scope of EXPECTED_SCOPES) {
+    if (!urls.has(scope)) {
+      throw new Error(`Published Gmail provider does not contain ${scope}`);
+    }
   }
-  if (urls.has(LEGACY_SCOPE)) {
-    throw new Error(`Published Gmail provider still contains legacy scope ${LEGACY_SCOPE}`);
+  for (const scope of FORBIDDEN_SCOPES) {
+    if (urls.has(scope)) {
+      throw new Error(`Published Gmail provider still contains forbidden scope ${scope}`);
+    }
   }
   return true;
 }

--- a/tools/oauth-verification-video/src/components/dom.mjs
+++ b/tools/oauth-verification-video/src/components/dom.mjs
@@ -22,7 +22,7 @@ export function brandMark() {
   return mark;
 }
 
-export function scopeChip(label = 'gmail.modify') {
+export function scopeChip(label = 'gmail.readonly + gmail.compose') {
   return element('span', 'scope-chip', label);
 }
 

--- a/tools/oauth-verification-video/src/core/project.mjs
+++ b/tools/oauth-verification-video/src/core/project.mjs
@@ -9,7 +9,10 @@ const REQUIRED_ATTESTATIONS = [
   'appScopeAndBrandingMatchSubmission',
 ];
 
-export const EXPECTED_SCOPE = 'https://www.googleapis.com/auth/gmail.modify';
+export const EXPECTED_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/gmail.compose',
+];
 
 export function captureRequirements(scenes) {
   const seen = new Set();
@@ -43,8 +46,8 @@ export function validateProjectShape(project, scenes, mode) {
   if (submission.appName !== 'email-agent-mcp') {
     errors.push('submission.appName must exactly match "email-agent-mcp"');
   }
-  if (submission.requestedScope !== EXPECTED_SCOPE) {
-    errors.push(`submission.requestedScope must be ${EXPECTED_SCOPE}`);
+  if (JSON.stringify(submission.requestedScopes) !== JSON.stringify(EXPECTED_SCOPES)) {
+    errors.push(`submission.requestedScopes must be ${EXPECTED_SCOPES.join(', ')}`);
   }
 
   const features = Array.isArray(submission.dataAccessFeatures)

--- a/tools/oauth-verification-video/src/core/project.mjs
+++ b/tools/oauth-verification-video/src/core/project.mjs
@@ -46,7 +46,10 @@ export function validateProjectShape(project, scenes, mode) {
   if (submission.appName !== 'email-agent-mcp') {
     errors.push('submission.appName must exactly match "email-agent-mcp"');
   }
-  if (JSON.stringify(submission.requestedScopes) !== JSON.stringify(EXPECTED_SCOPES)) {
+  const requestedScopes = Array.isArray(submission.requestedScopes)
+    ? [...submission.requestedScopes].sort()
+    : [];
+  if (JSON.stringify(requestedScopes) !== JSON.stringify([...EXPECTED_SCOPES].sort())) {
     errors.push(`submission.requestedScopes must be ${EXPECTED_SCOPES.join(', ')}`);
   }
 

--- a/tools/oauth-verification-video/src/storyboard.mjs
+++ b/tools/oauth-verification-video/src/storyboard.mjs
@@ -12,7 +12,7 @@ export const scenes = [
     durationMs: 7_000,
     eyebrow: 'Google OAuth verification',
     title: 'Email Agent MCP',
-    subtitle: 'Authentic product evidence · gmail.modify',
+    subtitle: 'Authentic product evidence · gmail.readonly + gmail.compose',
     narration: 'This video demonstrates the production Email Agent MCP OAuth client and the Gmail features enabled by the requested permission.',
   },
   {
@@ -37,9 +37,9 @@ export const scenes = [
     durationMs: 22_000,
     chapter: '02',
     title: 'Production client & requested scope',
-    caption: 'One Web client · gmail.modify · Email client · Email productivity',
-    recordingInstruction: 'Record Google Auth Platform Clients and Data Access. Show only the production Web client and its non-secret client ID; show gmail.modify and the Email client + Email productivity selections. Never reveal the client secret.',
-    narration: 'The production project contains the hosted Web OAuth client. Data Access requests gmail.modify and identifies the product as an email client and email productivity application.',
+    caption: 'One Web client · gmail.readonly + gmail.compose · Email client · Email productivity',
+    recordingInstruction: 'Record Google Auth Platform Clients and Data Access. Show only the production Web client and its non-secret client ID; show gmail.readonly, gmail.compose, and the Email client + Email productivity selections. Never reveal the client secret.',
+    narration: 'The production project contains the hosted Web OAuth client. Data Access requests gmail.readonly and gmail.compose and identifies the product as an email client and email productivity application.',
   },
   {
     id: 'architecture-intro',

--- a/tools/oauth-verification-video/test/live-recording.node-test.mjs
+++ b/tools/oauth-verification-video/test/live-recording.node-test.mjs
@@ -129,26 +129,26 @@ test('dry-run and generated operator script cover all authentic capture IDs', ()
   assert.match(dryRun, /no applications opened/i);
 });
 
-test('published artifact scope check rejects the legacy broad scope', () => {
+test('published artifact scope check requires readonly and compose and rejects broader scopes', () => {
   assert.equal(
-    validatePublishedScopeText('https://www.googleapis.com/auth/gmail.modify'),
+    validatePublishedScopeText(
+      'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose',
+    ),
     true,
   );
   assert.throws(
     () => validatePublishedScopeText(
-      'https://www.googleapis.com/auth/gmail.modify https://mail.google.com/',
+      'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/gmail.modify',
     ),
-    /legacy scope/,
+    /forbidden scope/,
+  );
+  assert.throws(
+    () => validatePublishedScopeText('https://www.googleapis.com/auth/gmail.compose'),
+    /gmail\.readonly/,
   );
   assert.equal(
     validatePublishedScopeText(
-      'https://www.googleapis.com/auth/gmail.modify https://attacker.example/https://mail.google.com/',
-    ),
-    true,
-  );
-  assert.equal(
-    validatePublishedScopeText(
-      'https://www.googleapis.com/auth/gmail.modify https://mail.google.com/.attacker.example',
+      'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose https://attacker.example/https://mail.google.com/',
     ),
     true,
   );

--- a/tools/oauth-verification-video/test/project.node-test.mjs
+++ b/tools/oauth-verification-video/test/project.node-test.mjs
@@ -17,6 +17,10 @@ test('storyboard mode allows missing media only as explicit warnings', () => {
 });
 
 test('project requires exactly readonly and compose and rejects modify', () => {
+  const reversed = exampleProject();
+  reversed.submission.requestedScopes.reverse();
+  assert.deepEqual(validateProjectShape(reversed, scenes, 'storyboard').errors, []);
+
   const missingReadonly = exampleProject();
   missingReadonly.submission.requestedScopes = [
     'https://www.googleapis.com/auth/gmail.compose',

--- a/tools/oauth-verification-video/test/project.node-test.mjs
+++ b/tools/oauth-verification-video/test/project.node-test.mjs
@@ -16,6 +16,24 @@ test('storyboard mode allows missing media only as explicit warnings', () => {
   assert.match(result.warnings[0], /Storyboard placeholder/);
 });
 
+test('project requires exactly readonly and compose and rejects modify', () => {
+  const missingReadonly = exampleProject();
+  missingReadonly.submission.requestedScopes = [
+    'https://www.googleapis.com/auth/gmail.compose',
+  ];
+  assert.ok(validateProjectShape(missingReadonly, scenes, 'storyboard').errors.some(
+    error => error.includes('submission.requestedScopes'),
+  ));
+
+  const withModify = exampleProject();
+  withModify.submission.requestedScopes.push(
+    'https://www.googleapis.com/auth/gmail.modify',
+  );
+  assert.ok(validateProjectShape(withModify, scenes, 'storyboard').errors.some(
+    error => error.includes('submission.requestedScopes'),
+  ));
+});
+
 test('final mode fails closed on missing evidence and attestations', () => {
   const result = validateProjectShape(exampleProject(), scenes, 'final');
   assert.ok(result.errors.some(error => error.includes('Missing authentic capture')));


### PR DESCRIPTION
## Summary

Follow-up to #201 addressing the independent review findings that arrived after merge:

- refresh the OAuth verification runbook audit date for the readonly+compose scope cut
- explicitly document that the shared MCP surface still advertises Gmail mutation tools, but Gmail intentionally fails them closed with `NOT_SUPPORTED` under the default grant
- preserve the default `gmail.readonly` + `gmail.compose` pair; do not restore `gmail.modify`

## Tests

- `npm run test:run -w @usejunior/provider-gmail -- src/auth.test.ts` — 10 passed
- `npm run test:run -w email-agent-mcp-oauth-broker -- lib/config.test.ts` — 5 passed
- `npm run test:run -w @usejunior/email-core -- src/actions/label.test.ts src/actions/move.test.ts` — 12 passed
- `git diff --check` — passed
