### PR TITLE
feat(email-core): guard against caller-replayed duplicate delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,9 +602,13 @@ stuck -- replays the same approved instruction, and the second call looks exactl
 first one.
 
 `send_email`, `reply_to_email`, and `send_draft` therefore record each dispatch in an
-in-process ledger, keyed by a digest of what would actually be delivered (mailbox,
+in-process ledger, keyed by a digest of the effective action inputs -- mailbox,
 recipients, subject, rendered body, attachment contents, and the reply parent or draft
-id). A repeat within the window is refused before the provider is touched:
+id. (Effective *inputs*, not final wire bytes: a provider may transform a message on
+the way out, and Graph for instance truncates a subject at 255 characters, so two
+different inputs can leave as identical mail. The guard catches a replayed tool call,
+which is what actually happens.) A repeat within the window is refused before the
+delivery is dispatched:
 
 | Code | Meaning | What to do |
 |------|---------|------------|
@@ -618,9 +622,16 @@ never blocked. Anything else, including a code from a provider we have not seen,
 as unresolved: a wrongly-held message costs one blocked resend, a wrongly-released one
 costs a duplicate in somebody's inbox.
 
-To send the same message again on purpose, pass `allow_duplicate: true`. Operators can
-change the window with `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` (default `900000`); `0`
-disables the guard entirely.
+To send the same message again on purpose, pass `allow_duplicate: true`. It is an
+unconditional per-request bypass -- a replay that also carries the flag dispatches
+again, because the flag asserts that a person decided on this send. The forced attempt
+is recorded alongside the earlier one rather than replacing it, so if the override is
+rejected the original delivery still refuses an ordinary replay.
+
+Records are scoped to a mailbox: `mailbox` when the caller supplies one, otherwise the
+provider instance. Operators can change the window with
+`AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` (default `900000`); `0` disables the guard
+entirely.
 
 The ledger lives in the server process and in memory. It closes the replay window that
 actually happens -- a retry inside a running server -- and does not survive restarting

--- a/README.md
+++ b/README.md
@@ -589,6 +589,42 @@ Agent Email ships with restrictive defaults that you loosen as needed:
   2. the caller passes `user_explicitly_requested_deletion: true` on the tool call.
 - **Error sanitization**: API keys, file paths, and stack traces are redacted from error responses
 - **Body file sandboxing**: no `../` traversal, no symlinks, binary detection
+- **Duplicate-delivery guard**: on by default -- an identical send, reply, or draft-send repeated within 15 minutes is refused instead of delivered twice
+
+### Duplicate-delivery guard
+
+Provider send endpoints (Graph `POST /sendMail`, Gmail `users.messages.send`) take no
+idempotency key, so Agent Email dispatches each delivery exactly once and never retries
+one automatically. That stops the *library* from duplicating a message. It does not stop
+the *caller*: an agent whose tool result was lost -- a compacted context, a dropped
+transport, a supervisor restarting the turn, a person retrying something that looked
+stuck -- replays the same approved instruction, and the second call looks exactly like a
+first one.
+
+`send_email`, `reply_to_email`, and `send_draft` therefore record each dispatch in an
+in-process ledger, keyed by a digest of what would actually be delivered (mailbox,
+recipients, subject, rendered body, attachment contents, and the reply parent or draft
+id). A repeat within the window is refused before the provider is touched:
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| `DUPLICATE_SEND_IN_FLIGHT` | An identical delivery has not returned yet | Wait for the first call |
+| `DUPLICATE_SEND_BLOCKED` | An identical delivery already succeeded | Stop -- the response carries the original `messageId` |
+| `DUPLICATE_SEND_UNRESOLVED` | An identical delivery ended ambiguously | Check Sent Items before resending |
+
+A failure that *proves* nothing was delivered -- any 4xx-derived code, a 429, or a
+connect failure -- releases the record immediately, so resending after a rejection is
+never blocked. Anything else, including a code from a provider we have not seen, is held
+as unresolved: a wrongly-held message costs one blocked resend, a wrongly-released one
+costs a duplicate in somebody's inbox.
+
+To send the same message again on purpose, pass `allow_duplicate: true`. Operators can
+change the window with `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` (default `900000`); `0`
+disables the guard entirely.
+
+The ledger lives in the server process and in memory. It closes the replay window that
+actually happens -- a retry inside a running server -- and does not survive restarting
+that server.
 
 ## Packages
 

--- a/openspec/changes/add-duplicate-send-guard/design.md
+++ b/openspec/changes/add-duplicate-send-guard/design.md
@@ -1,0 +1,90 @@
+## Context
+
+`isRetryable(err, 'delivery') === false` and the single-attempt dispatch in the three
+delivery actions make the *library* safe. The residual risk is entirely above that
+line: a caller that re-issues the same tool call.
+
+This design adds the missing state — a record that a given delivery was attempted —
+and makes the delivery actions consult it.
+
+## Goals / Non-Goals
+
+**Goals**
+- A second identical delivery call within the window does not reach the provider.
+- A resend after a *proven* rejection is not blocked.
+- A human can override deliberately.
+- On by default, no embedder wiring.
+
+**Non-Goals**
+- Surviving a process restart. (See the limitation in the proposal.)
+- Cross-mailbox or cross-tenant deduplication.
+- Detecting near-duplicates. The fingerprint is exact by construction; a body that
+  differs by one character is a different message and is allowed through.
+
+## Decisions
+
+### Decision: fingerprint the delivery, not the call
+
+Keying on a caller-supplied idempotency key was rejected: it pushes the burden onto
+the caller we are defending against, and an agent that replays a call replays the key
+too — which would work — but an agent that *forgets* to send one gets no protection at
+all. Fingerprinting the delivery content means protection is automatic and a replay is
+detected whether or not the caller cooperates.
+
+The fingerprint covers everything that determines what the recipient receives:
+mailbox, action name, normalized `to`/`cc`, subject, the rendered body and bodyHtml
+(post-truncation, so the fingerprint matches the bytes that would go out), attachment
+name/size/content digests, `scheduled_send_at`, and the reply parent id / draft id.
+
+Attachment *content* is digested rather than compared, so the ledger never holds
+message bytes.
+
+### Decision: three states, not a boolean
+
+`in-flight` / `delivered` / `unresolved` are distinguished because the caller's next
+move differs: wait, stop (here is the id), or escalate to a human who can look in
+Sent Items. Collapsing them to one "duplicate" code would force the agent to guess.
+
+### Decision: fail closed on unknown outcome codes
+
+Only an explicit allowlist of codes releases the fingerprint —
+`RATE_LIMITED`, `INVALID_REQUEST`, `AUTH_REQUIRED`, `PERMISSION_DENIED`, `NOT_FOUND`,
+`CONFLICT`, `PAYLOAD_TOO_LARGE`, `PROVIDER_REJECTED`, `PROVIDER_UNREACHABLE`,
+`SCHEDULE_SEND_FAILED`, `NOT_SUPPORTED`. These are exactly the outcomes the existing
+`classifyHttpStatus` reasoning already proves did not deliver: a 4xx proves receipt
+and rejection; a connect-failure proves no bytes were written.
+
+Every other code, including one this version has never seen from a third-party
+provider, holds the fingerprint as `unresolved`. The asymmetry is intentional. A false
+hold costs friction and has an override; a false release costs a duplicate in
+someone's inbox, which is the bug being fixed.
+
+### Decision: default-on singleton, injectable for tests
+
+`ActionContext.sendLedger` is optional, but when absent the actions use a module-level
+default rather than skipping the guard. `ActionContext.rateLimiter` is the cautionary
+example: it is an optional interface that no shipped adapter constructs, so the rate
+limit it describes does not exist in the product. An optional guard is not a guard.
+
+Tests inject a fresh `SendLedger` (and `resetDefaultSendLedger()` exists for suites
+that exercise the default path) so cases stay independent.
+
+### Decision: claim before dispatch, settle after
+
+The claim is written *before* the provider call, not after, so the in-flight window —
+the exact window in which the acknowledgement gets lost — is covered. A settle
+records the terminal state; a release removes the record.
+
+If the action throws between claim and settle, the record stays `in-flight` until its
+TTL expires and then becomes claimable again. Holding rather than releasing is the
+fail-closed direction: a throw after dispatch is precisely the ambiguous case.
+
+## Risks / Trade-offs
+
+- **Legitimate identical resends inside the window are blocked.** Mitigated by
+  `allow_duplicate`, by the 15-minute default, and by the error message naming the
+  flag. Repeated identical automated mail (a status ping) is normally further apart
+  than the window; an operator who disagrees can set the window to `0`.
+- **Memory growth.** Bounded: entries are pruned by TTL on every access and the map is
+  capped at 512 records, evicting oldest-first.
+- **A restart clears the ledger.** Documented rather than papered over.

--- a/openspec/changes/add-duplicate-send-guard/proposal.md
+++ b/openspec/changes/add-duplicate-send-guard/proposal.md
@@ -39,8 +39,13 @@ current design has the state to notice.
   is safe and must not be blocked. Anything else — including an unrecognised code —
   is held as unresolved. The guard fails closed.
 - Add `allow_duplicate: true` to the three delivery actions as the deliberate escape
-  hatch. The guard is a wall against machine replay and a speed bump for a human who
-  has decided to send the same thing twice on purpose.
+  hatch. It is an unconditional per-request bypass: a replay that itself carries the
+  flag dispatches again, because the flag says a person decided on this send. It
+  admits an attempt *alongside* the existing records rather than replacing them, so a
+  rejected override cannot clear the delivery it was overriding.
+- Each attempt carries its own identity, and a claim's settle/release act only on the
+  attempt that produced them. Addressing the fingerprint alone let a slow attempt's
+  late rejection delete a newer attempt's successful record.
 - The guard is **on by default**, with no wiring required by an embedder. This is
   deliberate: `ActionContext.rateLimiter` is an optional injected interface that no
   shipped adapter ever constructs, so it is inert in production. A duplicate-send
@@ -58,8 +63,16 @@ current design has the state to notice.
 - Compatibility: additive. The new input field is optional and the new error codes are
   only reachable on a second identical call within the window, which previously
   delivered a duplicate.
-- Security: the ledger stores a salted digest of message content, never the content
-  itself, and never leaves the process.
+- Security: the ledger stores a SHA-256 digest of canonical message content, never
+  the content itself, and never leaves the process. The digest is unsalted — it is a
+  collision key, not a privacy control. (An earlier draft of this proposal said
+  "salted digest"; no salt was ever implemented, and the claim was wrong when
+  written. Adding one is a separate privacy decision, not a duplicate-detection
+  requirement.)
+- Namespace: the fingerprint is scoped by `ctx.mailboxName`, falling back to a
+  per-provider-instance id when the caller supplies none. Two mailboxes in one
+  process previously shared the empty key, so the second mailbox's first-ever send
+  was refused and handed the first mailbox's message id.
 - **Documented limitation:** the ledger is per-process and in-memory, so it does not
   survive an MCP server restart. It closes the replay window that actually occurs —
   the agent loop retrying inside a live server — and does not claim to close a

--- a/openspec/changes/add-duplicate-send-guard/proposal.md
+++ b/openspec/changes/add-duplicate-send-guard/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+`email-write` already forbids automatic retry of a delivery: the provider endpoints
+carry no idempotency key, so the action layer dispatches exactly once and reports an
+ambiguous outcome as `SEND_STATUS_UNKNOWN`. That closes the machine-retry hole. It
+does not close the caller-replay hole.
+
+The guarantee today is "the library will not retry," not "a replay cannot duplicate."
+Nothing at the action layer stops the *caller* from re-issuing the identical send.
+The only defence is a sentence of English in each tool description — "do not resend
+without checking Sent Items" — and an LLM under retry pressure, or a supervisor loop
+that lost the tool result mid-flight, is exactly the caller that skips it. The
+failure is invisible when it happens: the second call succeeds, and the recipient
+gets the message twice.
+
+The concrete sequence: an agent calls `send_email`; the provider accepts; the
+acknowledgement is lost (context compaction, transport drop, process supervisor
+restart of the agent loop, a human retrying a "stuck" turn); the agent replays the
+same approved instruction; a second message is delivered. No component in the
+current design has the state to notice.
+
+## What Changes
+
+- Add a **send ledger**: an in-process, TTL-bounded record of delivery attempts keyed
+  by a stable fingerprint of what would be delivered (mailbox, action, recipients,
+  subject, rendered body, attachment digests, and for replies/drafts the parent
+  message or draft id).
+- Delivery actions (`send_email`, `reply_to_email`, `send_draft`) **claim** the
+  fingerprint before dispatch and settle it after. A claim that collides with a live
+  record short-circuits before the provider call and returns a structured error
+  instead of delivering.
+- Three outcomes are distinguished, because the recovery differs:
+  `DUPLICATE_SEND_IN_FLIGHT` (a prior identical attempt has not returned),
+  `DUPLICATE_SEND_BLOCKED` (a prior identical attempt was delivered — the prior
+  `messageId` is returned), and `DUPLICATE_SEND_UNRESOLVED` (a prior identical
+  attempt ended ambiguously, so Sent Items must be checked by a human).
+- A failure that **proves** nothing was delivered (any 4xx-derived code, a 429, or a
+  connect-failure) releases the fingerprint immediately: resending after a rejection
+  is safe and must not be blocked. Anything else — including an unrecognised code —
+  is held as unresolved. The guard fails closed.
+- Add `allow_duplicate: true` to the three delivery actions as the deliberate escape
+  hatch. The guard is a wall against machine replay and a speed bump for a human who
+  has decided to send the same thing twice on purpose.
+- The guard is **on by default**, with no wiring required by an embedder. This is
+  deliberate: `ActionContext.rateLimiter` is an optional injected interface that no
+  shipped adapter ever constructs, so it is inert in production. A duplicate-send
+  guard that has to be opted into is a guard that is off.
+- `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` tunes the retention window (default 15
+  minutes); `0` disables the guard for operators who want the old behavior.
+
+## Impact
+
+- Affected specs: `email-write`
+- Affected code: new `email-core/src/security/send-ledger.ts`; claim/settle wiring in
+  `actions/send.ts`, `actions/reply.ts`, `actions/draft.ts`; `ActionContext` gains an
+  optional `sendLedger`; new input field and error codes on three action schemas;
+  `index.ts` exports; tool descriptions.
+- Compatibility: additive. The new input field is optional and the new error codes are
+  only reachable on a second identical call within the window, which previously
+  delivered a duplicate.
+- Security: the ledger stores a salted digest of message content, never the content
+  itself, and never leaves the process.
+- **Documented limitation:** the ledger is per-process and in-memory, so it does not
+  survive an MCP server restart. It closes the replay window that actually occurs —
+  the agent loop retrying inside a live server — and does not claim to close a
+  crash-and-restart window. Cross-process durability would need a persisted store and
+  is deliberately out of scope here.

--- a/openspec/changes/add-duplicate-send-guard/specs/email-write/spec.md
+++ b/openspec/changes/add-duplicate-send-guard/specs/email-write/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: Duplicate Delivery Guard
+
+Delivery operations (`send_email`, `reply_to_email`, `send_draft`) SHALL record each
+dispatch attempt in a send ledger keyed by a stable fingerprint of the delivery
+(mailbox, action, normalized recipients, subject, rendered body and bodyHtml,
+attachment digests, `scheduled_send_at`, and the reply parent id or draft id). The
+record SHALL be written BEFORE the provider is invoked and settled after it returns.
+
+When a delivery request's fingerprint matches a live ledger record, the system SHALL
+NOT invoke the provider and SHALL return a structured error naming the prior attempt's
+state: `DUPLICATE_SEND_IN_FLIGHT` when the prior attempt has not returned,
+`DUPLICATE_SEND_BLOCKED` when it was delivered (carrying the prior `messageId`), and
+`DUPLICATE_SEND_UNRESOLVED` when its outcome was ambiguous.
+
+A delivery outcome that PROVES nothing was delivered — any 4xx-derived code, a 429, a
+connect-failure, or an unsupported-capability rejection — SHALL release the
+fingerprint, so a resend after a rejection is permitted. Any other outcome, including
+an unrecognized provider code, SHALL be held as unresolved.
+
+The guard SHALL be active without embedder configuration. Callers MAY bypass it for a
+single request with `allow_duplicate: true`. Operators MAY tune the retention window
+with `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS`, where `0` disables the guard.
+
+The ledger is per-process and in-memory; it SHALL NOT be presented as surviving a
+restart of the server.
+
+#### Scenario: Replay after successful delivery is blocked
+- **WHEN** `send_email` succeeds and an identical `send_email` is called again within the window
+- **THEN** the provider is not invoked a second time
+- **AND** the system returns `{success: false, error: {code: "DUPLICATE_SEND_BLOCKED", recoverable: false}}` carrying the `messageId` of the first delivery
+
+#### Scenario: Replay after ambiguous outcome is blocked
+- **WHEN** a send fails with `SEND_STATUS_UNKNOWN` and an identical send is called again within the window
+- **THEN** the provider is not invoked a second time
+- **AND** the system returns `DUPLICATE_SEND_UNRESOLVED` with guidance to check Sent Items before resending
+
+#### Scenario: Concurrent identical send is blocked while in flight
+- **WHEN** an identical send is issued while a prior attempt with the same fingerprint has not yet returned
+- **THEN** the second call returns `DUPLICATE_SEND_IN_FLIGHT` without invoking the provider
+
+#### Scenario: Resend after a proven rejection is allowed
+- **WHEN** a send fails with a code that proves the provider rejected it (for example `INVALID_REQUEST` or `RATE_LIMITED`)
+- **AND** the same send is issued again
+- **THEN** the fingerprint has been released and the provider is invoked
+
+#### Scenario: Unrecognized failure code is held as unresolved
+- **WHEN** a send fails with a provider code that is not on the proven-unsent list
+- **AND** the same send is issued again within the window
+- **THEN** the system returns `DUPLICATE_SEND_UNRESOLVED` rather than delivering again
+
+#### Scenario: A different message is not blocked
+- **WHEN** a send succeeds and a send differing in any fingerprinted field is issued
+- **THEN** the provider is invoked normally
+
+#### Scenario: Explicit duplicate override delivers
+- **WHEN** an identical send is issued with `allow_duplicate: true` after a prior delivery
+- **THEN** the provider is invoked and the ledger record is replaced by the new attempt
+
+#### Scenario: Guard is active without embedder wiring
+- **WHEN** a delivery action runs with an ActionContext that supplies no send ledger
+- **THEN** the process-default ledger is used and an identical replay is still refused
+
+#### Scenario: Replayed draft send reports the duplicate, not a stale draft lookup
+- **WHEN** `send_draft` succeeds and the same `draft_id` is sent again
+- **THEN** the system returns `DUPLICATE_SEND_BLOCKED`
+- **AND** it does not report a draft-lookup failure caused by the provider having consumed the draft on the first send
+
+#### Scenario: A bail-out before dispatch does not block the corrected call
+- **WHEN** a delivery is refused after the ledger record is written but before the provider is invoked (draft lookup failure, empty recipients, allowlist refusal, rate limit)
+- **THEN** the record is released
+- **AND** a corrected delivery with the same fingerprint is dispatched normally
+
+#### Scenario: Guard disabled by window of zero
+- **WHEN** `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` is `0`
+- **THEN** identical repeated sends are dispatched without duplicate checking

--- a/openspec/changes/add-duplicate-send-guard/specs/email-write/spec.md
+++ b/openspec/changes/add-duplicate-send-guard/specs/email-write/spec.md
@@ -9,8 +9,11 @@ attachment digests, `scheduled_send_at`, and the reply parent id or draft id). T
 record SHALL be written BEFORE the provider is invoked and settled after it returns.
 
 When a delivery request's fingerprint matches a live ledger record, the system SHALL
-NOT invoke the provider and SHALL return a structured error naming the prior attempt's
-state: `DUPLICATE_SEND_IN_FLIGHT` when the prior attempt has not returned,
+NOT dispatch the delivery and SHALL return a structured error naming the prior
+attempt's state. (Provider *reads* may still occur: `reply_to_email` fetches the
+parent message for its allowlist check before the ledger is consulted, and
+`send_draft` reads the draft. Only the delivery dispatch is suppressed.) The states
+are: `DUPLICATE_SEND_IN_FLIGHT` when the prior attempt has not returned,
 `DUPLICATE_SEND_BLOCKED` when it was delivered (carrying the prior `messageId`), and
 `DUPLICATE_SEND_UNRESOLVED` when its outcome was ambiguous.
 
@@ -18,6 +21,16 @@ A delivery outcome that PROVES nothing was delivered — any 4xx-derived code, a
 connect-failure, or an unsupported-capability rejection — SHALL release the
 fingerprint, so a resend after a rejection is permitted. Any other outcome, including
 an unrecognized provider code, SHALL be held as unresolved.
+
+Each attempt SHALL carry an identity, and a settlement or release SHALL apply only to
+the attempt that produced it. A fingerprint MAY carry more than one live attempt; a
+colliding claim SHALL be told about the strongest evidence available, preferring a
+delivered attempt over an unresolved one over one still in flight. The ledger SHALL
+NOT discard an in-flight reservation to stay within its size bound, and SHALL retain a
+successful outcome that settles after its reservation was pruned.
+
+The fingerprint SHALL be scoped to a mailbox namespace: the caller-supplied mailbox
+name, or a per-provider-instance identity when none is supplied.
 
 The guard SHALL be active without embedder configuration. Callers MAY bypass it for a
 single request with `allow_duplicate: true`. Operators MAY tune the retention window
@@ -28,17 +41,17 @@ restart of the server.
 
 #### Scenario: Replay after successful delivery is blocked
 - **WHEN** `send_email` succeeds and an identical `send_email` is called again within the window
-- **THEN** the provider is not invoked a second time
+- **THEN** the delivery is not dispatched a second time
 - **AND** the system returns `{success: false, error: {code: "DUPLICATE_SEND_BLOCKED", recoverable: false}}` carrying the `messageId` of the first delivery
 
 #### Scenario: Replay after ambiguous outcome is blocked
 - **WHEN** a send fails with `SEND_STATUS_UNKNOWN` and an identical send is called again within the window
-- **THEN** the provider is not invoked a second time
+- **THEN** the delivery is not dispatched a second time
 - **AND** the system returns `DUPLICATE_SEND_UNRESOLVED` with guidance to check Sent Items before resending
 
 #### Scenario: Concurrent identical send is blocked while in flight
 - **WHEN** an identical send is issued while a prior attempt with the same fingerprint has not yet returned
-- **THEN** the second call returns `DUPLICATE_SEND_IN_FLIGHT` without invoking the provider
+- **THEN** the second call returns `DUPLICATE_SEND_IN_FLIGHT` without dispatching
 
 #### Scenario: Resend after a proven rejection is allowed
 - **WHEN** a send fails with a code that proves the provider rejected it (for example `INVALID_REQUEST` or `RATE_LIMITED`)
@@ -56,7 +69,8 @@ restart of the server.
 
 #### Scenario: Explicit duplicate override delivers
 - **WHEN** an identical send is issued with `allow_duplicate: true` after a prior delivery
-- **THEN** the provider is invoked and the ledger record is replaced by the new attempt
+- **THEN** the delivery is dispatched and the new attempt is recorded ALONGSIDE the prior one
+- **AND** if the forced attempt is rejected, the prior delivery still refuses an ordinary replay
 
 #### Scenario: Guard is active without embedder wiring
 - **WHEN** a delivery action runs with an ActionContext that supplies no send ledger
@@ -71,6 +85,16 @@ restart of the server.
 - **WHEN** a delivery is refused after the ledger record is written but before the provider is invoked (draft lookup failure, empty recipients, allowlist refusal, rate limit)
 - **THEN** the record is released
 - **AND** a corrected delivery with the same fingerprint is dispatched normally
+
+#### Scenario: Separate mailboxes do not share a duplicate record
+- **WHEN** two mailboxes in one process send an identical message and neither context supplies a mailbox name
+- **THEN** each delivery is dispatched once
+- **AND** neither response carries the other mailbox's `messageId`
+
+#### Scenario: A stale settlement cannot overwrite a newer attempt
+- **WHEN** two attempts are live on one fingerprint (an ordinary one and an `allow_duplicate` one) and the older settles after the newer
+- **THEN** each settlement applies only to the attempt that produced it
+- **AND** a subsequent ordinary replay is still refused
 
 #### Scenario: Guard disabled by window of zero
 - **WHEN** `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` is `0`

--- a/openspec/changes/add-duplicate-send-guard/tasks.md
+++ b/openspec/changes/add-duplicate-send-guard/tasks.md
@@ -1,0 +1,25 @@
+## 1. Ledger
+
+- [x] 1.1 Add `packages/email-core/src/security/send-ledger.ts`: fingerprint builder, `SendLedger` class (claim/settle/release, TTL + size pruning), default singleton, and the `duplicateSendError` builder
+- [x] 1.2 Add `send-ledger.test.ts` covering claim collision per state, release on proven-unsent codes, fail-closed on unknown codes, TTL expiry, and size eviction
+
+## 2. Wiring
+
+- [x] 2.1 Add optional `sendLedger` to `ActionContext`
+- [x] 2.2 Claim/settle `send_email` (immediate and scheduled paths)
+- [x] 2.3 Claim/settle `reply_to_email` (send path only — the draft path delivers nothing)
+- [x] 2.4 Claim/settle `send_draft` (immediate and scheduled paths)
+- [x] 2.5 Add `allow_duplicate` input and the three duplicate error codes to the three action schemas
+- [x] 2.6 Update the three tool descriptions
+- [x] 2.7 Export the ledger surface from `email-core/src/index.ts`
+
+## 3. Tests
+
+- [x] 3.1 Action-level scenario tests: replay blocked after delivery, after ambiguous outcome, and while in flight
+- [x] 3.2 Action-level scenario tests: resend allowed after a proven rejection, and under `allow_duplicate`
+- [x] 3.3 Negative control: the guard must be able to fail — a test that a *different* message is not blocked
+
+## 4. Docs and gates
+
+- [x] 4.1 Document `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` in README
+- [x] 4.2 `npm run build`, `npm run lint --workspaces --if-present`, `npm run test:run`, `npm run check:spec-coverage`

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -10,6 +10,12 @@ import type { PathSandboxInput } from '../content/safe-path.js';
 import type { BodyFormat } from '../content/body-renderer.js';
 import { parseAddressList } from '../utils/address.js';
 import { validateAttachment, sanitizeFilename } from './attachments.js';
+import {
+  computeSendFingerprint,
+  duplicateSendError,
+  getDefaultSendLedger,
+} from '../security/send-ledger.js';
+import type { SendClaim, SendFingerprintInput } from '../security/send-ledger.js';
 import type { EmailAddress, EmailMessage, OutboundAttachment } from '../types.js';
 
 // --- Error shape used by all actions ---
@@ -491,4 +497,69 @@ export function handleProviderError(err: unknown, fallbackCode: string) {
       recoverable: false,
     },
   };
+}
+
+// --- claimDelivery ---
+
+/**
+ * The deliberate-duplicate escape hatch, shared by every delivery action.
+ *
+ * Worded for the agent reading the tool schema: the guard exists because an
+ * agent replaying a lost turn is the common case, so the flag has to read as a
+ * human decision rather than a retry knob.
+ */
+export const AllowDuplicateSchema = z.boolean()
+  .describe('Bypass the duplicate-delivery guard for this request. The guard refuses an identical delivery repeated within the duplicate window (default 15 minutes) so a replayed tool call cannot send the same message twice. Set true ONLY when a person has decided to deliberately send the same message again — never as a way to retry a call that failed.');
+
+export type DeliveryClaim =
+  | { claim: SendClaim }
+  | { duplicate: { success: false; messageId?: string; error: ActionError } };
+
+/**
+ * Reserve this delivery in the send ledger before touching the provider.
+ *
+ * Call AFTER every pre-dispatch gate (mailbox, allowlist, rate limit) and
+ * IMMEDIATELY BEFORE the provider call, so the reserved window is exactly the
+ * window in which an acknowledgement can be lost.
+ *
+ * On a collision the prior attempt's `messageId` is surfaced at the top level
+ * even though `success` is false: the caller asked whether this message went
+ * out, and the honest answer includes which message it already is.
+ */
+export function claimDelivery(
+  ctx: ActionContext,
+  actionName: string,
+  fingerprintInput: Omit<SendFingerprintInput, 'action' | 'mailbox'>,
+  allowDuplicate: boolean | undefined,
+): DeliveryClaim {
+  const ledger = ctx.sendLedger ?? getDefaultSendLedger();
+  const fingerprint = computeSendFingerprint({
+    ...fingerprintInput,
+    action: actionName,
+    mailbox: ctx.mailboxName,
+  });
+  const result = ledger.claim(fingerprint, { force: allowDuplicate === true });
+  if (result.ok) return { claim: result };
+  return {
+    duplicate: {
+      success: false,
+      ...(result.prior.messageId !== undefined ? { messageId: result.prior.messageId } : {}),
+      error: duplicateSendError(result.prior, actionName),
+    },
+  };
+}
+
+/**
+ * Settle a claim from a thrown provider error.
+ *
+ * Only a classified ProviderError carries a code we can reason about. An
+ * unclassified throw is settled with no code at all, which the ledger holds as
+ * unresolved — the fail-closed direction, because a throw after dispatch is
+ * exactly the case where we cannot prove the message did not go out.
+ */
+export function settleClaimFromThrow(claim: SendClaim, err: unknown): void {
+  claim.settle({
+    success: false,
+    ...(isProviderError(err) ? { errorCode: err.code } : {}),
+  });
 }

--- a/packages/email-core/src/actions/compose-helpers.ts
+++ b/packages/email-core/src/actions/compose-helpers.ts
@@ -14,6 +14,7 @@ import {
   computeSendFingerprint,
   duplicateSendError,
   getDefaultSendLedger,
+  providerNamespace,
 } from '../security/send-ledger.js';
 import type { SendClaim, SendFingerprintInput } from '../security/send-ledger.js';
 import type { EmailAddress, EmailMessage, OutboundAttachment } from '../types.js';
@@ -533,10 +534,14 @@ export function claimDelivery(
   allowDuplicate: boolean | undefined,
 ): DeliveryClaim {
   const ledger = ctx.sendLedger ?? getDefaultSendLedger();
+  // Namespace the fingerprint by mailbox. `mailboxName` is optional on
+  // ActionContext, and two mailboxes sharing the process default ledger under
+  // an empty key would collide — the second mailbox's first send refused, and
+  // handed the first mailbox's message id. Fall back to the provider instance.
   const fingerprint = computeSendFingerprint({
     ...fingerprintInput,
     action: actionName,
-    mailbox: ctx.mailboxName,
+    mailbox: ctx.mailboxName ?? providerNamespace(ctx.provider),
   });
   const result = ledger.claim(fingerprint, { force: allowDuplicate === true });
   if (result.ok) return { claim: result };

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -8,6 +8,7 @@ import { sendEmailAction } from './send.js';
 import { replyToEmailAction } from './reply.js';
 import { buildDraftPreview, PREVIEW_BODY_LIMIT } from './compose-helpers.js';
 import { ProviderError } from '../providers/provider.js';
+import { SendLedger } from '../security/send-ledger.js';
 import type { ActionContext } from './registry.js';
 import type { EmailMessage } from '../types.js';
 
@@ -21,6 +22,10 @@ beforeEach(async () => {
   await mkdir(testDir, { recursive: true });
   ctx = {
     provider,
+    // A fresh ledger per test. Without it the process-default ledger is shared
+    // across cases, and two tests sending the same message collide as
+    // duplicates — which is the guard working, not a test bug.
+    sendLedger: new SendLedger(),
     sendAllowlist: { entries: ['*@allowed.com'] },
     safeDir: testDir,
   };
@@ -1709,5 +1714,91 @@ describe('email-write/Reply Scope Control', () => {
       expect.any(String),
       expect.objectContaining({ replyAll: false }),
     );
+  });
+});
+
+describe('email-write/Duplicate Delivery Guard (send_draft)', () => {
+  async function makeDraft(): Promise<string> {
+    const draft = await createDraftAction.run(ctx, {
+      to: 'alice@allowed.com',
+      subject: 'Draft to Send',
+      body: 'Body',
+    });
+    return draft.draftId!;
+  }
+
+  it('Scenario: Replayed draft send reports the duplicate, not a stale draft lookup', async () => {
+    const draftId = await makeDraft();
+
+    const first = await sendDraftAction.run(ctx, { draft_id: draftId });
+    expect(first.success).toBe(true);
+
+    const replay = await sendDraftAction.run(ctx, { draft_id: draftId });
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+    expect(replay.messageId).toBe(first.messageId);
+  });
+
+  it('does not block a different draft', async () => {
+    const a = await makeDraft();
+    const b = await makeDraft();
+
+    expect((await sendDraftAction.run(ctx, { draft_id: a })).success).toBe(true);
+    expect((await sendDraftAction.run(ctx, { draft_id: b })).success).toBe(true);
+  });
+
+  it('allows a resend after a failure that proves the draft was not delivered', async () => {
+    const draftId = await makeDraft();
+    let calls = 0;
+    const realSendDraft = provider.sendDraft.bind(provider);
+    provider.sendDraft = async (id: string) => {
+      calls++;
+      if (calls === 1) throw new ProviderError('INVALID_REQUEST', 'rejected', 'microsoft', false);
+      return realSendDraft(id);
+    };
+
+    expect((await sendDraftAction.run(ctx, { draft_id: draftId })).error!.code).toBe('INVALID_REQUEST');
+    expect((await sendDraftAction.run(ctx, { draft_id: draftId })).success).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  it('holds the draft after an ambiguous failure rather than letting a replay resend it', async () => {
+    const draftId = await makeDraft();
+    let calls = 0;
+    provider.sendDraft = async () => {
+      calls++;
+      throw new ProviderError('SEND_STATUS_UNKNOWN', 'response lost', 'test', false);
+    };
+
+    expect((await sendDraftAction.run(ctx, { draft_id: draftId })).error!.code).toBe('SEND_STATUS_UNKNOWN');
+    const replay = await sendDraftAction.run(ctx, { draft_id: draftId });
+
+    expect(calls).toBe(1);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_UNRESOLVED');
+  });
+
+  it('releases the reservation when the draft lookup fails before dispatch', async () => {
+    // The claim is taken before the lookup, so a lookup failure must release
+    // it — otherwise a typo in a draft id would poison that id for 15 minutes
+    // and report a duplicate that never happened.
+    const first = await sendDraftAction.run(ctx, { draft_id: 'no-such-draft' });
+    const second = await sendDraftAction.run(ctx, { draft_id: 'no-such-draft' });
+
+    expect(first.error!.code).toBe('DRAFT_LOOKUP_FAILED');
+    expect(second.error!.code).toBe('DRAFT_LOOKUP_FAILED');
+  });
+
+  it('lets allow_duplicate past the guard, leaving the real obstacle visible', async () => {
+    // Sending consumes the draft, so a deliberate duplicate of a *draft* fails
+    // on the draft being gone rather than on the guard. The flag bypasses the
+    // duplicate check; it does not conjure back a message that no longer
+    // exists, and the error the caller sees says which of those happened.
+    const draftId = await makeDraft();
+    await sendDraftAction.run(ctx, { draft_id: draftId });
+
+    const forced = await sendDraftAction.run(ctx, { draft_id: draftId, allow_duplicate: true });
+
+    expect(forced.success).toBe(false);
+    expect(forced.error!.code).toBe('DRAFT_LOOKUP_FAILED');
+    expect(forced.error!.code).not.toMatch(/^DUPLICATE_SEND_/);
   });
 });

--- a/packages/email-core/src/actions/draft.test.ts
+++ b/packages/email-core/src/actions/draft.test.ts
@@ -1787,6 +1787,21 @@ describe('email-write/Duplicate Delivery Guard (send_draft)', () => {
     expect(second.error!.code).toBe('DRAFT_LOOKUP_FAILED');
   });
 
+  it('keeps the original delivery record when a forced resend aborts before dispatch', async () => {
+    // Forcing a consumed draft fails at the lookup, which releases the forced
+    // claim. That release must not take the original delivery with it, or an
+    // ordinary replay reports DRAFT_LOOKUP_FAILED instead of naming the
+    // message that already went out.
+    const draftId = await makeDraft();
+    const first = await sendDraftAction.run(ctx, { draft_id: draftId });
+    await sendDraftAction.run(ctx, { draft_id: draftId, allow_duplicate: true });
+
+    const replay = await sendDraftAction.run(ctx, { draft_id: draftId });
+
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+    expect(replay.messageId).toBe(first.messageId);
+  });
+
   it('lets allow_duplicate past the guard, leaving the real obstacle visible', async () => {
     // Sending consumes the draft, so a deliberate duplicate of a *draft* fails
     // on the draft being gone rather than on the guard. The flag bypasses the

--- a/packages/email-core/src/actions/draft.ts
+++ b/packages/email-core/src/actions/draft.ts
@@ -24,6 +24,9 @@ import {
   DraftPreviewSchema,
   PreviewErrorSchema,
   pathSandbox,
+  claimDelivery,
+  settleClaimFromThrow,
+  AllowDuplicateSchema,
 } from './compose-helpers.js';
 
 // --- Shared schemas ---
@@ -211,6 +214,7 @@ const SendDraftInput = z.object({
   draft_id: z.string(),
   mailbox: z.string().optional(),
   scheduled_send_at: ScheduledSendAtSchema.optional(),
+  allow_duplicate: AllowDuplicateSchema.optional(),
 });
 
 const SendDraftOutput = z.object({
@@ -232,7 +236,7 @@ export const sendDraftAction: EmailAction<
   z.infer<typeof SendDraftOutput>
 > = {
   name: 'send_draft',
-  description: 'Send a previously created draft. Enforces send allowlist before sending. Rate-limited. If a send fails with SEND_STATUS_UNKNOWN, the message may already have been delivered; do not resend without checking Sent Items.',
+  description: 'Send a previously created draft. Enforces send allowlist before sending. Rate-limited. If a send fails with SEND_STATUS_UNKNOWN, the message may already have been delivered; do not resend without checking Sent Items. Sending the same draft id twice within the duplicate window is refused with a DUPLICATE_SEND_* code instead of delivering twice; pass allow_duplicate: true only when a human has decided to send it again.',
   input: SendDraftInput,
   output: SendDraftOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -253,6 +257,24 @@ export const sendDraftAction: EmailAction<
       if (!ctx.provider.scheduleDraft) return scheduledSendNotSupportedError();
     }
 
+    // Reserve this delivery before ANY other work — see claimDelivery.
+    //
+    // A draft id IS the fingerprint here: the same draft sent twice is the same
+    // message twice. The claim goes ahead of the draft lookup deliberately,
+    // because a provider that consumed the draft on the first send makes the
+    // second lookup fail — and "cannot verify draft recipients" is a
+    // misleading answer to "did this already go out?". Every bail-out between
+    // here and dispatch releases the claim, so nothing that provably did not
+    // send can block the corrected call.
+    const claimed = claimDelivery(
+      ctx,
+      'send_draft',
+      { draftId: input.draft_id, scheduledSendAt },
+      input.allow_duplicate,
+    );
+    if ('duplicate' in claimed) return claimed.duplicate;
+    const { claim } = claimed;
+
     // Fetch draft to check recipients against allowlist (fail closed)
     let draftMessage;
     try {
@@ -261,6 +283,7 @@ export const sendDraftAction: EmailAction<
         { operation: 'idempotent-read' },
       );
     } catch (err) {
+      claim.release();
       return {
         success: false,
         error: {
@@ -280,6 +303,7 @@ export const sendDraftAction: EmailAction<
       ...(draftMessage.bcc?.map(a => a.email) ?? []),
     ];
     if (recipients.length === 0) {
+      claim.release();
       return {
         success: false,
         error: { code: 'NO_RECIPIENTS', message: 'Draft has no recipients', recoverable: false },
@@ -288,6 +312,7 @@ export const sendDraftAction: EmailAction<
 
     const allowlistError = checkSendAllowlist(recipients, ctx.sendAllowlist);
     if (allowlistError) {
+      claim.release();
       return {
         success: false,
         error: { code: 'ALLOWLIST_BLOCKED', message: allowlistError, recoverable: false },
@@ -297,6 +322,7 @@ export const sendDraftAction: EmailAction<
     // Check rate limit
     const rateLimitError = checkRateLimit(ctx.rateLimiter, 'send_draft');
     if (rateLimitError) {
+      claim.release();
       return rateLimitError;
     }
 
@@ -304,6 +330,11 @@ export const sendDraftAction: EmailAction<
       if (scheduledSendAt !== undefined) {
         // Capability presence was checked before draft lookup above.
         const result = await ctx.provider.scheduleDraft!(input.draft_id, scheduledSendAt);
+        claim.settle({
+          success: result.success,
+          ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+          ...(result.error?.code !== undefined ? { errorCode: result.error.code } : {}),
+        });
         if (
           ctx.rateLimiter
           && (result.success || result.error?.code === 'SCHEDULE_SEND_STATUS_UNKNOWN')
@@ -330,6 +361,12 @@ export const sendDraftAction: EmailAction<
       // deliver duplicates. Fail fast instead.
       const result = await ctx.provider.sendDraft(input.draft_id);
 
+      claim.settle({
+        success: result.success,
+        ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+        ...(result.error?.code !== undefined ? { errorCode: result.error.code } : {}),
+      });
+
       if (ctx.rateLimiter) {
         ctx.rateLimiter.recordUsage('send_draft');
       }
@@ -345,6 +382,7 @@ export const sendDraftAction: EmailAction<
         } : undefined,
       };
     } catch (err) {
+      settleClaimFromThrow(claim, err);
       const handled = handleProviderError(err, 'SEND_STATUS_UNKNOWN');
       if (ctx.rateLimiter && handled.error.code === 'SEND_STATUS_UNKNOWN') {
         ctx.rateLimiter.recordUsage('send_draft');

--- a/packages/email-core/src/actions/registry.ts
+++ b/packages/email-core/src/actions/registry.ts
@@ -1,6 +1,7 @@
 // Action registry — single source of truth for all email actions
 import { z } from 'zod';
 import type { EmailProvider } from '../providers/provider.js';
+import type { SendLedger } from '../security/send-ledger.js';
 import { listAttachmentsAction, downloadAttachmentAction } from './attachments.js';
 import { getThreadAction } from './conversation.js';
 import { createDraftAction, sendDraftAction, updateDraftAction } from './draft.js';
@@ -30,6 +31,14 @@ export interface ActionContext {
   deleteEnabled?: boolean;
   hardDeleteAllowed?: boolean;
   rateLimiter?: RateLimiter;
+  /**
+   * Duplicate-delivery guard. Optional only so tests can inject an isolated
+   * ledger — when absent the delivery actions fall back to the process default
+   * rather than skipping the check, because a guard an embedder has to wire is
+   * a guard that is off (see `rateLimiter` above, which no shipped adapter
+   * constructs).
+   */
+  sendLedger?: SendLedger;
 }
 
 export interface MailboxEntry {

--- a/packages/email-core/src/actions/reply.test.ts
+++ b/packages/email-core/src/actions/reply.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { replyToEmailAction } from './reply.js';
 import { ProviderError } from '../providers/provider.js';
+import { SendLedger } from '../security/send-ledger.js';
 import type { ActionContext } from './registry.js';
 import type { EmailMessage } from '../types.js';
 
@@ -24,6 +25,10 @@ beforeEach(() => {
   });
   ctx = {
     provider,
+    // A fresh ledger per test. Without it the process-default ledger is shared
+    // across cases, and two tests sending the same message collide as
+    // duplicates — which is the guard working, not a test bug.
+    sendLedger: new SendLedger(),
     mailboxName: 'work',
     allMailboxes: [
       { name: 'work', emailAddress: 'me@company.com', provider, providerType: 'microsoft', isDefault: true, status: 'connected' },
@@ -588,5 +593,43 @@ describe('email-write/Delivery Failure Handling', () => {
     expect(callCount).toBe(1);
     expect(result.success).toBe(false);
     expect(result.error!.code).toBe('SEND_STATUS_UNKNOWN');
+  });
+});
+
+describe('email-write/Duplicate Delivery Guard (reply)', () => {
+  const REPLY = { message_id: VALID_MSG_ID, body: 'Thanks!' };
+
+  it('blocks an identical reply replayed after delivery', async () => {
+    const first = await replyToEmailAction.run(ctx, REPLY);
+    expect(first.success).toBe(true);
+
+    const replay = await replyToEmailAction.run(ctx, REPLY);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+    expect(replay.messageId).toBe(first.messageId);
+  });
+
+  it('does not block a reply whose body differs', async () => {
+    await replyToEmailAction.run(ctx, REPLY);
+    const different = await replyToEmailAction.run(ctx, { ...REPLY, body: 'Thanks so much!' });
+    expect(different.success).toBe(true);
+  });
+
+  it('separates reply-all from sender-only, which reach different recipients', async () => {
+    await replyToEmailAction.run(ctx, REPLY);
+    const senderOnly = await replyToEmailAction.run(ctx, { ...REPLY, reply_all: false });
+    expect(senderOnly.success).toBe(true);
+  });
+
+  it('does not guard the reply-draft path — a draft delivers nothing', async () => {
+    const first = await replyToEmailAction.run(ctx, { ...REPLY, draft: true });
+    const second = await replyToEmailAction.run(ctx, { ...REPLY, draft: true });
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+  });
+
+  it('delivers again under an explicit allow_duplicate', async () => {
+    await replyToEmailAction.run(ctx, REPLY);
+    const forced = await replyToEmailAction.run(ctx, { ...REPLY, allow_duplicate: true });
+    expect(forced.success).toBe(true);
   });
 });

--- a/packages/email-core/src/actions/reply.ts
+++ b/packages/email-core/src/actions/reply.ts
@@ -16,6 +16,9 @@ import {
   DraftPreviewSchema,
   PreviewErrorSchema,
   pathSandbox,
+  claimDelivery,
+  settleClaimFromThrow,
+  AllowDuplicateSchema,
 } from './compose-helpers.js';
 
 const ReplyToEmailInput = z.object({
@@ -34,6 +37,7 @@ const ReplyToEmailInput = z.object({
     .describe('Wrap rendered HTML in a force-black div so Outlook dark mode does not hide the text. Default true.'),
   attachments: z.array(AttachmentInputSchema).optional()
     .describe('Files to attach. Each entry takes a sandboxed `path` or inline `base64`.'),
+  allow_duplicate: AllowDuplicateSchema.optional(),
 });
 
 const ReplyToEmailOutput = z.object({
@@ -117,7 +121,7 @@ export const replyToEmailAction: EmailAction<
   z.infer<typeof ReplyToEmailOutput>
 > = {
   name: 'reply_to_email',
-  description: 'Reply to an email within an existing thread. Default reply_all=true cc\'s the original thread; pass reply_all=false to reply only to the sender. Send path validates all effective recipients against the send allowlist; draft path bypasses. If a send fails with SEND_STATUS_UNKNOWN, the message may already have been delivered; do not resend without checking Sent Items.',
+  description: 'Reply to an email within an existing thread. Default reply_all=true cc\'s the original thread; pass reply_all=false to reply only to the sender. Send path validates all effective recipients against the send allowlist; draft path bypasses. If a send fails with SEND_STATUS_UNKNOWN, the message may already have been delivered; do not resend without checking Sent Items. An identical reply repeated within the duplicate window is refused with a DUPLICATE_SEND_* code instead of delivering twice; pass allow_duplicate: true only when a human has decided to send the same reply again.',
   input: ReplyToEmailInput,
   output: ReplyToEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -223,6 +227,25 @@ export const replyToEmailAction: EmailAction<
       return rateLimitError;
     }
 
+    // Reserve this delivery before touching the provider — see claimDelivery.
+    // The draft branch above deliberately does not claim: creating a draft
+    // delivers nothing, so a repeat is not a duplicate send.
+    const claimed = claimDelivery(
+      ctx,
+      'reply_to_email',
+      {
+        cc: parsed.cc,
+        body: bodyPlain,
+        bodyHtml,
+        attachments,
+        parentMessageId: input.message_id,
+        replyAll: input.reply_all,
+      },
+      input.allow_duplicate,
+    );
+    if ('duplicate' in claimed) return claimed.duplicate;
+    const { claim } = claimed;
+
     try {
       // Exactly one provider attempt — replies deliver mail through
       // non-idempotent provider endpoints with no idempotency key, so an
@@ -233,6 +256,12 @@ export const replyToEmailAction: EmailAction<
         bodyHtml,
         replyAll: input.reply_all,
         attachments,
+      });
+
+      claim.settle({
+        success: result.success,
+        ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+        ...(result.error?.code !== undefined ? { errorCode: result.error.code } : {}),
       });
 
       if (ctx.rateLimiter) {
@@ -250,6 +279,7 @@ export const replyToEmailAction: EmailAction<
         } : undefined,
       };
     } catch (err) {
+      settleClaimFromThrow(claim, err);
       const handled = handleProviderError(err, 'SEND_STATUS_UNKNOWN');
       if (ctx.rateLimiter && handled.error.code === 'SEND_STATUS_UNKNOWN') {
         ctx.rateLimiter.recordUsage('reply_to_email');

--- a/packages/email-core/src/actions/scheduling.test.ts
+++ b/packages/email-core/src/actions/scheduling.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { EmailProvider } from '../providers/provider.js';
+import { ProviderError } from '../providers/provider.js';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { sendDraftAction } from './draft.js';
 import type { ActionContext, RateLimiter } from './registry.js';
@@ -240,6 +241,58 @@ describe('email-write/Provider-Held Scheduled Delivery', () => {
       error: { code: 'SCHEDULE_SEND_STATUS_UNKNOWN', recoverable: false },
     });
     expect(rateLimiter.recordUsage).toHaveBeenCalledWith('send_email');
+  });
+
+  it('reports an unclassified scheduling throw as ambiguous, not as a terminal failure', async () => {
+    // Scheduling is a two-write draft→send. A throw with no provider
+    // classification cannot prove the submission was rejected, so telling the
+    // caller SCHEDULE_SEND_FAILED invited exactly the duplicate the scheduled
+    // path is meant to avoid. handleProviderError already states this rule for
+    // every delivery operation.
+    const provider = new MockEmailProvider();
+    provider.scheduleMessage = vi.fn().mockRejectedValue(new Error('lost acknowledgement'));
+    const rateLimiter: RateLimiter = {
+      checkLimit: vi.fn().mockReturnValue({ allowed: true }),
+      recordUsage: vi.fn(),
+    };
+
+    const result = await sendEmailAction.run({
+      ...actionContext(provider),
+      rateLimiter,
+    }, {
+      to: 'alice@example.com',
+      subject: 'Unclassified scheduling throw',
+      body: 'Body',
+      scheduled_send_at: futureAt(),
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { code: 'SCHEDULE_SEND_STATUS_UNKNOWN', recoverable: false },
+    });
+    expect(rateLimiter.recordUsage).toHaveBeenCalledWith('send_email');
+  });
+
+  it('preserves a provider-classified scheduling rejection as terminal', async () => {
+    // Negative control for the change above: a code the provider DID classify
+    // must survive unchanged, or the fix would have blurred the very
+    // distinction it exists to keep.
+    const provider = new MockEmailProvider();
+    provider.scheduleMessage = vi.fn().mockRejectedValue(
+      new ProviderError('SCHEDULE_SEND_FAILED', 'Graph rejected the send', 'microsoft', false),
+    );
+
+    const result = await sendEmailAction.run(actionContext(provider), {
+      to: 'alice@example.com',
+      subject: 'Classified scheduling rejection',
+      body: 'Body',
+      scheduled_send_at: futureAt(),
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { code: 'SCHEDULE_SEND_FAILED', recoverable: false },
+    });
   });
 });
 

--- a/packages/email-core/src/actions/send.test.ts
+++ b/packages/email-core/src/actions/send.test.ts
@@ -865,6 +865,51 @@ describe('email-write/Duplicate Delivery Guard', () => {
     }
   });
 
+  it('Scenario: Separate mailboxes do not share a duplicate record', async () => {
+    // Two mailboxes, no mailboxName, sharing the process-default ledger. Before
+    // the namespace fix the second mailbox's FIRST send was refused and handed
+    // the first mailbox's message id — a wrong refusal and a cross-mailbox id
+    // leak in one response.
+    resetDefaultSendLedger();
+    try {
+      const providerB = new MockEmailProvider();
+      const ctxA: ActionContext = { provider, sendAllowlist: { entries: ['*@allowed.com'] }, safeDir: testDir };
+      const ctxB: ActionContext = { provider: providerB, sendAllowlist: { entries: ['*@allowed.com'] }, safeDir: testDir };
+
+      const a = await sendEmailAction.run(ctxA, MESSAGE);
+      const b = await sendEmailAction.run(ctxB, MESSAGE);
+
+      expect(a.success).toBe(true);
+      expect(b.success).toBe(true);
+      expect(provider.getSentMessages()).toHaveLength(1);
+      expect(providerB.getSentMessages()).toHaveLength(1);
+
+      // ...and each mailbox is still guarded against its own replay.
+      const replayB = await sendEmailAction.run(ctxB, MESSAGE);
+      expect(replayB.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+      expect(replayB.messageId).toBe(b.messageId);
+    } finally {
+      resetDefaultSendLedger();
+    }
+  });
+
+  it('holds a delivery record through a rejected allow_duplicate attempt', async () => {
+    const first = await sendEmailAction.run(ctx, MESSAGE);
+    expect(first.success).toBe(true);
+
+    provider.sendMessage = async () => {
+      throw new ProviderError('INVALID_REQUEST', 'rejected', 'microsoft', false);
+    };
+    const forced = await sendEmailAction.run(ctx, { ...MESSAGE, allow_duplicate: true });
+    expect(forced.error!.code).toBe('INVALID_REQUEST');
+
+    // The override authorized that one send, not the erasure of the delivery
+    // it was overriding. An ordinary replay must still be refused.
+    const replay = await sendEmailAction.run(ctx, MESSAGE);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+    expect(replay.messageId).toBe(first.messageId);
+  });
+
   it('Scenario: A bail-out before dispatch does not block the corrected call', async () => {
     // An allowlist refusal never touched the provider, so it must not leave a
     // record that blocks the corrected send.

--- a/packages/email-core/src/actions/send.test.ts
+++ b/packages/email-core/src/actions/send.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { MockEmailProvider } from '../testing/mock-provider.js';
 import { sendEmailAction } from './send.js';
 import { ProviderError } from '../providers/provider.js';
+import { SendLedger, resetDefaultSendLedger } from '../security/send-ledger.js';
 import type { ActionContext } from './registry.js';
 
 let provider: MockEmailProvider;
@@ -17,6 +18,10 @@ beforeEach(async () => {
   await mkdir(testDir, { recursive: true });
   ctx = {
     provider,
+    // A fresh ledger per test. Without it the process-default ledger is shared
+    // across cases, and two tests sending the same message collide as
+    // duplicates — which is the guard working, not a test bug.
+    sendLedger: new SendLedger(),
     sendAllowlist: { entries: ['*@allowed.com'] },
     safeDir: testDir,
   };
@@ -697,5 +702,199 @@ describe('email-write/Send Address Parsing', () => {
     expect(result.error!.code).toBe('INVALID_ADDRESS');
     expect(result.error!.message).toContain('cc[1]');
     expect(provider.getDrafts().size).toBe(0);
+  });
+});
+
+describe('email-write/Duplicate Delivery Guard', () => {
+  const MESSAGE = {
+    to: 'alice@allowed.com',
+    subject: 'Quarterly update',
+    body: 'Numbers attached.',
+  };
+
+  it('Scenario: Replay after successful delivery is blocked', async () => {
+    const first = await sendEmailAction.run(ctx, MESSAGE);
+    expect(first.success).toBe(true);
+
+    const replay = await sendEmailAction.run(ctx, MESSAGE);
+
+    expect(replay.success).toBe(false);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+    expect(replay.error!.recoverable).toBe(false);
+    // The caller asked whether this went out; the honest answer names which
+    // message it already is.
+    expect(replay.messageId).toBe(first.messageId);
+    // The provider was touched exactly once, which is the whole point.
+    expect(provider.getSentMessages()).toHaveLength(1);
+  });
+
+  it('Scenario: Replay after ambiguous outcome is blocked', async () => {
+    let calls = 0;
+    provider.sendMessage = async () => {
+      calls++;
+      throw new ProviderError('SEND_STATUS_UNKNOWN', 'response lost', 'test', false);
+    };
+
+    const first = await sendEmailAction.run(ctx, MESSAGE);
+    expect(first.error!.code).toBe('SEND_STATUS_UNKNOWN');
+
+    const replay = await sendEmailAction.run(ctx, MESSAGE);
+
+    expect(calls).toBe(1);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_UNRESOLVED');
+    expect(replay.error!.message).toContain('Sent Items');
+  });
+
+  it('Scenario: Concurrent identical send is blocked while in flight', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    let calls = 0;
+    provider.sendMessage = async () => {
+      calls++;
+      await gate;
+      return { success: true, messageId: 'concurrent-1' };
+    };
+
+    const inFlight = sendEmailAction.run(ctx, MESSAGE);
+    // Second call arrives before the first has returned — the lost-ack replay
+    // in its most literal form.
+    const second = await sendEmailAction.run(ctx, MESSAGE);
+    release();
+    const first = await inFlight;
+
+    expect(first.success).toBe(true);
+    expect(second.error!.code).toBe('DUPLICATE_SEND_IN_FLIGHT');
+    expect(calls).toBe(1);
+  });
+
+  it('Scenario: Resend after a proven rejection is allowed', async () => {
+    let calls = 0;
+    provider.sendMessage = async () => {
+      calls++;
+      if (calls === 1) {
+        // 4xx-derived: the provider received AND rejected it, so nothing was
+        // delivered and a resend must not be blocked.
+        throw new ProviderError('INVALID_REQUEST', 'ErrorInvalidRecipients', 'microsoft', false);
+      }
+      return { success: true, messageId: 'retry-ok' };
+    };
+
+    const rejected = await sendEmailAction.run(ctx, MESSAGE);
+    expect(rejected.error!.code).toBe('INVALID_REQUEST');
+
+    const resend = await sendEmailAction.run(ctx, MESSAGE);
+    expect(resend.success).toBe(true);
+    expect(resend.messageId).toBe('retry-ok');
+    expect(calls).toBe(2);
+  });
+
+  it('Scenario: Unrecognized failure code is held as unresolved', async () => {
+    let calls = 0;
+    provider.sendMessage = async () => {
+      calls++;
+      throw new ProviderError('SOME_FUTURE_PROVIDER_CODE', 'who knows', 'test', false);
+    };
+
+    await sendEmailAction.run(ctx, MESSAGE);
+    const replay = await sendEmailAction.run(ctx, MESSAGE);
+
+    expect(calls).toBe(1);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_UNRESOLVED');
+  });
+
+  it('Scenario: A different message is not blocked', async () => {
+    // Negative control: a guard that blocks everything is not a guard. If this
+    // test ever passes for the wrong reason, the ones above prove nothing.
+    await sendEmailAction.run(ctx, MESSAGE);
+
+    const otherBody = await sendEmailAction.run(ctx, { ...MESSAGE, body: 'Numbers attached!' });
+    const otherRecipient = await sendEmailAction.run(ctx, { ...MESSAGE, to: 'bob@allowed.com' });
+    const otherSubject = await sendEmailAction.run(ctx, { ...MESSAGE, subject: 'Quarterly update v2' });
+
+    expect(otherBody.success).toBe(true);
+    expect(otherRecipient.success).toBe(true);
+    expect(otherSubject.success).toBe(true);
+    expect(provider.getSentMessages()).toHaveLength(4);
+  });
+
+  it('Scenario: Explicit duplicate override delivers', async () => {
+    await sendEmailAction.run(ctx, MESSAGE);
+    const forced = await sendEmailAction.run(ctx, { ...MESSAGE, allow_duplicate: true });
+
+    expect(forced.success).toBe(true);
+    expect(provider.getSentMessages()).toHaveLength(2);
+
+    // The deliberate duplicate re-arms the guard against its own replay.
+    const replay = await sendEmailAction.run(ctx, MESSAGE);
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+    expect(provider.getSentMessages()).toHaveLength(2);
+  });
+
+  it('Scenario: Guard disabled by window of zero', async () => {
+    ctx.sendLedger = new SendLedger({ windowMs: 0 });
+
+    await sendEmailAction.run(ctx, MESSAGE);
+    const replay = await sendEmailAction.run(ctx, MESSAGE);
+
+    expect(replay.success).toBe(true);
+    expect(provider.getSentMessages()).toHaveLength(2);
+  });
+
+  it('Scenario: Guard is active without embedder wiring', async () => {
+    // The production path: the MCP adapter builds an ActionContext with no
+    // sendLedger, so the actions must fall back to the process default rather
+    // than skipping the check. ActionContext.rateLimiter is the cautionary
+    // example — an optional interface no shipped adapter constructs, so the
+    // limit it describes does not exist in the product.
+    resetDefaultSendLedger();
+    try {
+      const unwired: ActionContext = {
+        provider,
+        sendAllowlist: { entries: ['*@allowed.com'] },
+        safeDir: testDir,
+      };
+
+      const first = await sendEmailAction.run(unwired, MESSAGE);
+      const replay = await sendEmailAction.run(unwired, MESSAGE);
+
+      expect(first.success).toBe(true);
+      expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+      expect(provider.getSentMessages()).toHaveLength(1);
+    } finally {
+      resetDefaultSendLedger();
+    }
+  });
+
+  it('Scenario: A bail-out before dispatch does not block the corrected call', async () => {
+    // An allowlist refusal never touched the provider, so it must not leave a
+    // record that blocks the corrected send.
+    const blocked = await sendEmailAction.run(ctx, { ...MESSAGE, to: 'stranger@elsewhere.com' });
+    expect(blocked.error!.code).toBe('ALLOWLIST_BLOCKED');
+
+    const allowed = await sendEmailAction.run(ctx, MESSAGE);
+    expect(allowed.success).toBe(true);
+  });
+
+  it('does not guard the draft path — creating a draft delivers nothing', async () => {
+    const first = await sendEmailAction.run(ctx, { ...MESSAGE, draft: true });
+    const second = await sendEmailAction.run(ctx, { ...MESSAGE, draft: true });
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+    expect(provider.getDrafts().size).toBe(2);
+  });
+
+  it('guards a scheduled send, and separately from the same message sent now', async () => {
+    const at = new Date(Date.now() + 3600_000).toISOString();
+
+    const scheduled = await sendEmailAction.run(ctx, { ...MESSAGE, scheduled_send_at: at });
+    expect(scheduled.success).toBe(true);
+
+    const replay = await sendEmailAction.run(ctx, { ...MESSAGE, scheduled_send_at: at });
+    expect(replay.error!.code).toBe('DUPLICATE_SEND_BLOCKED');
+
+    // Same bytes, different delivery time — a different decision, not a replay.
+    const immediate = await sendEmailAction.run(ctx, MESSAGE);
+    expect(immediate.success).toBe(true);
   });
 });

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -259,7 +259,18 @@ export const sendEmailAction: EmailAction<
         };
       } catch (err) {
         settleClaimFromThrow(claim, err);
-        return handleProviderError(err, 'SCHEDULE_SEND_FAILED');
+        // An unclassified throw out of a two-write draft→send cannot prove the
+        // submission was not accepted, so the fallback must be the ambiguous
+        // code, not a terminal one — the rule handleProviderError states for
+        // every delivery operation. SCHEDULE_SEND_FAILED remains correct where
+        // the provider itself classified a 4xx rejection; it is wrong as a
+        // catch-all here. Quota is charged on the ambiguous outcome for the
+        // same reason the non-throw branch above charges it.
+        const handled = handleProviderError(err, 'SCHEDULE_SEND_STATUS_UNKNOWN');
+        if (ctx.rateLimiter && handled.error.code === 'SCHEDULE_SEND_STATUS_UNKNOWN') {
+          ctx.rateLimiter.recordUsage('send_email');
+        }
+        return handled;
       }
     }
 

--- a/packages/email-core/src/actions/send.ts
+++ b/packages/email-core/src/actions/send.ts
@@ -23,6 +23,9 @@ import {
   DraftPreviewSchema,
   PreviewErrorSchema,
   pathSandbox,
+  claimDelivery,
+  settleClaimFromThrow,
+  AllowDuplicateSchema,
 } from './compose-helpers.js';
 
 const SendEmailInput = z.object({
@@ -41,6 +44,7 @@ const SendEmailInput = z.object({
   attachments: z.array(AttachmentInputSchema).optional()
     .describe('Files to attach. Each entry takes a sandboxed `path` or inline `base64`.'),
   scheduled_send_at: ScheduledSendAtSchema.optional(),
+  allow_duplicate: AllowDuplicateSchema.optional(),
 });
 
 const SendEmailOutput = z.object({
@@ -65,7 +69,7 @@ export const sendEmailAction: EmailAction<
   z.infer<typeof SendEmailOutput>
 > = {
   name: 'send_email',
-  description: 'Compose and send a new email. Gated by send allowlist. Draft mode bypasses allowlist. If a send fails with SEND_STATUS_UNKNOWN, the message may already have been delivered; do not resend without checking Sent Items.',
+  description: 'Compose and send a new email. Gated by send allowlist. Draft mode bypasses allowlist. If a send fails with SEND_STATUS_UNKNOWN, the message may already have been delivered; do not resend without checking Sent Items. An identical send repeated within the duplicate window is refused with a DUPLICATE_SEND_* code instead of delivering twice; pass allow_duplicate: true only when a human has decided to send the same message again.',
   input: SendEmailInput,
   output: SendEmailOutput,
   annotations: { readOnlyHint: false, destructiveHint: false },
@@ -201,12 +205,41 @@ export const sendEmailAction: EmailAction<
       attachments,
     };
 
+    // Reserve this delivery before touching the provider. Everything above
+    // this line can refuse the request without any chance of having sent it;
+    // everything below it can lose its acknowledgement, which is what a caller
+    // then replays.
+    const claimed = claimDelivery(
+      ctx,
+      'send_email',
+      {
+        to: parsed.to,
+        cc: parsed.cc,
+        subject: subject!,
+        body,
+        bodyHtml: outBodyHtml,
+        attachments,
+        scheduledSendAt,
+      },
+      input.allow_duplicate,
+    );
+    if ('duplicate' in claimed) return claimed.duplicate;
+    const { claim } = claimed;
+
     if (scheduledSendAt !== undefined) {
-      if (!ctx.provider.scheduleMessage) return scheduledSendNotSupportedError();
+      if (!ctx.provider.scheduleMessage) {
+        claim.settle({ success: false, errorCode: 'NOT_SUPPORTED' });
+        return scheduledSendNotSupportedError();
+      }
       try {
         // Do not retry the two-write draft→send operation as a unit: a lost
         // response after draft creation could otherwise queue a duplicate.
         const result = await ctx.provider.scheduleMessage(composeMessage, scheduledSendAt);
+        claim.settle({
+          success: result.success,
+          ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+          ...(result.error?.code !== undefined ? { errorCode: result.error.code } : {}),
+        });
         if (
           ctx.rateLimiter
           && (result.success || result.error?.code === 'SCHEDULE_SEND_STATUS_UNKNOWN')
@@ -225,6 +258,7 @@ export const sendEmailAction: EmailAction<
           } : undefined,
         };
       } catch (err) {
+        settleClaimFromThrow(claim, err);
         return handleProviderError(err, 'SCHEDULE_SEND_FAILED');
       }
     }
@@ -237,6 +271,12 @@ export const sendEmailAction: EmailAction<
     // error instead (mirrors the scheduled-send branch above).
     try {
       const result = await ctx.provider.sendMessage(composeMessage);
+
+      claim.settle({
+        success: result.success,
+        ...(result.messageId !== undefined ? { messageId: result.messageId } : {}),
+        ...(result.error?.code !== undefined ? { errorCode: result.error.code } : {}),
+      });
 
       if (ctx.rateLimiter) {
         ctx.rateLimiter.recordUsage('send_email');
@@ -253,6 +293,7 @@ export const sendEmailAction: EmailAction<
         } : undefined,
       };
     } catch (err) {
+      settleClaimFromThrow(claim, err);
       const handled = handleProviderError(err, 'SEND_STATUS_UNKNOWN');
       if (ctx.rateLimiter && handled.error.code === 'SEND_STATUS_UNKNOWN') {
         ctx.rateLimiter.recordUsage('send_email');

--- a/packages/email-core/src/index.ts
+++ b/packages/email-core/src/index.ts
@@ -70,6 +70,31 @@ export {
   SendRateLimiter,
 } from './security/send-allowlist.js';
 export { WatchedAllowlist } from './security/watched-allowlist.js';
+export {
+  SendLedger,
+  computeSendFingerprint,
+  duplicateSendError,
+  getDefaultSendLedger,
+  resetDefaultSendLedger,
+  resolveDuplicateSendWindowMs,
+  isDeliveryProvenUnsent,
+  DELIVERY_PROVEN_UNSENT_CODES,
+  DEFAULT_DUPLICATE_SEND_WINDOW_MS,
+  MAX_SEND_LEDGER_ENTRIES,
+  DUPLICATE_SEND_WINDOW_ENV,
+  DUPLICATE_SEND_IN_FLIGHT,
+  DUPLICATE_SEND_BLOCKED,
+  DUPLICATE_SEND_UNRESOLVED,
+} from './security/send-ledger.js';
+export type {
+  SendAttempt,
+  SendAttemptState,
+  SendClaim,
+  SendOutcome,
+  ClaimResult,
+  SendFingerprintInput,
+  SendLedgerOptions,
+} from './security/send-ledger.js';
 export { recordActionMetric, getMetrics, resetMetrics } from './metrics.js';
 export { htmlToMarkdown, transformEmailContent } from './content/sanitize.js';
 export { readEmailAction, READ_HTML_BODY_LIMIT } from './actions/read.js';

--- a/packages/email-core/src/security/send-ledger.test.ts
+++ b/packages/email-core/src/security/send-ledger.test.ts
@@ -7,6 +7,7 @@ import {
   resetDefaultSendLedger,
   resolveDuplicateSendWindowMs,
   isDeliveryProvenUnsent,
+  providerNamespace,
   DEFAULT_DUPLICATE_SEND_WINDOW_MS,
   DUPLICATE_SEND_IN_FLIGHT,
   DUPLICATE_SEND_BLOCKED,
@@ -160,6 +161,96 @@ describe('email-write/Send Ledger', () => {
     expect(clocked.claim(FP).ok).toBe(true);
   });
 
+  // --- Attempt ownership. Every case below dispatched a duplicate before the
+  // claim callbacks were bound to the attempt that produced them.
+
+  it('Scenario: A stale settlement cannot overwrite a newer attempt', () => {
+    const slow = ledger.claim(FP);
+    const forced = ledger.claim(FP, { force: true });
+    if (forced.ok) forced.settle({ success: true, messageId: 'B-delivered' });
+    // The first attempt finally comes back, rejected. It must settle itself
+    // only — before this fix it deleted whichever record held the key.
+    if (slow.ok) slow.settle({ success: false, errorCode: 'INVALID_REQUEST' });
+
+    expect(ledger.peek(FP)).toMatchObject({ state: 'delivered', messageId: 'B-delivered' });
+    expect(ledger.claim(FP).ok).toBe(false);
+  });
+
+  it('a stale release cannot withdraw a newer attempt', () => {
+    const slow = ledger.claim(FP);
+    ledger.claim(FP, { force: true });
+    if (slow.ok) slow.release();
+
+    expect(ledger.peek(FP)).toMatchObject({ state: 'in-flight' });
+    expect(ledger.claim(FP).ok).toBe(false);
+  });
+
+  it('a rejected override does not erase the delivery it was overriding', () => {
+    // Sequential, no concurrency needed. A delivered; the deliberate duplicate
+    // was rejected; an ordinary replay must still be refused.
+    const first = ledger.claim(FP);
+    if (first.ok) first.settle({ success: true, messageId: 'A-delivered' });
+
+    const forced = ledger.claim(FP, { force: true });
+    if (forced.ok) forced.settle({ success: false, errorCode: 'INVALID_REQUEST' });
+
+    const replay = ledger.claim(FP);
+    expect(replay.ok).toBe(false);
+    if (!replay.ok) expect(replay.prior.messageId).toBe('A-delivered');
+  });
+
+  it('keeps a success that lands after its reservation was pruned', () => {
+    let now = 0;
+    const clocked = new SendLedger({ windowMs: 100, now: () => now });
+    const claim = clocked.claim(FP);
+
+    now = 101;
+    clocked.claim('unrelated'); // prunes the aged in-flight reservation
+    if (claim.ok) claim.settle({ success: true, messageId: 'late' });
+
+    // The delivery happened. Dropping the outcome because the reservation
+    // aged out would admit an immediate replay of a message just sent.
+    expect(clocked.peek(FP)).toMatchObject({ state: 'delivered', messageId: 'late' });
+    expect(clocked.claim(FP).ok).toBe(false);
+  });
+
+  it('never evicts an in-flight reservation to stay under the size cap', () => {
+    // Evicting a live reservation drops cover for a send that is on the wire.
+    const small = new SendLedger({ windowMs: 60_000, maxEntries: 2 });
+    small.claim('a');
+    small.claim('b');
+    small.claim('c');
+
+    expect(small.peek('a')).toMatchObject({ state: 'in-flight' });
+    expect(small.claim('a').ok).toBe(false);
+    expect(small.size()).toBe(3); // deliberately over cap rather than unsafe
+  });
+
+  it('evicts the oldest settled attempt first when over the cap', () => {
+    let now = 1000;
+    const small = new SendLedger({ windowMs: 60_000, maxEntries: 2, now: () => now });
+    for (const fp of ['a', 'b', 'c']) {
+      const claim = small.claim(fp);
+      if (claim.ok) claim.settle({ success: true, messageId: fp });
+      now += 10;
+    }
+    expect(small.size()).toBe(2);
+    expect(small.peek('a')).toBeUndefined();
+    expect(small.peek('c')).toBeDefined();
+  });
+
+  it('reports the strongest evidence when a fingerprint carries several attempts', () => {
+    const delivered = ledger.claim(FP);
+    if (delivered.ok) delivered.settle({ success: true, messageId: 'went-out' });
+    ledger.claim(FP, { force: true }); // still in flight
+
+    const replay = ledger.claim(FP);
+    expect(replay.ok).toBe(false);
+    // "already delivered as X" answers the caller's question more decisively
+    // than "something is in flight".
+    if (!replay.ok) expect(replay.prior).toMatchObject({ state: 'delivered', messageId: 'went-out' });
+  });
+
   it('force re-claims for a deliberate duplicate and re-arms against ITS replay', () => {
     const claim = ledger.claim(FP);
     if (claim.ok) claim.settle({ success: true, messageId: 'm1' });
@@ -193,23 +284,21 @@ describe('email-write/Send Ledger', () => {
     expect(ledger.claim(FP).ok).toBe(false);
   });
 
-  it('evicts oldest entries beyond the size cap', () => {
-    const small = new SendLedger({ windowMs: 60_000, maxEntries: 3 });
-    for (const fp of ['a', 'b', 'c', 'd']) {
-      const claim = small.claim(fp);
-      if (claim.ok) claim.settle({ success: true, messageId: fp });
-    }
-    expect(small.size()).toBe(3);
-    expect(small.peek('a')).toBeUndefined();
-    expect(small.peek('d')).toBeDefined();
-  });
-
   it('admits everything when the window is zero', () => {
     const off = new SendLedger({ windowMs: 0 });
     expect(off.enabled).toBe(false);
     const first = off.claim(FP);
     if (first.ok) first.settle({ success: true, messageId: 'm1' });
     expect(off.claim(FP).ok).toBe(true);
+  });
+});
+
+describe('email-write/Provider Namespace', () => {
+  it('gives each provider instance its own namespace and is stable per instance', () => {
+    const a = {}, b = {};
+    expect(providerNamespace(a)).toBe(providerNamespace(a));
+    expect(providerNamespace(a)).not.toBe(providerNamespace(b));
+    expect(providerNamespace(undefined)).toBe('');
   });
 });
 

--- a/packages/email-core/src/security/send-ledger.test.ts
+++ b/packages/email-core/src/security/send-ledger.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  SendLedger,
+  computeSendFingerprint,
+  duplicateSendError,
+  getDefaultSendLedger,
+  resetDefaultSendLedger,
+  resolveDuplicateSendWindowMs,
+  isDeliveryProvenUnsent,
+  DEFAULT_DUPLICATE_SEND_WINDOW_MS,
+  DUPLICATE_SEND_IN_FLIGHT,
+  DUPLICATE_SEND_BLOCKED,
+  DUPLICATE_SEND_UNRESOLVED,
+} from './send-ledger.js';
+
+const BASE = {
+  action: 'send_email',
+  mailbox: 'me@company.com',
+  to: [{ email: 'alice@allowed.com' }],
+  subject: 'Quarterly update',
+  body: 'Numbers attached.',
+} as const;
+
+describe('email-write/Send Fingerprint', () => {
+  it('is stable across calls with identical input', () => {
+    expect(computeSendFingerprint(BASE)).toBe(computeSendFingerprint(BASE));
+  });
+
+  it('ignores recipient display name and ordering', () => {
+    const a = computeSendFingerprint({
+      ...BASE,
+      to: [{ email: 'alice@allowed.com', name: 'Alice' }, { email: 'bob@allowed.com' }],
+    });
+    const b = computeSendFingerprint({
+      ...BASE,
+      to: [{ email: 'BOB@allowed.com' }, { email: 'alice@allowed.com' }],
+    });
+    // Same mailboxes reached — a display name is not part of what is delivered.
+    expect(a).toBe(b);
+  });
+
+  it('separates a reply from a fresh send with the same content', () => {
+    expect(computeSendFingerprint({ ...BASE, action: 'reply_to_email' }))
+      .not.toBe(computeSendFingerprint(BASE));
+  });
+
+  it('separates sends that differ in any delivered field', () => {
+    const base = computeSendFingerprint(BASE);
+    expect(computeSendFingerprint({ ...BASE, subject: 'Quarterly update ' })).not.toBe(base);
+    expect(computeSendFingerprint({ ...BASE, body: 'Numbers attached!' })).not.toBe(base);
+    expect(computeSendFingerprint({ ...BASE, mailbox: 'other@company.com' })).not.toBe(base);
+    expect(computeSendFingerprint({ ...BASE, cc: [{ email: 'carol@allowed.com' }] })).not.toBe(base);
+    expect(computeSendFingerprint({ ...BASE, bodyHtml: '<p>x</p>' })).not.toBe(base);
+    expect(computeSendFingerprint({ ...BASE, scheduledSendAt: '2026-09-08T09:00:00Z' })).not.toBe(base);
+  });
+
+  it('distinguishes attachments by content, not just filename', () => {
+    const withA = computeSendFingerprint({
+      ...BASE,
+      attachments: [{ filename: 'q3.pdf', mimeType: 'application/pdf', content: Buffer.from('AAA') }],
+    });
+    const withB = computeSendFingerprint({
+      ...BASE,
+      attachments: [{ filename: 'q3.pdf', mimeType: 'application/pdf', content: Buffer.from('BBB') }],
+    });
+    expect(withA).not.toBe(withB);
+    expect(withA).not.toBe(computeSendFingerprint(BASE));
+  });
+});
+
+describe('email-write/Send Ledger', () => {
+  let ledger: SendLedger;
+  const FP = 'fingerprint-1';
+
+  beforeEach(() => {
+    ledger = new SendLedger({ windowMs: 60_000 });
+  });
+
+  it('admits a first claim', () => {
+    const claim = ledger.claim(FP);
+    expect(claim.ok).toBe(true);
+    expect(ledger.peek(FP)).toMatchObject({ state: 'in-flight' });
+  });
+
+  it('refuses a second claim while the first is in flight', () => {
+    ledger.claim(FP);
+    const second = ledger.claim(FP);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.prior.state).toBe('in-flight');
+  });
+
+  it('refuses a second claim after a delivered attempt, keeping the message id', () => {
+    const claim = ledger.claim(FP);
+    if (claim.ok) claim.settle({ success: true, messageId: 'AAMk-1' });
+
+    const second = ledger.claim(FP);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.prior.state).toBe('delivered');
+      expect(second.prior.messageId).toBe('AAMk-1');
+    }
+  });
+
+  it('refuses a second claim after an ambiguous outcome', () => {
+    const claim = ledger.claim(FP);
+    if (claim.ok) claim.settle({ success: false, errorCode: 'SEND_STATUS_UNKNOWN' });
+
+    const second = ledger.claim(FP);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.prior.state).toBe('unresolved');
+  });
+
+  it('releases the fingerprint after a failure that proves nothing was sent', () => {
+    for (const code of ['INVALID_REQUEST', 'RATE_LIMITED', 'PROVIDER_UNREACHABLE', 'ALLOWLIST_BLOCKED']) {
+      const claim = ledger.claim(code);
+      if (claim.ok) claim.settle({ success: false, errorCode: code });
+      expect(ledger.peek(code)).toBeUndefined();
+      expect(ledger.claim(code).ok).toBe(true);
+    }
+  });
+
+  it('holds an unrecognized failure code as unresolved rather than releasing it', () => {
+    // Fail closed: a code this version has never seen could have been a
+    // post-acceptance failure, and a wrong release costs a duplicate.
+    const claim = ledger.claim(FP);
+    if (claim.ok) claim.settle({ success: false, errorCode: 'SOME_FUTURE_PROVIDER_CODE' });
+    const second = ledger.claim(FP);
+    expect(second.ok).toBe(false);
+    if (!second.ok) expect(second.prior.state).toBe('unresolved');
+  });
+
+  it('holds an outcome with no code at all as unresolved', () => {
+    const claim = ledger.claim(FP);
+    if (claim.ok) claim.settle({ success: false });
+    expect(ledger.peek(FP)).toMatchObject({ state: 'unresolved' });
+  });
+
+  it('forgets an attempt once the window passes', () => {
+    let now = 1_000_000;
+    const clocked = new SendLedger({ windowMs: 60_000, now: () => now });
+    const claim = clocked.claim(FP);
+    if (claim.ok) claim.settle({ success: true, messageId: 'm1' });
+
+    now += 59_000;
+    expect(clocked.claim(FP).ok).toBe(false);
+
+    now += 2_000;
+    expect(clocked.claim(FP).ok).toBe(true);
+  });
+
+  it('ages an abandoned in-flight claim from its start, so a throw cannot wedge it forever', () => {
+    let now = 1_000_000;
+    const clocked = new SendLedger({ windowMs: 60_000, now: () => now });
+    clocked.claim(FP); // never settled — the action threw between claim and settle
+
+    now += 30_000;
+    expect(clocked.claim(FP).ok).toBe(false);
+
+    now += 31_000;
+    expect(clocked.claim(FP).ok).toBe(true);
+  });
+
+  it('force re-claims for a deliberate duplicate and re-arms against ITS replay', () => {
+    const claim = ledger.claim(FP);
+    if (claim.ok) claim.settle({ success: true, messageId: 'm1' });
+
+    const forced = ledger.claim(FP, { force: true });
+    expect(forced.ok).toBe(true);
+    if (forced.ok) forced.settle({ success: true, messageId: 'm2' });
+
+    // The deliberate duplicate is itself now protected.
+    const third = ledger.claim(FP);
+    expect(third.ok).toBe(false);
+    if (!third.ok) expect(third.prior.messageId).toBe('m2');
+  });
+
+  it('release drops an in-flight reservation so a pre-dispatch bail-out does not block', () => {
+    const claim = ledger.claim(FP);
+    if (claim.ok) claim.release();
+    expect(ledger.peek(FP)).toBeUndefined();
+    expect(ledger.claim(FP).ok).toBe(true);
+  });
+
+  it('release does not reopen an attempt that already settled', () => {
+    // A settled attempt is real history. A late release would hand a replay
+    // the delivery it was meant to be refused.
+    const claim = ledger.claim(FP);
+    if (claim.ok) {
+      claim.settle({ success: true, messageId: 'm1' });
+      claim.release();
+    }
+    expect(ledger.peek(FP)).toMatchObject({ state: 'delivered', messageId: 'm1' });
+    expect(ledger.claim(FP).ok).toBe(false);
+  });
+
+  it('evicts oldest entries beyond the size cap', () => {
+    const small = new SendLedger({ windowMs: 60_000, maxEntries: 3 });
+    for (const fp of ['a', 'b', 'c', 'd']) {
+      const claim = small.claim(fp);
+      if (claim.ok) claim.settle({ success: true, messageId: fp });
+    }
+    expect(small.size()).toBe(3);
+    expect(small.peek('a')).toBeUndefined();
+    expect(small.peek('d')).toBeDefined();
+  });
+
+  it('admits everything when the window is zero', () => {
+    const off = new SendLedger({ windowMs: 0 });
+    expect(off.enabled).toBe(false);
+    const first = off.claim(FP);
+    if (first.ok) first.settle({ success: true, messageId: 'm1' });
+    expect(off.claim(FP).ok).toBe(true);
+  });
+});
+
+describe('email-write/Duplicate Send Window Config', () => {
+  it('falls back to the default for a missing, empty, malformed, or negative value', () => {
+    // A malformed env var must not silently disable a safety guard.
+    for (const raw of [undefined, '', '   ', 'forever', 'NaN', '-1']) {
+      expect(resolveDuplicateSendWindowMs(raw)).toBe(DEFAULT_DUPLICATE_SEND_WINDOW_MS);
+    }
+  });
+
+  it('honours an explicit window, including zero', () => {
+    expect(resolveDuplicateSendWindowMs('30000')).toBe(30_000);
+    expect(resolveDuplicateSendWindowMs('0')).toBe(0);
+  });
+});
+
+describe('email-write/Default Send Ledger', () => {
+  afterEach(() => resetDefaultSendLedger());
+
+  it('is a single process-wide instance, so an unwired embedder is still guarded', () => {
+    // The cautionary example is ActionContext.rateLimiter: an optional
+    // interface no shipped adapter constructs, so the limit it describes does
+    // not exist in the product. This guard must not be opt-in.
+    expect(getDefaultSendLedger()).toBe(getDefaultSendLedger());
+  });
+
+  it('is rebuilt after a reset', () => {
+    const first = getDefaultSendLedger();
+    resetDefaultSendLedger();
+    expect(getDefaultSendLedger()).not.toBe(first);
+  });
+});
+
+describe('email-write/Duplicate Send Error', () => {
+  it('names the state, the prior message, and the override', () => {
+    const inFlight = duplicateSendError({ state: 'in-flight', startedAt: 0 }, 'send_email');
+    expect(inFlight.code).toBe(DUPLICATE_SEND_IN_FLIGHT);
+    expect(inFlight.message).toContain('allow_duplicate');
+
+    const delivered = duplicateSendError(
+      { state: 'delivered', startedAt: 0, settledAt: 1, messageId: 'AAMk-9' },
+      'send_email',
+    );
+    expect(delivered.code).toBe(DUPLICATE_SEND_BLOCKED);
+    expect(delivered.message).toContain('AAMk-9');
+
+    const unresolved = duplicateSendError({ state: 'unresolved', startedAt: 0 }, 'reply_to_email');
+    expect(unresolved.code).toBe(DUPLICATE_SEND_UNRESOLVED);
+    expect(unresolved.message).toContain('Sent Items');
+    expect(unresolved.recoverable).toBe(false);
+  });
+});
+
+describe('email-write/Proven Unsent Codes', () => {
+  it('treats only the proven-rejection codes as safe to resend', () => {
+    expect(isDeliveryProvenUnsent('INVALID_REQUEST')).toBe(true);
+    expect(isDeliveryProvenUnsent('PROVIDER_UNREACHABLE')).toBe(true);
+    expect(isDeliveryProvenUnsent('SEND_STATUS_UNKNOWN')).toBe(false);
+    expect(isDeliveryProvenUnsent('SCHEDULE_SEND_STATUS_UNKNOWN')).toBe(false);
+    expect(isDeliveryProvenUnsent(undefined)).toBe(false);
+  });
+});

--- a/packages/email-core/src/security/send-ledger.ts
+++ b/packages/email-core/src/security/send-ledger.ts
@@ -65,6 +65,15 @@ export const DELIVERY_PROVEN_UNSENT_CODES: ReadonlySet<string> = new Set([
   'SCHEDULE_SEND_FAILED', // scheduling's non-ambiguous variant
   'NOT_SUPPORTED',       // capability rejection, never dispatched
   'ALLOWLIST_BLOCKED',   // refused before dispatch
+  // Graph paths that fail strictly BEFORE the delivery POST. Each was checked
+  // at its production site: prepareReplyDraft throws before `/send`
+  // (email-graph-provider.ts REPLY_FAILED), attachment size validation runs
+  // with zero POSTs, an attachment upload failure leaves an unsent draft, and
+  // a scheduled draft with no id was never given a deferred-send time.
+  'REPLY_FAILED',
+  'ATTACHMENT_TOO_LARGE_FOR_PROVIDER',
+  'ATTACHMENT_UPLOAD_FAILED',
+  'SCHEDULE_DRAFT_FAILED',
 ]);
 
 /** Whether a failure code proves nothing was delivered. */
@@ -82,6 +91,21 @@ export interface SendAttempt {
   settledAt?: number;
   /** Provider message id, present only for a delivered attempt. */
   messageId?: string;
+}
+
+/**
+ * An attempt plus the identity that makes its callbacks safe.
+ *
+ * A fingerprint can carry more than one live attempt — `allow_duplicate`
+ * deliberately creates a second — so a callback that addressed only the
+ * fingerprint would act on whichever attempt happened to occupy the key. That
+ * let a slow first attempt's rejection delete a newer attempt's successful
+ * record, after which an ordinary replay dispatched again. The claim closure
+ * holds the entry object itself, so settle and release can only ever touch the
+ * attempt that produced them.
+ */
+interface LedgerEntry extends SendAttempt {
+  readonly id: number;
 }
 
 export interface SendOutcome {
@@ -207,10 +231,18 @@ export function resolveDuplicateSendWindowMs(
 }
 
 export class SendLedger {
-  private readonly attempts = new Map<string, SendAttempt>();
+  /**
+   * Live attempts per fingerprint, oldest first.
+   *
+   * A list rather than a single record because `allow_duplicate` legitimately
+   * puts two attempts on one fingerprint. Keeping both means a rejected
+   * override cannot erase the delivery it was overriding.
+   */
+  private readonly attempts = new Map<string, LedgerEntry[]>();
   private readonly windowMs: number;
   private readonly maxEntries: number;
   private readonly now: () => number;
+  private nextId = 1;
 
   constructor(opts: SendLedgerOptions = {}) {
     this.windowMs = opts.windowMs ?? resolveDuplicateSendWindowMs();
@@ -226,9 +258,10 @@ export class SendLedger {
   /**
    * Reserve a fingerprint ahead of dispatch.
    *
-   * `force` is the `allow_duplicate` path: it discards any prior record and
-   * claims afresh, so the deliberate duplicate is still protected against ITS
-   * own replay.
+   * `force` is the `allow_duplicate` path. It admits an attempt alongside any
+   * existing ones rather than replacing them: the caller authorised THIS send,
+   * not the erasure of what came before. If the forced attempt is then
+   * rejected, the earlier delivery still blocks an ordinary replay.
    */
   claim(fingerprint: string, opts: { force?: boolean } = {}): ClaimResult {
     if (!this.enabled) {
@@ -238,89 +271,181 @@ export class SendLedger {
     this.prune();
 
     if (!opts.force) {
-      const prior = this.attempts.get(fingerprint);
+      const prior = this.strongest(fingerprint);
       if (prior) return { ok: false, fingerprint, prior };
     }
 
-    const attempt: SendAttempt = { state: 'in-flight', startedAt: this.now() };
-    this.attempts.delete(fingerprint); // re-insert so eviction order is recency
-    this.attempts.set(fingerprint, attempt);
+    const entry: LedgerEntry = { id: this.nextId++, state: 'in-flight', startedAt: this.now() };
+    this.insert(fingerprint, entry);
     this.evictOverflow();
 
     return {
       ok: true,
       fingerprint,
-      settle: (outcome: SendOutcome) => this.settle(fingerprint, outcome),
-      release: () => {
-        // Only drop a record still in flight: a settled attempt is real
-        // history, and a late release would reopen it to replay.
-        if (this.attempts.get(fingerprint)?.state === 'in-flight') {
-          this.attempts.delete(fingerprint);
-        }
-      },
+      settle: (outcome: SendOutcome) => this.settle(fingerprint, entry, outcome),
+      release: () => this.release(fingerprint, entry),
     };
   }
 
-  /** Inspect a record without claiming. Intended for tests and diagnostics. */
+  /**
+   * The attempt a colliding claim is told about.
+   *
+   * Strongest evidence first: a delivered attempt (most recently settled) beats
+   * an unresolved one, which beats one still in flight. The caller's question
+   * is "did this already go out?", and a delivery elsewhere in the list answers
+   * it more decisively than a sibling attempt that has not returned.
+   */
+  private strongest(fingerprint: string): SendAttempt | undefined {
+    const entries = this.attempts.get(fingerprint);
+    if (!entries || entries.length === 0) return undefined;
+    // Latest first, with the attempt id as tie-break: two attempts can settle
+    // inside the same millisecond, and a caller told about the older of two
+    // deliveries is told about the wrong message.
+    const byState = (state: SendAttemptState): LedgerEntry | undefined => entries
+      .filter(e => e.state === state)
+      .sort((a, b) => ((b.settledAt ?? b.startedAt) - (a.settledAt ?? a.startedAt)) || (b.id - a.id))[0];
+    return byState('delivered') ?? byState('unresolved') ?? byState('in-flight');
+  }
+
+  /** Inspect the strongest record without claiming. For tests and diagnostics. */
   peek(fingerprint: string): SendAttempt | undefined {
     this.prune();
-    return this.attempts.get(fingerprint);
+    return this.strongest(fingerprint);
+  }
+
+  /** Every live attempt on a fingerprint, oldest first. For tests. */
+  peekAll(fingerprint: string): readonly SendAttempt[] {
+    this.prune();
+    return [...(this.attempts.get(fingerprint) ?? [])];
   }
 
   size(): number {
     this.prune();
-    return this.attempts.size;
+    let total = 0;
+    for (const entries of this.attempts.values()) total += entries.length;
+    return total;
   }
 
   clear(): void {
     this.attempts.clear();
   }
 
-  private settle(fingerprint: string, outcome: SendOutcome): void {
-    const attempt = this.attempts.get(fingerprint);
-    if (!attempt) return; // pruned mid-flight; nothing to settle
+  private insert(fingerprint: string, entry: LedgerEntry): void {
+    const entries = this.attempts.get(fingerprint);
+    if (entries) entries.push(entry);
+    else this.attempts.set(fingerprint, [entry]);
+  }
 
-    if (outcome.success) {
-      attempt.state = 'delivered';
-      attempt.settledAt = this.now();
-      if (outcome.messageId !== undefined) attempt.messageId = outcome.messageId;
-      return;
-    }
+  private remove(fingerprint: string, entry: LedgerEntry): void {
+    const entries = this.attempts.get(fingerprint);
+    if (!entries) return;
+    const index = entries.indexOf(entry);
+    if (index >= 0) entries.splice(index, 1);
+    if (entries.length === 0) this.attempts.delete(fingerprint);
+  }
 
+  private settle(fingerprint: string, entry: LedgerEntry, outcome: SendOutcome): void {
     if (isDeliveryProvenUnsent(outcome.errorCode)) {
-      // Provably not delivered — resending is safe, so stop blocking it.
-      this.attempts.delete(fingerprint);
+      // Provably not delivered — this attempt stops blocking. Siblings are
+      // untouched: a rejected override must not clear the delivery it overrode.
+      this.remove(fingerprint, entry);
       return;
     }
 
-    attempt.state = 'unresolved';
-    attempt.settledAt = this.now();
+    entry.settledAt = this.now();
+    if (outcome.success) {
+      entry.state = 'delivered';
+      if (outcome.messageId !== undefined) entry.messageId = outcome.messageId;
+    } else {
+      entry.state = 'unresolved';
+    }
+
+    // The attempt may have been pruned or evicted while it was in flight. A
+    // success that lands late is still evidence that mail went out, so put it
+    // back rather than dropping it; its window now runs from settlement.
+    const entries = this.attempts.get(fingerprint);
+    if (!entries || !entries.includes(entry)) this.insert(fingerprint, entry);
+  }
+
+  private release(fingerprint: string, entry: LedgerEntry): void {
+    // Only a reservation that never reached the provider may be withdrawn. A
+    // settled attempt is real history, and a late release would hand a replay
+    // the delivery it was meant to be refused.
+    if (entry.state === 'in-flight') this.remove(fingerprint, entry);
   }
 
   /**
-   * Drop records past the window.
+   * Drop attempts past the window.
    *
-   * An in-flight record is aged from `startedAt`, so an action that throws
+   * An in-flight attempt is aged from `startedAt`, so an action that throws
    * between claim and settle stops blocking once the window passes rather than
    * wedging the fingerprint forever. Holding it until then is the fail-closed
    * direction: a throw after dispatch is precisely the ambiguous case.
    */
   private prune(): void {
     const cutoff = this.now() - this.windowMs;
-    for (const [fingerprint, attempt] of this.attempts) {
-      if ((attempt.settledAt ?? attempt.startedAt) <= cutoff) {
-        this.attempts.delete(fingerprint);
-      }
+    for (const [fingerprint, entries] of this.attempts) {
+      const live = entries.filter(e => (e.settledAt ?? e.startedAt) > cutoff);
+      if (live.length === 0) this.attempts.delete(fingerprint);
+      else if (live.length !== entries.length) this.attempts.set(fingerprint, live);
     }
   }
 
+  /**
+   * Keep memory bounded by discarding the oldest SETTLED attempts.
+   *
+   * In-flight attempts are never evicted. Evicting one would drop a
+   * reservation covering a send that is on the wire right now, which is the
+   * single worst thing this module can do; and refusing a new claim because
+   * the ledger is full would block first-ever sends, which is worse still.
+   * So a burst of concurrent sends may briefly carry the map past the cap, and
+   * those entries age out on the ordinary TTL.
+   */
   private evictOverflow(): void {
-    while (this.attempts.size > this.maxEntries) {
-      const oldest = this.attempts.keys().next();
-      if (oldest.done) return;
-      this.attempts.delete(oldest.value);
+    while (this.size() > this.maxEntries) {
+      let oldestKey: string | undefined;
+      let oldest: LedgerEntry | undefined;
+      for (const [fingerprint, entries] of this.attempts) {
+        for (const entry of entries) {
+          if (entry.state === 'in-flight') continue;
+          if (!oldest || (entry.settledAt ?? entry.startedAt) < (oldest.settledAt ?? oldest.startedAt)) {
+            oldest = entry;
+            oldestKey = fingerprint;
+          }
+        }
+      }
+      if (!oldest || oldestKey === undefined) return; // nothing evictable — all in flight
+      this.remove(oldestKey, oldest);
     }
   }
+}
+
+/**
+ * A stable id for a provider instance, used as the ledger namespace when the
+ * caller supplies no mailbox name.
+ *
+ * Without this, two mailboxes in one process with no `mailboxName` share the
+ * empty key: the second mailbox's first-ever send is refused and handed the
+ * FIRST mailbox's message id. A WeakMap keyed on the provider object gives
+ * each one its own namespace and holds no reference that would keep a
+ * disconnected provider alive.
+ *
+ * Lifetime assumption: one provider instance means one mailbox. A provider
+ * rebuilt for the same mailbox (a reconnect) starts a fresh namespace and
+ * loses protection for the window — which is why a caller that knows its
+ * mailbox name should always supply it, as the MCP server does.
+ */
+const providerNamespaces = new WeakMap<object, string>();
+let nextProviderNamespace = 1;
+
+export function providerNamespace(provider: object | undefined): string {
+  if (!provider) return '';
+  let namespace = providerNamespaces.get(provider);
+  if (namespace === undefined) {
+    namespace = `provider#${nextProviderNamespace++}`;
+    providerNamespaces.set(provider, namespace);
+  }
+  return namespace;
 }
 
 let defaultLedger: SendLedger | undefined;

--- a/packages/email-core/src/security/send-ledger.ts
+++ b/packages/email-core/src/security/send-ledger.ts
@@ -1,0 +1,391 @@
+// Duplicate-delivery guard — the caller-replay half of delivery safety.
+//
+// `isRetryable(err, 'delivery')` and the single-attempt dispatch in the three
+// delivery actions guarantee that THIS LIBRARY never re-issues a send. They
+// guarantee nothing about the caller. An agent whose tool result was lost —
+// context compaction, a dropped transport, a supervisor restarting the turn, a
+// human retrying something that looked stuck — replays the same approved
+// instruction, and the second call is indistinguishable from a first one.
+//
+// The ledger supplies the missing state: a record, written BEFORE dispatch and
+// settled after, that says "a delivery with exactly these bytes was attempted."
+// A colliding claim short-circuits before the provider is touched.
+//
+// LIMITATION, stated rather than papered over: this is per-process and in
+// memory. It closes the replay window that actually occurs — a retry inside a
+// live server — and does not survive a restart of that server. Cross-process
+// durability needs a persisted store and is deliberately not attempted here.
+import { createHash } from 'node:crypto';
+import type { EmailAddress, OutboundAttachment } from '../types.js';
+
+export const DUPLICATE_SEND_WINDOW_ENV = 'AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS';
+
+/**
+ * How long a settled attempt keeps blocking an identical one.
+ *
+ * Fifteen minutes covers the realistic replay distance (a retried turn, a
+ * resumed loop) without blocking the legitimate case of the same automated
+ * message going out on a schedule, which is normally further apart. Operators
+ * who disagree have the env var; a caller who disagrees for one message has
+ * `allow_duplicate`.
+ */
+export const DEFAULT_DUPLICATE_SEND_WINDOW_MS = 15 * 60 * 1000;
+
+/** Ledger size cap. Oldest-first eviction keeps memory bounded. */
+export const MAX_SEND_LEDGER_ENTRIES = 512;
+
+export const DUPLICATE_SEND_IN_FLIGHT = 'DUPLICATE_SEND_IN_FLIGHT';
+export const DUPLICATE_SEND_BLOCKED = 'DUPLICATE_SEND_BLOCKED';
+export const DUPLICATE_SEND_UNRESOLVED = 'DUPLICATE_SEND_UNRESOLVED';
+
+/**
+ * Outcome codes that PROVE the provider did not deliver, and therefore release
+ * the fingerprint so a resend is permitted.
+ *
+ * This is an allowlist, not a denylist, and the asymmetry is the whole point.
+ * A false hold costs a caller one blocked resend and prints the override flag
+ * in the error. A false release costs a duplicate in someone's inbox, which is
+ * the bug this module exists to prevent. Anything not named here — including a
+ * code some future provider invents — is held as unresolved.
+ *
+ * Membership follows the same line `classifyHttpStatus` already draws: a 4xx
+ * proves the service received AND rejected the request, and a connect-failure
+ * proves no request bytes were written.
+ */
+export const DELIVERY_PROVEN_UNSENT_CODES: ReadonlySet<string> = new Set([
+  'RATE_LIMITED',        // 429 — rejected, not queued
+  'INVALID_REQUEST',     // 400 / 422
+  'AUTH_REQUIRED',       // 401
+  'PERMISSION_DENIED',   // 403
+  'NOT_FOUND',           // 404
+  'CONFLICT',            // 409
+  'PAYLOAD_TOO_LARGE',   // 413
+  'PROVIDER_REJECTED',   // other 4xx
+  'PROVIDER_UNREACHABLE', // connect-failed: provably no bytes on the wire
+  'SCHEDULE_SEND_FAILED', // scheduling's non-ambiguous variant
+  'NOT_SUPPORTED',       // capability rejection, never dispatched
+  'ALLOWLIST_BLOCKED',   // refused before dispatch
+]);
+
+/** Whether a failure code proves nothing was delivered. */
+export function isDeliveryProvenUnsent(code: string | undefined): boolean {
+  return code !== undefined && DELIVERY_PROVEN_UNSENT_CODES.has(code);
+}
+
+export type SendAttemptState = 'in-flight' | 'delivered' | 'unresolved';
+
+export interface SendAttempt {
+  state: SendAttemptState;
+  /** Epoch ms when the attempt was claimed. */
+  startedAt: number;
+  /** Epoch ms when the attempt settled, absent while in flight. */
+  settledAt?: number;
+  /** Provider message id, present only for a delivered attempt. */
+  messageId?: string;
+}
+
+export interface SendOutcome {
+  success: boolean;
+  messageId?: string;
+  errorCode?: string;
+}
+
+/** A successful claim. Exactly one of settle/release should be called. */
+export interface SendClaim {
+  ok: true;
+  fingerprint: string;
+  /** Record the terminal state, releasing the fingerprint if proven unsent. */
+  settle: (outcome: SendOutcome) => void;
+  /**
+   * Drop the reservation without recording an attempt.
+   *
+   * For a bail-out AFTER the claim but BEFORE the provider is touched — a draft
+   * that could not be read, an empty recipient list, an allowlist refusal. The
+   * message provably did not go out, so it must not block the corrected call.
+   * Never call this once the provider has been invoked: that is `settle`'s job,
+   * and the difference is whether a duplicate is possible.
+   */
+  release: () => void;
+}
+
+export interface DuplicateSend {
+  ok: false;
+  fingerprint: string;
+  prior: SendAttempt;
+}
+
+export type ClaimResult = SendClaim | DuplicateSend;
+
+/** Everything that determines what a recipient would actually receive. */
+export interface SendFingerprintInput {
+  /** Action name, so a reply and a fresh send never collide. */
+  action: string;
+  mailbox?: string | undefined;
+  to?: readonly EmailAddress[] | undefined;
+  cc?: readonly EmailAddress[] | undefined;
+  subject?: string | undefined;
+  body?: string | undefined;
+  bodyHtml?: string | undefined;
+  attachments?: readonly OutboundAttachment[] | undefined;
+  scheduledSendAt?: string | undefined;
+  /** Parent message for a reply. */
+  parentMessageId?: string | undefined;
+  /** Draft being sent, for send_draft. */
+  draftId?: string | undefined;
+  replyAll?: boolean | undefined;
+}
+
+function normalizeAddresses(addresses: readonly EmailAddress[] | undefined): string[] {
+  if (!addresses) return [];
+  // Address identity is the mailbox, not the display name: "Jane <j@x>" and
+  // "j@x" deliver to the same person, and ordering is not meaningful.
+  return [...new Set(addresses.map(a => a.email.trim().toLowerCase()))].sort();
+}
+
+function digestAttachments(attachments: readonly OutboundAttachment[] | undefined): string[] {
+  if (!attachments) return [];
+  // Content is digested, never stored: the ledger must not become a copy of
+  // outbound mail sitting in memory.
+  return attachments
+    .map(a => [
+      a.filename,
+      a.mimeType,
+      String(a.content.byteLength),
+      createHash('sha256').update(a.content).digest('hex'),
+    ].join(':'))
+    .sort();
+}
+
+/**
+ * Stable digest of a delivery.
+ *
+ * Body and bodyHtml are fingerprinted post-render and post-truncation by the
+ * callers, so the digest describes the bytes that would leave the process
+ * rather than the caller's input.
+ */
+export function computeSendFingerprint(input: SendFingerprintInput): string {
+  const canonical = JSON.stringify([
+    input.action,
+    input.mailbox ?? '',
+    normalizeAddresses(input.to),
+    normalizeAddresses(input.cc),
+    input.subject ?? '',
+    input.body ?? '',
+    input.bodyHtml ?? '',
+    digestAttachments(input.attachments),
+    input.scheduledSendAt ?? '',
+    input.parentMessageId ?? '',
+    input.draftId ?? '',
+    input.replyAll ?? null,
+  ]);
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+export interface SendLedgerOptions {
+  /** Retention window in ms. `0` disables the guard entirely. */
+  windowMs?: number;
+  maxEntries?: number;
+  /** Injectable clock, for tests. */
+  now?: () => number;
+}
+
+/**
+ * Read the operator-configured window.
+ *
+ * Read at construction rather than cached at module load so a test or an
+ * embedder can set the variable before building a ledger. An unparseable or
+ * negative value falls back to the default: a malformed env var must not
+ * silently disable a safety guard.
+ */
+export function resolveDuplicateSendWindowMs(
+  raw: string | undefined = process.env[DUPLICATE_SEND_WINDOW_ENV],
+): number {
+  if (raw === undefined || raw.trim() === '') return DEFAULT_DUPLICATE_SEND_WINDOW_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_DUPLICATE_SEND_WINDOW_MS;
+  return parsed;
+}
+
+export class SendLedger {
+  private readonly attempts = new Map<string, SendAttempt>();
+  private readonly windowMs: number;
+  private readonly maxEntries: number;
+  private readonly now: () => number;
+
+  constructor(opts: SendLedgerOptions = {}) {
+    this.windowMs = opts.windowMs ?? resolveDuplicateSendWindowMs();
+    this.maxEntries = opts.maxEntries ?? MAX_SEND_LEDGER_ENTRIES;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /** True when the operator disabled the guard. */
+  get enabled(): boolean {
+    return this.windowMs > 0;
+  }
+
+  /**
+   * Reserve a fingerprint ahead of dispatch.
+   *
+   * `force` is the `allow_duplicate` path: it discards any prior record and
+   * claims afresh, so the deliberate duplicate is still protected against ITS
+   * own replay.
+   */
+  claim(fingerprint: string, opts: { force?: boolean } = {}): ClaimResult {
+    if (!this.enabled) {
+      return { ok: true, fingerprint, settle: () => {}, release: () => {} };
+    }
+
+    this.prune();
+
+    if (!opts.force) {
+      const prior = this.attempts.get(fingerprint);
+      if (prior) return { ok: false, fingerprint, prior };
+    }
+
+    const attempt: SendAttempt = { state: 'in-flight', startedAt: this.now() };
+    this.attempts.delete(fingerprint); // re-insert so eviction order is recency
+    this.attempts.set(fingerprint, attempt);
+    this.evictOverflow();
+
+    return {
+      ok: true,
+      fingerprint,
+      settle: (outcome: SendOutcome) => this.settle(fingerprint, outcome),
+      release: () => {
+        // Only drop a record still in flight: a settled attempt is real
+        // history, and a late release would reopen it to replay.
+        if (this.attempts.get(fingerprint)?.state === 'in-flight') {
+          this.attempts.delete(fingerprint);
+        }
+      },
+    };
+  }
+
+  /** Inspect a record without claiming. Intended for tests and diagnostics. */
+  peek(fingerprint: string): SendAttempt | undefined {
+    this.prune();
+    return this.attempts.get(fingerprint);
+  }
+
+  size(): number {
+    this.prune();
+    return this.attempts.size;
+  }
+
+  clear(): void {
+    this.attempts.clear();
+  }
+
+  private settle(fingerprint: string, outcome: SendOutcome): void {
+    const attempt = this.attempts.get(fingerprint);
+    if (!attempt) return; // pruned mid-flight; nothing to settle
+
+    if (outcome.success) {
+      attempt.state = 'delivered';
+      attempt.settledAt = this.now();
+      if (outcome.messageId !== undefined) attempt.messageId = outcome.messageId;
+      return;
+    }
+
+    if (isDeliveryProvenUnsent(outcome.errorCode)) {
+      // Provably not delivered — resending is safe, so stop blocking it.
+      this.attempts.delete(fingerprint);
+      return;
+    }
+
+    attempt.state = 'unresolved';
+    attempt.settledAt = this.now();
+  }
+
+  /**
+   * Drop records past the window.
+   *
+   * An in-flight record is aged from `startedAt`, so an action that throws
+   * between claim and settle stops blocking once the window passes rather than
+   * wedging the fingerprint forever. Holding it until then is the fail-closed
+   * direction: a throw after dispatch is precisely the ambiguous case.
+   */
+  private prune(): void {
+    const cutoff = this.now() - this.windowMs;
+    for (const [fingerprint, attempt] of this.attempts) {
+      if ((attempt.settledAt ?? attempt.startedAt) <= cutoff) {
+        this.attempts.delete(fingerprint);
+      }
+    }
+  }
+
+  private evictOverflow(): void {
+    while (this.attempts.size > this.maxEntries) {
+      const oldest = this.attempts.keys().next();
+      if (oldest.done) return;
+      this.attempts.delete(oldest.value);
+    }
+  }
+}
+
+let defaultLedger: SendLedger | undefined;
+
+/**
+ * The ledger used when an ActionContext supplies none.
+ *
+ * Deliberately a default rather than an opt-in. `ActionContext.rateLimiter` is
+ * the cautionary example in this codebase: an optional injected interface that
+ * no shipped adapter ever constructs, so the limit it describes does not exist
+ * in the product. A duplicate guard that an embedder has to remember to wire is
+ * a duplicate guard that is off.
+ */
+export function getDefaultSendLedger(): SendLedger {
+  defaultLedger ??= new SendLedger();
+  return defaultLedger;
+}
+
+/** Drop the default ledger (tests, and any embedder re-reading the env). */
+export function resetDefaultSendLedger(): void {
+  defaultLedger = undefined;
+}
+
+export interface DuplicateSendError {
+  code: string;
+  message: string;
+  recoverable: false;
+}
+
+/**
+ * Build the refusal for a colliding claim.
+ *
+ * The guidance rides in the message string because the action result has no
+ * separate guidance field — the same convention the Graph delivery errors use.
+ * Each state gets different advice because the caller's next move differs:
+ * wait, stop, or escalate to a human who can look in Sent Items.
+ */
+export function duplicateSendError(prior: SendAttempt, actionName: string): DuplicateSendError {
+  const override = `Pass allow_duplicate: true to send it anyway.`;
+  switch (prior.state) {
+    case 'in-flight':
+      return {
+        code: DUPLICATE_SEND_IN_FLIGHT,
+        message:
+          `An identical ${actionName} is already in flight and has not returned. `
+          + `Not dispatching a second copy. Wait for the first call to complete. `
+          + override,
+        recoverable: false,
+      };
+    case 'delivered':
+      return {
+        code: DUPLICATE_SEND_BLOCKED,
+        message:
+          `An identical ${actionName} was already delivered`
+          + (prior.messageId ? ` as message ${prior.messageId}` : '')
+          + `. Not dispatching a duplicate. ${override}`,
+        recoverable: false,
+      };
+    case 'unresolved':
+      return {
+        code: DUPLICATE_SEND_UNRESOLVED,
+        message:
+          `An identical ${actionName} was already attempted and its outcome is unknown — `
+          + `it may have been delivered. Check Sent Items before resending. ${override}`,
+        recoverable: false,
+      };
+  }
+}

--- a/packages/provider-gmail/src/errors.test.ts
+++ b/packages/provider-gmail/src/errors.test.ts
@@ -44,3 +44,39 @@ describe('provider-gmail/Gmail Error Classification', () => {
     expect(getErrorStatus({ code: '429' })).toBe(429);
   });
 });
+
+describe('provider-gmail/Gmail Transport Classification', () => {
+  it('names a delivery whose connection never opened as unreachable, not a generic error', () => {
+    // Provably no request bytes were written. The distinction is load-bearing:
+    // the duplicate-send guard releases a proven non-delivery and holds an
+    // ambiguous one, and it cannot release a generic PROVIDER_ERROR because
+    // that code also covers failures that are not proven. Matches what the
+    // Graph provider already reports for the same condition.
+    const error = gmailProviderError(
+      Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      'delivery',
+    );
+
+    expect(error.code).toBe('PROVIDER_UNREACHABLE');
+    expect(error.recoverable).toBe(false);
+  });
+
+  it('still reports an ambiguous delivery transport failure as unknown', () => {
+    const error = gmailProviderError(
+      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' }),
+      'delivery',
+    );
+
+    expect(error.code).toBe('SEND_STATUS_UNKNOWN');
+  });
+
+  it('leaves non-delivery transport failures on the generic recoverable code', () => {
+    const error = gmailProviderError(
+      Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      'idempotent-read',
+    );
+
+    expect(error.code).toBe('PROVIDER_ERROR');
+    expect(error.recoverable).toBe(true);
+  });
+});

--- a/packages/provider-gmail/src/errors.ts
+++ b/packages/provider-gmail/src/errors.ts
@@ -72,6 +72,15 @@ export function gmailProviderError(
   }
 
   const dispatched = classifyTransportError(err) === 'dispatched-or-unknown';
-  const code = operation === 'delivery' && dispatched ? 'SEND_STATUS_UNKNOWN' : 'PROVIDER_ERROR';
+  // A delivery whose connection never opened provably wrote no request bytes,
+  // so name it as such rather than folding it into the generic PROVIDER_ERROR.
+  // The distinction is load-bearing downstream: the duplicate-send guard
+  // releases a proven non-delivery and holds an ambiguous one, and a generic
+  // code cannot be released because it also describes failures that are not
+  // proven. This mirrors what the Graph provider already reports for the same
+  // transport condition.
+  const code = operation === 'delivery'
+    ? (dispatched ? 'SEND_STATUS_UNKNOWN' : 'PROVIDER_UNREACHABLE')
+    : 'PROVIDER_ERROR';
   return new ProviderError(code, message, provider, operation !== 'delivery' && !dispatched);
 }


### PR DESCRIPTION
## Why

`isRetryable(err, 'delivery') === false` and the single-attempt dispatch in `send_email` / `reply_to_email` / `send_draft` guarantee that **this library** never re-issues a send. They guarantee nothing about the caller, and the caller is the one that replays.

An agent whose tool result was lost — a compacted context, a dropped transport, a supervisor restarting the turn, a person retrying a call that looked stuck — re-issues the identical instruction, and the second call is indistinguishable from a first one. The only defence was a sentence of English in each tool description ("do not resend without checking Sent Items"), which is exactly the guard an LLM under retry pressure skips. When it fails it fails silently: the second send succeeds and the recipient gets the message twice.

Provider endpoints take no idempotency key, so this cannot be fixed at the provider boundary. It is fixed one level up.

## What

An in-process send ledger keyed by a digest of the effective action inputs — mailbox, recipients, subject, rendered post-truncation body, attachment content hashes, scheduled time, reply parent or draft id. The record is written **before** dispatch, so the reserved window is exactly the window in which an acknowledgement gets lost, and settled after.

Three refusal codes, because the recovery differs:

| Code | Meaning | What to do |
|------|---------|------------|
| `DUPLICATE_SEND_IN_FLIGHT` | An identical delivery has not returned | Wait for the first call |
| `DUPLICATE_SEND_BLOCKED` | An identical delivery already succeeded | Stop — the response carries the original `messageId` |
| `DUPLICATE_SEND_UNRESOLVED` | An identical delivery ended ambiguously | Check Sent Items before resending |

Release is an **allowlist, not a denylist**. Only codes that *prove* non-delivery — 4xx-derived, 429, connect-failure, and the Graph paths that fail before the delivery POST — free the fingerprint, so a resend after a rejection is never blocked. Everything else, including a code no provider has shown us yet, is held. A wrongly-held message costs one refused resend and names the override; a wrongly-released one costs a duplicate in somebody's inbox.

On by default, with no embedder wiring. `ActionContext.sendLedger` exists only so tests can inject an isolated ledger. `ActionContext.rateLimiter` is the cautionary example — an optional injected interface that no shipped adapter constructs, so the rate limit it documents does not exist in the product.

`allow_duplicate: true` is the deliberate escape hatch; `AGENT_EMAIL_DUPLICATE_SEND_WINDOW_MS` tunes the window (default 15 min, `0` disables).

## Commits

1. `feat(email-core)` — the guard.
2. `fix(email-core)` — five defects Codex peer review found in it, each reproduced before being fixed and each now carrying a regression test that fails without the fix: settlement/release addressed the fingerprint rather than the attempt (a slow attempt's late rejection deleted a newer attempt's successful record); a rejected `allow_duplicate` erased the delivery it was overriding; the process-default ledger keyed on an optional `mailboxName`, so a second mailbox's first-ever send was refused and handed the first mailbox's message id; a success settling after its reservation was pruned was dropped; size-cap eviction could evict an in-flight reservation. Plus incomplete proven-unsent codes for both shipped providers, and four documentation claims that overstated what the code does — including a "salted digest" that was never implemented, corrected in place rather than quietly deleted.
3. `fix(email-core)` — a pre-existing misreport, found during that review and confirmed to predate the guard: an unclassified throw on the scheduled-send path was labelled `SCHEDULE_SEND_FAILED`, a terminal code, for an outcome that proves nothing of the kind.

## Limitation, stated rather than papered over

The ledger is per-process and in memory. It closes the replay window that actually occurs — a retry inside a running server — and does **not** survive restarting that server. Cross-process durability needs a persisted store and is deliberately not attempted here.

## Evidence

All four gates green: `build`, `lint`, `test:run`, `check:spec-coverage` (290/290). 571 email-core tests (from 546) and 119 provider-gmail tests (from 116).

Two mutation controls, because a green check that could not have gone red proves nothing:

- Ledger window forced to `0` (guard off) → 7 of the new assertions go red; the ones asserting *non*-blocking behavior correctly stay green.
- Fingerprint mutated to ignore the body, guard still **on** → 3 tests go red, including the "a different message is not blocked" negative control.

Codex's own 13 executable probes go from 1 passing to 12. The one that remains is the provider-truncation equivalence it classified itself as a scope/wording issue — Graph truncates a subject at 255 chars, so two different inputs can leave as identical mail; addressed by correcting the README to describe the fingerprint as effective action inputs rather than final wire bytes.

OpenSpec change: `openspec/changes/add-duplicate-send-guard` (validates `--strict`, 13 scenarios each backed by a matching test name).

https://claude.ai/code/session_01HkdNf9x4QS4LYS2DSiQWXS