### PR TITLE
chore(release): bump workspace versions to 0.3.1

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Microsoft 365 / Outlook mail via MCP.",
   "contextFileName": "GEMINI.md",
   "entrypoint": "GEMINI.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "email-agent-mcp-suite",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
@@ -5927,10 +5927,10 @@
       }
     },
     "packages/email-agent-mcp": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@usejunior/email-mcp": "^0.3.0"
+        "@usejunior/email-mcp": "^0.3.1"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -5941,10 +5941,10 @@
     },
     "packages/email-agent-mcp-scoped": {
       "name": "@usejunior/email-agent-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "email-agent-mcp": "0.3.0"
+        "email-agent-mcp": "0.3.1"
       },
       "bin": {
         "email-agent-mcp": "bin/email-agent-mcp.js"
@@ -5955,7 +5955,7 @@
     },
     "packages/email-core": {
       "name": "@usejunior/email-core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "marked": "^18.0.0",
@@ -5974,14 +5974,14 @@
     },
     "packages/email-mcp": {
       "name": "@usejunior/email-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "@usejunior/email-core": "^0.3.0",
-        "@usejunior/provider-gmail": "^0.3.0",
-        "@usejunior/provider-microsoft": "^0.3.0"
+        "@usejunior/email-core": "^0.3.1",
+        "@usejunior/provider-gmail": "^0.3.1",
+        "@usejunior/provider-microsoft": "^0.3.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
@@ -5995,11 +5995,11 @@
     },
     "packages/provider-gmail": {
       "name": "@usejunior/provider-gmail",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@googleapis/gmail": "^4.0.0",
-        "@usejunior/email-core": "^0.3.0",
+        "@usejunior/email-core": "^0.3.1",
         "google-auth-library": "^8.9.0"
       },
       "devDependencies": {
@@ -6014,13 +6014,13 @@
     },
     "packages/provider-microsoft": {
       "name": "@usejunior/provider-microsoft",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@azure/identity": "^4.0.0",
         "@azure/identity-cache-persistence": "^1.2.0",
         "@microsoft/microsoft-graph-client": "^3.0.0",
-        "@usejunior/email-core": "^0.3.0"
+        "@usejunior/email-core": "^0.3.1"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp-suite",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 and manual-token Gmail setup",
   "type": "module",

--- a/packages/email-agent-mcp-scoped/package.json
+++ b/packages/email-agent-mcp-scoped/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-agent-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Compatibility package for email-agent-mcp — use the unscoped package for new installations",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "email-agent-mcp": "0.3.0"
+    "email-agent-mcp": "0.3.1"
   },
   "engines": {
     "node": ">=20"

--- a/packages/email-agent-mcp/package.json
+++ b/packages/email-agent-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "email-agent-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local email connectivity for AI agents — MCP server for Microsoft 365 / Outlook and manual-token Gmail setup",
   "type": "module",
   "main": "./index.js",
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@usejunior/email-mcp": "^0.3.0"
+    "@usejunior/email-mcp": "^0.3.1"
   },
   "mcpName": "io.github.UseJunior/email-agent-mcp",
   "engines": {

--- a/packages/email-agent-mcp/server.json
+++ b/packages/email-agent-mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.UseJunior/email-agent-mcp",
   "title": "Agent Email",
   "description": "Local email connectivity for AI agents — read, draft, send, and organize Outlook mail via MCP",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "websiteUrl": "https://github.com/UseJunior/email-agent-mcp",
   "repository": {
     "url": "https://github.com/UseJunior/email-agent-mcp",
@@ -26,7 +26,7 @@
     {
       "registryType": "npm",
       "identifier": "email-agent-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": {
         "type": "stdio"
       },

--- a/packages/email-core/package.json
+++ b/packages/email-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Core email actions, content engine, security, and provider interfaces for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/email-mcp/package.json
+++ b/packages/email-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/email-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server adapter + CLI + watcher for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -21,9 +21,9 @@
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@usejunior/email-core": "^0.3.0",
-    "@usejunior/provider-gmail": "^0.3.0",
-    "@usejunior/provider-microsoft": "^0.3.0"
+    "@usejunior/email-core": "^0.3.1",
+    "@usejunior/provider-gmail": "^0.3.1",
+    "@usejunior/provider-microsoft": "^0.3.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/packages/provider-gmail/package.json
+++ b/packages/provider-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-gmail",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Gmail API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@googleapis/gmail": "^4.0.0",
-    "@usejunior/email-core": "^0.3.0",
+    "@usejunior/email-core": "^0.3.1",
     "google-auth-library": "^8.9.0"
   },
   "devDependencies": {

--- a/packages/provider-microsoft/package.json
+++ b/packages/provider-microsoft/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@usejunior/provider-microsoft",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Microsoft Graph API email provider for email-agent-mcp",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/identity-cache-persistence": "^1.2.0",
     "@microsoft/microsoft-graph-client": "^3.0.0",
-    "@usejunior/email-core": "^0.3.0"
+    "@usejunior/email-core": "^0.3.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary
- bump all synchronized workspace and distribution versions to 0.3.1
- update exact/caret workspace dependency versions and package lock
- prepare the merged Gmail readonly + compose scope cut for tag-driven publication

## Verification
- npm run build
- npm run lint
- npm run test:run (1,112 Vitest tests + 32 Node tests passed)
- npm run check:spec-coverage (290/290)
- npm run check:server-json
- npm run check:gemini-extension-manifest
- node scripts/bump_version.mjs --check